### PR TITLE
Add shell auto-completion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,55 @@ This will install the CLI globally, allowing you to use the `dedpaste` command f
    npm link
    ```
 
+### Shell Auto-Completion
+
+DedPaste includes built-in commands to set up shell completion for Bash and Zsh:
+
+#### For Bash
+
+```bash
+# Generate the completion script
+dedpaste completion --bash > ~/.dedpaste-completion.bash
+
+# Add this to your ~/.bashrc
+echo 'source ~/.dedpaste-completion.bash' >> ~/.bashrc
+
+# Apply changes to current session
+source ~/.bashrc
+```
+
+#### For Zsh
+
+```bash
+# Generate the completion script
+dedpaste completion --zsh > ~/.dedpaste-completion.zsh
+
+# Add this to your ~/.zshrc
+echo 'source ~/.dedpaste-completion.zsh' >> ~/.zshrc
+
+# Apply changes to current session
+source ~/.zshrc
+```
+
+For more installation options:
+
+```bash
+# View Bash installation instructions
+dedpaste completion --bash --install
+
+# View Zsh installation instructions
+dedpaste completion --zsh --install
+```
+
 ## Usage
 
-DedPaste CLI has four main command modes:
+DedPaste CLI has five main command modes:
 
 1. **Default mode** - Basic paste operations (no subcommand)
 2. **`keys`** - Key management operations
 3. **`send`** - Create and send encrypted pastes
 4. **`get`** - Retrieve and decrypt pastes
+5. **`completion`** - Generate shell auto-completion scripts
 
 ### Basic Usage (Default Command)
 
@@ -132,6 +173,22 @@ dedpaste get AbCdEfGh
 
 # Get an encrypted paste using a specific private key file
 dedpaste get https://paste.d3d.dev/e/AbCdEfGh --key-file /path/to/private.pem
+```
+
+### Auto-Completion (`completion` Command)
+
+```bash
+# Generate Bash completion script
+dedpaste completion --bash > ~/.dedpaste-completion.bash
+
+# Generate Zsh completion script
+dedpaste completion --zsh > ~/.dedpaste-completion.zsh
+
+# Show Bash installation instructions
+dedpaste completion --bash --install
+
+# Show Zsh installation instructions
+dedpaste completion --zsh --install
 ```
 
 ### Interactive Mode

--- a/completion/README.md
+++ b/completion/README.md
@@ -1,0 +1,78 @@
+# DedPaste Command Auto-Completion
+
+This directory contains shell command auto-completion scripts for DedPaste CLI.
+
+## Installation
+
+### Bash Completion
+
+1. Source the completion script in your `.bashrc` or `.bash_profile`:
+
+   ```bash
+   # Add this line to your ~/.bashrc or ~/.bash_profile
+   source /path/to/dedpaste/completion/dedpaste-completion.bash
+   ```
+
+2. Alternatively, you can copy or symlink it to the bash completion directory if you have one set up:
+
+   ```bash
+   # On macOS (if you have bash-completion installed via Homebrew)
+   ln -s /path/to/dedpaste/completion/dedpaste-completion.bash /usr/local/etc/bash_completion.d/dedpaste
+
+   # On Linux (Ubuntu/Debian)
+   sudo ln -s /path/to/dedpaste/completion/dedpaste-completion.bash /etc/bash_completion.d/dedpaste
+   ```
+
+### Zsh Completion
+
+1. Make sure you have the Zsh completion system initialized in your `.zshrc`. If not, add:
+
+   ```zsh
+   # Add to your ~/.zshrc if it's not already there
+   autoload -Uz compinit
+   compinit
+   ```
+
+2. Source the completion script in your `.zshrc`:
+
+   ```zsh
+   # Add this line to your ~/.zshrc
+   source /path/to/dedpaste/completion/dedpaste-completion.zsh
+   ```
+
+3. Alternatively, you can copy or symlink it to one of the directories in your `$fpath`:
+
+   ```zsh
+   # Find a suitable directory in your fpath
+   echo $fpath
+   
+   # Then symlink it (replacing with an appropriate directory from your fpath)
+   ln -s /path/to/dedpaste/completion/dedpaste-completion.zsh ~/.zsh/completions/_dedpaste
+   ```
+
+## Features
+
+The completion scripts provide auto-completion for:
+
+- All DedPaste commands (`keys`, `send`, `get`)
+- All command options for each subcommand
+- File paths for options that accept files
+- Content type suggestions for the `--type` option
+
+## Usage Examples
+
+Try typing these and press Tab to see completions:
+
+```
+dedpaste [TAB]              # Show all commands
+dedpaste --[TAB]            # Show all global options
+dedpaste keys --[TAB]       # Show all options for the 'keys' command
+dedpaste send --[TAB]       # Show all options for the 'send' command
+dedpaste get --[TAB]        # Show all options for the 'get' command
+dedpaste --file [TAB]       # Show file completion
+dedpaste --type [TAB]       # Show content type suggestions
+```
+
+## Updating
+
+When new commands or options are added to DedPaste, you'll need to update these completion scripts accordingly.

--- a/completion/dedpaste-completion.bash
+++ b/completion/dedpaste-completion.bash
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+_dedpaste_completions() {
+  local cur prev opts commands
+  COMPREPLY=()
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  prev="${COMP_WORDS[COMP_CWORD-1]}"
+  commands="keys send get"
+  main_opts="-t --temp --type -f --file -o --output -e --encrypt -c --copy --help --version"
+  
+  # Check if we're completing a command
+  if [[ ${COMP_CWORD} -eq 1 ]]; then
+    if [[ ${cur} == -* ]]; then
+      COMPREPLY=( $(compgen -W "${main_opts}" -- "${cur}") )
+      return 0
+    else
+      COMPREPLY=( $(compgen -W "${commands}" -- "${cur}") )
+      return 0
+    fi
+  fi
+  
+  # Complete options for specific commands
+  case "${COMP_WORDS[1]}" in
+    keys)
+      local key_opts="--interactive --list --add-friend --key-file --export --remove --gen-key --my-key --help"
+      if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $(compgen -W "${key_opts}" -- "${cur}") )
+      elif [[ ${prev} == "--key-file" ]]; then
+        COMPREPLY=( $(compgen -f -- "${cur}") )
+      fi
+      return 0
+      ;;
+    send)
+      local send_opts="-t --temp --type -f --file -o --output -e --encrypt --for --list-friends --key-file --gen-key --interactive --debug -c --copy --help"
+      if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $(compgen -W "${send_opts}" -- "${cur}") )
+      elif [[ ${prev} == "--key-file" || ${prev} == "-f" || ${prev} == "--file" ]]; then
+        COMPREPLY=( $(compgen -f -- "${cur}") )
+      elif [[ ${prev} == "--type" ]]; then
+        local content_types="text/plain application/json text/html text/markdown application/xml application/javascript text/css"
+        COMPREPLY=( $(compgen -W "${content_types}" -- "${cur}") )
+      fi
+      return 0
+      ;;
+    get)
+      local get_opts="--key-file --help"
+      if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $(compgen -W "${get_opts}" -- "${cur}") )
+      elif [[ ${prev} == "--key-file" ]]; then
+        COMPREPLY=( $(compgen -f -- "${cur}") )
+      fi
+      return 0
+      ;;
+    *)
+      if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $(compgen -W "${main_opts}" -- "${cur}") )
+      elif [[ ${prev} == "--key-file" || ${prev} == "-f" || ${prev} == "--file" ]]; then
+        COMPREPLY=( $(compgen -f -- "${cur}") )
+      elif [[ ${prev} == "--type" ]]; then
+        local content_types="text/plain application/json text/html text/markdown application/xml application/javascript text/css"
+        COMPREPLY=( $(compgen -W "${content_types}" -- "${cur}") )
+      fi
+      return 0
+      ;;
+  esac
+}
+
+complete -F _dedpaste_completions dedpaste

--- a/completion/dedpaste-completion.zsh
+++ b/completion/dedpaste-completion.zsh
@@ -1,0 +1,74 @@
+#compdef dedpaste
+
+_dedpaste() {
+  local -a commands
+  local -a main_opts
+  
+  commands=(
+    'keys:Manage encryption keys for secure communication'
+    'send:Create and send an encrypted paste to friends'
+    'get:Retrieve and decrypt a paste by URL or ID'
+  )
+  
+  main_opts=(
+    '(-t --temp)'{-t,--temp}'[Create a one-time paste that is deleted after being viewed]'
+    '--type[Specify the content type of the paste (e.g., application/json)]:content-type:(text/plain application/json text/html text/markdown application/xml application/javascript text/css)'
+    '(-f --file)'{-f,--file}'[Upload a file from the specified path instead of stdin]:file:_files'
+    '(-o --output)'{-o,--output}'[Print only the URL (without any additional text)]'
+    '(-e --encrypt)'{-e,--encrypt}'[Encrypt the content before uploading (requires key setup)]'
+    '(-c --copy)'{-c,--copy}'[Copy the URL to clipboard automatically]'
+    '--help[Show help message]'
+    '--version[Show version information]'
+  )
+  
+  _arguments -C \
+    '1: :->command' \
+    '*: :->args' && ret=0
+    
+  case $state in
+    (command)
+      _describe -t commands 'dedpaste commands' commands
+      _describe -t options 'dedpaste options' main_opts
+      ;;
+    (args)
+      case $line[1] in
+        (keys)
+          _arguments \
+            '--interactive[Use interactive menu-driven mode for key management]' \
+            '--list[List all your keys and friends keys with fingerprints]' \
+            '--add-friend[Add a friends public key (requires --key-file)]:friend name:' \
+            '--key-file[Path to key file for import/export operations]:key file:_files' \
+            '--export[Export your public key to share with friends]' \
+            '--remove[Remove a friends key from your keyring]:friend name:' \
+            '--gen-key[Generate a new RSA key pair for encryption]' \
+            '--my-key[Output your public key to the console for sharing]' \
+            '--help[Show help message]'
+          ;;
+        (send)
+          _arguments \
+            '(-t --temp)'{-t,--temp}'[Create a one-time paste that is deleted after being viewed]' \
+            '--type[Specify the content type of the paste (e.g., application/json)]:content-type:(text/plain application/json text/html text/markdown application/xml application/javascript text/css)' \
+            '(-f --file)'{-f,--file}'[Upload a file from the specified path instead of stdin]:file:_files' \
+            '(-o --output)'{-o,--output}'[Print only the URL (without any additional text)]' \
+            '(-e --encrypt)'{-e,--encrypt}'[Encrypt the content before uploading (requires key setup)]' \
+            '--for[Encrypt for a specific friend (requires adding their key first)]:friend name:' \
+            '--list-friends[List available friends you can encrypt messages for]' \
+            '--key-file[Path to public key for encryption (alternative to stored keys)]:key file:_files' \
+            '--gen-key[Generate a new key pair for encryption if you dont have one]' \
+            '--interactive[Use interactive mode with guided prompts for message creation]' \
+            '--debug[Debug mode: show encrypted content without uploading]' \
+            '(-c --copy)'{-c,--copy}'[Copy the URL to clipboard automatically]' \
+            '--help[Show help message]'
+          ;;
+        (get)
+          _arguments \
+            '1:url or ID:' \
+            '--key-file[Path to private key for decryption (if not using default key)]:key file:_files' \
+            '--help[Show help message]'
+          ;;
+      esac
+      ;;
+  esac
+}
+
+_dedpaste "$@"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dedpaste",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dedpaste",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dedpaste",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "CLI pastebin application using Cloudflare Workers and R2",
   "main": "dist/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "files": [
     "dist",
     "cli",
+    "completion",
     "README.md"
   ],
   "keywords": [


### PR DESCRIPTION
- Add new 'completion' command to generate shell completion scripts
- Implement support for both Bash and Zsh shells
- Add '--bash' and '--zsh' options to output completion scripts
- Add '--install' option to show installation instructions
- Update documentation with auto-completion setup and usage
- Include the completion directory in the published npm package