### PR TITLE
fix: Fix release pipeline by removing [skip ci] flag

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Commit and push version bump
         run: |
           git add package.json
-          git commit -m "Bump version to ${{ steps.bump-version.outputs.new_version }} [skip ci]
+          git commit -m "Bump version to ${{ steps.bump-version.outputs.new_version }}
 
           Version bump type: ${{ steps.check-label.outputs.bump_type }}
           PR: #${{ github.event.pull_request.number }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dedpaste",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "CLI pastebin application using Cloudflare Workers and R2",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
This PR fixes the automatic release pipeline by removing the [skip ci] flag from the version bump commit message. This flag was causing GitHub Actions to skip running the release workflow after the version was bumped.

Changes:
- Remove [skip ci] flag from auto-version-bump.yml commit message
- Bump version to 1.3.1 to test the release workflow

After this is merged, the automatic version bumping should correctly trigger the release workflow.