### PR TITLE
feat: Bump version to 1.3.3 to test release pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dedpaste",
-  "version": "1.3.1",
+  "version": "1.3.3",
   "description": "CLI pastebin application using Cloudflare Workers and R2",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
This PR bumps the version to 1.3.3 to test if our fixed release pipeline works correctly. 

After our recent fix to remove the [skip ci] flag from the auto-version-bump workflow, we need to verify that the release workflow is running as expected when version changes are merged to main.

This is a test PR to simulate a real feature or fix being merged, which should trigger:
1. The auto-version-bump workflow
2. A commit updating the version number
3. The release workflow to generate SBOM, release notes, etc.

Note: After merging, please check that the release workflow runs successfully.