### PR TITLE
fix: Improve release workflow reliability

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -147,10 +147,12 @@ jobs:
           echo "✅ Version bumped to ${{ steps.bump-version.outputs.new_version }} (${{ steps.check-label.outputs.bump_type }} bump)"
           echo "🚀 The release workflow will be triggered automatically by this change."
       
-      # Create repository dispatch event to trigger the release workflow
-      - name: Trigger release workflow
-        uses: peter-evans/repository-dispatch@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          event-type: version-bumped
-          client-payload: '{"version": "${{ steps.bump-version.outputs.new_version }}", "bump_type": "${{ steps.check-label.outputs.bump_type }}", "pr_number": "${{ github.event.pull_request.number }}", "pr_title": "${{ github.event.pull_request.title }}"}'
+      # Note: We won't use repository-dispatch as it requires a PAT
+      # The workflow_run trigger in release.yml should handle this automatically
+      # If you need repository-dispatch in the future, use a PAT:
+      # - name: Trigger release workflow
+      #   uses: peter-evans/repository-dispatch@v2
+      #   with:
+      #     token: ${{ secrets.REPO_ACCESS_TOKEN }} # This would need to be created and added to repo secrets
+      #     event-type: version-bumped
+      #     client-payload: '{"version": "${{ steps.bump-version.outputs.new_version }}", "bump_type": "${{ steps.check-label.outputs.bump_type }}", "pr_number": "${{ github.event.pull_request.number }}", "pr_title": "${{ github.event.pull_request.title }}"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,24 +1,31 @@
 name: Release to NPM
 
 on:
+  # This is the key trigger - when package.json is changed on main
   push:
     branches:
       - main
     paths:
       - 'package.json'
+  
+  # This is a backup trigger - when Auto Version Bump workflow completes
   workflow_run:
     workflows: ["Auto Version Bump"]
     types:
       - completed
     branches:
       - main
-  repository_dispatch:
-    types: [version-bumped]
+      
+  # Manual trigger for testing and emergency releases
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (leave empty to use current version in package.json)'
+        required: false
 
 jobs:
   check-version:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'repository_dispatch'
     permissions:
       contents: read
     outputs:
@@ -55,6 +62,16 @@ jobs:
             
             OLD_VERSION=$(git show HEAD^:package.json | jq -r '.version')
             echo "Previous version from HEAD^: $OLD_VERSION"
+            
+            # Compare versions for push events
+            if [ "$OLD_VERSION" != "$NEW_VERSION" ]; then
+              echo "Version changed from $OLD_VERSION to $NEW_VERSION"
+              echo "version_changed=true" >> $GITHUB_OUTPUT
+              echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+            else
+              echo "Version unchanged ($OLD_VERSION == $NEW_VERSION)"
+              echo "version_changed=false" >> $GITHUB_OUTPUT
+            fi
           
           elif [ "${{ github.event_name }}" = "workflow_run" ]; then
             # For workflow_run events triggered by Auto Version Bump, assume there was a version change
@@ -71,43 +88,34 @@ jobs:
             echo "version_changed=true" >> $GITHUB_OUTPUT
             echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
             echo "Version will be published: $NEW_VERSION"
-            exit 0
+          
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            # For manually triggered workflow
+            echo "This is a workflow_dispatch event"
             
-          elif [ "${{ github.event_name }}" = "repository_dispatch" ]; then
-            # For repository_dispatch events with version-bumped type
-            echo "This is a repository_dispatch event with version-bumped type"
-            
-            # Use the version from the client payload if available
-            if [ -n "${{ github.event.client_payload.version }}" ]; then
-              CLIENT_VERSION="${{ github.event.client_payload.version }}"
-              echo "Version from client payload: $CLIENT_VERSION"
+            # Check if a version was specified in the input
+            if [ -n "${{ github.event.inputs.version }}" ]; then
+              INPUT_VERSION="${{ github.event.inputs.version }}"
+              echo "Version from workflow input: $INPUT_VERSION"
               
-              # Set outputs using client payload version
               echo "version_changed=true" >> $GITHUB_OUTPUT
-              echo "new_version=$CLIENT_VERSION" >> $GITHUB_OUTPUT
-              echo "Version will be published: $CLIENT_VERSION"
+              echo "new_version=$INPUT_VERSION" >> $GITHUB_OUTPUT
+              echo "Version will be published: $INPUT_VERSION"
             else
-              # Fallback to version in package.json
-              echo "Client payload version not found, using package.json version"
+              # Use the version from package.json
+              echo "No version specified in input, using version from package.json"
               echo "version_changed=true" >> $GITHUB_OUTPUT
               echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
               echo "Version will be published: $NEW_VERSION"
             fi
-            exit 0
-          else
-            echo "Unknown event type - cannot determine version change"
-            echo "version_changed=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
           
-          # Compare versions for push events
-          if [ "$OLD_VERSION" != "$NEW_VERSION" ]; then
-            echo "Version changed from $OLD_VERSION to $NEW_VERSION"
+          else
+            # Fallback for any other event types
+            echo "Event type: ${{ github.event_name }}"
+            echo "Using version from package.json"
             echo "version_changed=true" >> $GITHUB_OUTPUT
             echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
-          else
-            echo "Version unchanged ($OLD_VERSION == $NEW_VERSION)"
-            echo "version_changed=false" >> $GITHUB_OUTPUT
+            echo "Version will be published: $NEW_VERSION"
           fi
 
   generate-sbom:


### PR DESCRIPTION
This PR makes several key improvements to the release workflow to ensure it runs reliably after version bumps:

1. **Repository Dispatch Event Fix**:
   - Removed the repository-dispatch event trigger that was failing due to token permission issues
   - The workflow_run trigger should handle this automatically without needing custom dispatch events

2. **Workflow Trigger Improvements**:
   - Added a manual workflow_dispatch trigger for testing and emergency releases
   - Improved handling of multiple trigger types
   - Added more detailed documentation in comments

3. **Error Handling**:
   - Added better fallback handling for all event types
   - Improved version detection logic 

4. **Code Structure**:
   - Simplified conditional logic
   - Made the script more maintainable with better organization

These changes should ensure that the release workflow runs correctly when:
- A PR with version changes is merged to main (via workflow_run trigger)
- package.json is directly modified on main (via push trigger)
- The workflow is manually triggered (via workflow_dispatch trigger)

This addresses the issue where the release pipeline wasn't running after version bumps.