### PR TITLE
feat: Add simplified release workflow

### DIFF
--- a/.github/workflows/simple-release.yml
+++ b/.github/workflows/simple-release.yml
@@ -1,0 +1,39 @@
+name: Simple Release Test
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'package.json'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 10
+      
+      - name: Get version info
+        id: version
+        run: |
+          VERSION=$(jq -r '.version' package.json)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Current version in package.json: $VERSION"
+      
+      - name: Build test
+        run: |
+          echo "Building version ${{ steps.version.outputs.version }}"
+          
+      - name: Create test release
+        run: |
+          echo "Creating release for version ${{ steps.version.outputs.version }}"
+          echo "This is a test release"
+      
+      - name: Test complete
+        run: |
+          echo "✅ Simple release test complete"
+          echo "Version: ${{ steps.version.outputs.version }}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dedpaste",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "CLI pastebin application using Cloudflare Workers and R2",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
This PR adds a simplified release workflow that should work more reliably. 

The simplified workflow:
1. Is triggered by push events that change package.json on main
2. Can be manually triggered with workflow_dispatch
3. Has minimal steps for testing the core release process

It also bumps the version to 1.4.1 for testing.

After merging this PR, we should be able to trigger the workflow manually and also see it run automatically when the version is bumped by auto-version-bump.

This is a simpler approach that we can build upon once the core workflow is working.