### PR TITLE
fix: implement reliable workflow trigger mechanism

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -151,14 +151,17 @@ jobs:
       # Add a special commit file to trigger the release workflow
       - name: Create release trigger file
         run: |
-          # Create a special file to trigger the release workflow
+          # Create a special file to trigger the release workflow with timestamp to ensure uniqueness
           echo "Creating trigger file for release..."
-          mkdir -p .github
-          echo "VERSION=${{ steps.bump-version.outputs.new_version }}" > .github/release-trigger.txt
+          mkdir -p .github/triggers
+          TIMESTAMP=$(date +%s)
+          
+          # Use version and timestamp to ensure file is always unique
+          echo "VERSION=${{ steps.bump-version.outputs.new_version }}" > .github/triggers/release-${{ steps.bump-version.outputs.new_version }}-${TIMESTAMP}.txt
           
           # Commit and push the trigger file
-          git add .github/release-trigger.txt
-          git commit -m "trigger: release version ${{ steps.bump-version.outputs.new_version }}"
+          git add .github/triggers/
+          git commit -m "trigger: release version ${{ steps.bump-version.outputs.new_version }} [${TIMESTAMP}]"
           git push
           
           echo "Release trigger committed and pushed. The release workflow should start automatically."

--- a/.github/workflows/release-with-sbom.yml
+++ b/.github/workflows/release-with-sbom.yml
@@ -9,17 +9,18 @@ on:
         description: 'Force release of specific version (leave empty to use package.json)'
         required: false
   
-  # Triggered by package.json changes or release trigger file
+  # Triggered by package.json changes or release trigger files
   push:
     branches:
       - main
     paths:
       - 'package.json'
-      - '.github/release-trigger.txt'
+      - '.github/triggers/**'
   
   # Also triggered when auto-version-bump workflow completes successfully
   workflow_run:
-    workflows: ["Auto Version Bump"]
+    workflows: 
+      - "Auto Version Bump"
     types:
       - completed
     branches:
@@ -60,6 +61,12 @@ jobs:
           
           echo "Recent commits on main:"
           git log -n 5 --pretty=format:"%h %s"
+          
+          echo "Checking for trigger files:"
+          find .github -type f -name "*.txt" 2>/dev/null || echo "No trigger files found"
+          
+          echo "Package.json version:"
+          cat package.json | grep version || echo "Could not find version in package.json"
           echo "========================================"
       
       - name: Get version from package.json or trigger file
@@ -73,9 +80,11 @@ jobs:
             exit 0
           fi
           
-          # Check if we have a trigger file with a version
-          if [ -f ".github/release-trigger.txt" ]; then
-            TRIGGER_VERSION=$(grep "VERSION=" .github/release-trigger.txt | cut -d= -f2)
+          # Check if we have any trigger files with a version
+          TRIGGER_FILES=$(find .github/triggers -name "release-*.txt" 2>/dev/null | sort -r | head -n 1)
+          if [ -n "$TRIGGER_FILES" ]; then
+            echo "Found trigger file: $TRIGGER_FILES"
+            TRIGGER_VERSION=$(grep "VERSION=" "$TRIGGER_FILES" | cut -d= -f2)
             if [ -n "$TRIGGER_VERSION" ]; then
               echo "Using version from trigger file: $TRIGGER_VERSION"
               echo "version=$TRIGGER_VERSION" >> $GITHUB_OUTPUT
@@ -146,6 +155,18 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_run" ]; then
             if [ "${{ github.event.workflow_run.conclusion }}" = "success" ]; then
               echo "Auto Version Bump completed successfully - proceeding with release"
+              
+              # Get the head SHA from the workflow run
+              HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+              echo "Source workflow HEAD SHA: $HEAD_SHA"
+              
+              # Check if we have a package.json change in the workflow run
+              git fetch origin main
+              
+              # Get the current version from package.json
+              CURRENT_VERSION=$(jq -r '.version' package.json)
+              echo "Current version from package.json: $CURRENT_VERSION"
+              
               echo "proceed=true" >> $GITHUB_OUTPUT
             else
               echo "Auto Version Bump did not complete successfully - skipping release"


### PR DESCRIPTION
## Summary
This PR implements a more reliable trigger mechanism between the Auto Version Bump and Release workflows:

1. Replaces static trigger file with timestamped unique files:
   - Creates a unique trigger file for each version bump with timestamp
   - Uses a dedicated  directory for better organization
   - Makes files unique to ensure they always trigger the workflow

2. Improves file detection in the release workflow:
   - Updates path patterns to match files in the triggers directory
   - Adds more robust file detection and version extraction
   - Adds additional debugging to trace trigger file presence

3. Enhances workflow_run trigger handling:
   - Improves debug output for better traceability
   - Adds more robust version detection
   - Restructures workflow_run configuration for clarity

## Problem
Previous implementation used a static file which might not always trigger the workflow due to GitHub's event filtering.

## Solution
Using unique files with timestamps ensures the push event always contains new files that will trigger the workflow reliably.

## Test plan
When a PR is merged that triggers the auto-version-bump workflow:
1. A unique trigger file with timestamp will be created in 
2. This will trigger the release workflow via the push event
3. The release workflow will extract the version from the trigger file
4. A GitHub release will be created automatically