### PR TITLE
Fix: Ensure release-with-sbom workflow is triggered after version bump

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -14,61 +14,61 @@ jobs:
       contents: write
       pull-requests: write
       actions: write # Needed to trigger workflows
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Setup Git
         run: |
           git config --global user.name 'GitHub Actions'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-      
+
       - name: Check PR label for version bump type
         id: check-label
         run: |
           PR_LABELS="${{ toJson(github.event.pull_request.labels.*.name) }}"
-          
+
           # Determine conventional commit type from PR title or commits
           PR_TITLE="${{ github.event.pull_request.title }}"
           PR_BODY="${{ github.event.pull_request.body }}"
-          
+
           # Simple, robust function to determine bump type from conventional commits
           determine_bump_type() {
             local commits="$1"
-            
+
             echo "Analyzing commits for conventional commit patterns..."
-            
+
             # Check for breaking changes first (highest priority)
             if echo "$commits" | grep -q "^BREAKING CHANGE:" || echo "$commits" | grep -qE "^[a-z]+(\([a-z]+\))?!:"; then
               echo "Found breaking change - will use major bump"
               echo "major"
               return 0
             fi
-            
+
             # Then check for features
             if echo "$commits" | grep -qE "^feat(\([a-z]+\))?:"; then
               echo "Found feature - will use minor bump"
               echo "minor"
               return 0
             fi
-            
+
             # Then check for fixes
             if echo "$commits" | grep -qE "^fix(\([a-z]+\))?:"; then
               echo "Found fix - will use patch bump"
               echo "patch"
               return 0
             fi
-            
+
             # Default to patch if no patterns match
             echo "No conventional commit patterns found - defaulting to patch"
             echo "patch"
             return 0
           }
-          
+
           # Check PR title for conventional commit format
           AUTO_BUMP_TYPE=""
           if [[ "$PR_TITLE" =~ ^BREAKING\ CHANGE: || "$PR_TITLE" =~ ^[a-z]+(\([a-z]+\))?!: ]]; then
@@ -80,14 +80,14 @@ jobs:
           else
             # Check PR commits for conventional commit format
             echo "PR title not in conventional commit format, checking commits..."
-            
+
             # Set GH_TOKEN for gh CLI
             export GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
-            
+
             # Safely capture commits, providing a fallback if the command fails
             echo "Fetching commits from PR #${{ github.event.pull_request.number }}..."
             PR_COMMITS=$(gh pr view ${{ github.event.pull_request.number }} --json commits --jq '.commits[].messageHeadline' 2>/dev/null || echo "")
-            
+
             if [ -z "$PR_COMMITS" ]; then
               echo "Failed to get PR commits or no commits found - defaulting to patch"
               AUTO_BUMP_TYPE="patch"
@@ -96,9 +96,9 @@ jobs:
               AUTO_BUMP_TYPE=$(determine_bump_type "$PR_COMMITS")
             fi
           fi
-          
+
           echo "Auto-detected bump type from commits/title: $AUTO_BUMP_TYPE"
-          
+
           # Explicit labels take precedence over auto-detection
           if echo "$PR_LABELS" | grep -q '"major"'; then
             echo "bump_type=major" >> $GITHUB_OUTPUT
@@ -117,21 +117,21 @@ jobs:
             echo "bump_type=patch" >> $GITHUB_OUTPUT
             echo "No version indicators found, defaulting to patch"
           fi
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '18'
-      
+
       - name: Install dependencies
         run: npm install -g semver
-      
+
       - name: Bump version
         id: bump-version
         run: |
           # Get current version from package.json
           CURRENT_VERSION=$(node -p "require('./package.json').version")
-          
+
           # Determine new version based on bump type
           if [ "${{ steps.check-label.outputs.bump_type }}" = "major" ]; then
             NEW_VERSION=$(semver -i major $CURRENT_VERSION)
@@ -140,15 +140,15 @@ jobs:
           else
             NEW_VERSION=$(semver -i patch $CURRENT_VERSION)
           fi
-          
+
           echo "Current version: $CURRENT_VERSION"
           echo "New version: $NEW_VERSION"
           echo "Bump type: ${{ steps.check-label.outputs.bump_type }}"
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
-          
+
           # Update package.json with new version
           node -e "const fs = require('fs'); const pkg = require('./package.json'); pkg.version = '$NEW_VERSION'; fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');"
-      
+
       - name: Commit and push version bump
         run: |
           git add package.json
@@ -158,12 +158,12 @@ jobs:
           PR: #${{ github.event.pull_request.number }}
           Title: ${{ github.event.pull_request.title }}"
           git push
-      
+
       - name: Output summary
         run: |
           echo "✅ Version bumped to ${{ steps.bump-version.outputs.new_version }} (${{ steps.check-label.outputs.bump_type }} bump)"
           echo "🚀 The release-with-sbom workflow will be triggered automatically by this change."
-      
+
       # Add a special commit file to trigger the release workflow
       - name: Create release trigger file
         run: |
@@ -171,13 +171,41 @@ jobs:
           echo "Creating trigger file for release..."
           mkdir -p .github/triggers
           TIMESTAMP=$(date +%s)
-          
+
           # Use version and timestamp to ensure file is always unique
           echo "VERSION=${{ steps.bump-version.outputs.new_version }}" > .github/triggers/release-${{ steps.bump-version.outputs.new_version }}-${TIMESTAMP}.txt
-          
+
           # Commit and push the trigger file
           git add .github/triggers/
           git commit -m "trigger: release version ${{ steps.bump-version.outputs.new_version }} [${TIMESTAMP}]"
+
+          echo "Pushing changes to trigger release workflow..."
           git push
-          
+
           echo "Release trigger committed and pushed. The release workflow should start automatically."
+
+          # Debug information about the workflow
+          echo "========== WORKFLOW DEBUG INFO =========="
+          echo "Workflow name: ${{ github.workflow }}"
+          echo "Job name: ${{ github.job }}"
+          echo "Run ID: ${{ github.run_id }}"
+          echo "Run number: ${{ github.run_number }}"
+          echo "Actor: ${{ github.actor }}"
+          echo "Repository: ${{ github.repository }}"
+          echo "Ref: ${{ github.ref }}"
+          echo "SHA: ${{ github.sha }}"
+          echo "Event name: ${{ github.event_name }}"
+          echo "Workflow permissions:"
+          echo "  Contents: write"
+          echo "  Pull requests: write"
+          echo "  Actions: write"
+          echo "========================================"
+
+          # Wait a moment to ensure the push is processed
+          sleep 5
+
+          echo "Checking if the release workflow was triggered..."
+          # This is just informational and won't affect the workflow
+          curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/runs?event=workflow_run&status=in_progress" | \
+            grep -o '"name":"Release with SBOM and Notes"' || echo "Release workflow not found in currently running workflows"

--- a/.github/workflows/release-with-sbom.yml
+++ b/.github/workflows/release-with-sbom.yml
@@ -4,21 +4,27 @@ name: Release with SBOM and Notes
 # It compares the current package.json version with existing GitHub releases,
 # and only creates a new release if one doesn't already exist for that version.
 
+# Default permissions for all jobs
+permissions:
+  contents: write  # Needed for creating releases and tags
+  actions: read    # Needed to read workflow runs
+  id-token: write  # Needed for npm provenance
+
 on:
   workflow_dispatch:
     inputs:
       force_version:
         description: 'Force release of specific version (leave empty to use package.json)'
         required: false
-  
+
   # Run this workflow on EVERY push to main to check for release conditions
   push:
     branches:
       - main
-  
+
   # Also triggered when auto-version-bump workflow completes successfully
   workflow_run:
-    workflows: 
+    workflows:
       - "Auto Version Bump"
     types:
       - completed
@@ -28,6 +34,9 @@ on:
 jobs:
   check-version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Needed for checking releases and tags
+      actions: read    # Needed to read workflow runs
     outputs:
       version: ${{ steps.get-version.outputs.version }}
       proceed: ${{ steps.check.outputs.proceed }}
@@ -37,7 +46,7 @@ jobs:
         with:
           fetch-depth: 0  # Full history for release notes
           ref: ${{ github.event_name == 'workflow_run' && 'main' || github.ref }}
-      
+
       - name: Debug workflow metadata
         run: |
           echo "========== WORKFLOW DEBUG INFO =========="
@@ -46,28 +55,37 @@ jobs:
           echo "Ref: ${{ github.ref }}"
           echo "SHA: ${{ github.sha }}"
           echo "Repository: ${{ github.repository }}"
-          
+          echo "Actor: ${{ github.actor }}"
+          echo "Workflow permissions:"
+          echo "  Contents: ${{ github.token_permissions.contents }}"
+          echo "  Actions: ${{ github.token_permissions.actions }}"
+          echo "  ID-token: ${{ github.token_permissions.id-token }}"
+
           if [ "${{ github.event_name }}" = "workflow_run" ]; then
             echo "Workflow run details:"
             echo "  Source workflow: ${{ github.event.workflow_run.name }}"
             echo "  Workflow ID: ${{ github.event.workflow_run.id }}"
             echo "  Workflow conclusion: ${{ github.event.workflow_run.conclusion }}"
             echo "  Source HEAD SHA: ${{ github.event.workflow_run.head_sha }}"
+            echo "  Source branch: ${{ github.event.workflow_run.head_branch }}"
+            echo "  Source repository: ${{ github.event.workflow_run.repository.full_name }}"
+            echo "  Created at: ${{ github.event.workflow_run.created_at }}"
+            echo "  Updated at: ${{ github.event.workflow_run.updated_at }}"
           fi
-          
+
           echo "Listing repository tags:"
           git tag --list -n
-          
+
           echo "Recent commits on main:"
           git log -n 5 --pretty=format:"%h %s"
-          
+
           echo "Checking for trigger files:"
           find .github -type f -name "*.txt" 2>/dev/null || echo "No trigger files found"
-          
+
           echo "Package.json version:"
           cat package.json | grep version || echo "Could not find version in package.json"
           echo "========================================"
-      
+
       - name: Get version from package.json or trigger file
         id: get-version
         run: |
@@ -78,7 +96,7 @@ jobs:
             echo "version=$FORCE_VERSION" >> $GITHUB_OUTPUT
             exit 0
           fi
-          
+
           # We no longer depend on trigger files, but check them for legacy support
           if [ -d ".github/triggers" ]; then
             TRIGGER_FILES=$(find .github/triggers -name "release-*.txt" 2>/dev/null | sort -r | head -n 1)
@@ -90,7 +108,7 @@ jobs:
               fi
             fi
           fi
-          
+
           # Otherwise get version from package.json
           if [ -f "package.json" ]; then
             VERSION=$(jq -r '.version' package.json)
@@ -102,20 +120,20 @@ jobs:
             ls -la
             exit 1
           fi
-      
+
       - name: Check for existing GitHub release
         id: check-release
         run: |
           VERSION="${{ steps.get-version.outputs.version }}"
           echo "Checking if GitHub release v$VERSION already exists..."
-          
+
           # Set GH_TOKEN for gh CLI
           export GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
-          
+
           if gh release view "v$VERSION" &> /dev/null; then
             echo "::warning::Release v$VERSION already exists!"
             echo "release_exists=true" >> $GITHUB_OUTPUT
-            
+
             # Get release URL
             RELEASE_URL=$(gh release view "v$VERSION" --json url -q .url)
             echo "Existing release: $RELEASE_URL"
@@ -123,12 +141,12 @@ jobs:
             echo "No existing release for v$VERSION found, can proceed with new release"
             echo "release_exists=false" >> $GITHUB_OUTPUT
           fi
-      
+
       - name: Check if we should proceed with release
         id: check
         run: |
           echo "Event name: ${{ github.event_name }}"
-          
+
           # Always honor forced release for manual workflow dispatch
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             FORCE_VERSION="${{ github.event.inputs.force_version }}"
@@ -137,67 +155,79 @@ jobs:
               echo "proceed=true" >> $GITHUB_OUTPUT
               exit 0
             fi
-            
+
             echo "Manual workflow trigger - proceeding with release"
             echo "proceed=true" >> $GITHUB_OUTPUT
             exit 0
           fi
-          
+
           # Check if release already exists
           if [ "${{ steps.check-release.outputs.release_exists }}" = "true" ]; then
             echo "::warning::Release already exists for this version - skipping release"
             echo "proceed=false" >> $GITHUB_OUTPUT
             exit 0
           fi
-          
+
           # For workflow_run events from Auto Version Bump
           if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            echo "Processing workflow_run event from ${github.event.workflow_run.name}"
+
             if [ "${{ github.event.workflow_run.conclusion }}" = "success" ]; then
               echo "Auto Version Bump completed successfully - proceeding with release"
-              
+
               # Get the head SHA from the workflow run
               HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
               echo "Source workflow HEAD SHA: $HEAD_SHA"
-              
-              # Check if we have a package.json change in the workflow run
+
+              # Ensure we have the latest code from main
               git fetch origin main
-              
+              git checkout main
+              git pull origin main
+
               # Get the current version from package.json
               CURRENT_VERSION=$(jq -r '.version' package.json)
               echo "Current version from package.json: $CURRENT_VERSION"
-              
-              echo "proceed=true" >> $GITHUB_OUTPUT
+
+              # Check if this version already has a release
+              export GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
+              if gh release view "v$CURRENT_VERSION" &> /dev/null; then
+                echo "Release v$CURRENT_VERSION already exists - skipping release creation"
+                echo "proceed=false" >> $GITHUB_OUTPUT
+              else
+                echo "Version $CURRENT_VERSION has no existing GitHub release - proceeding with release"
+                echo "proceed=true" >> $GITHUB_OUTPUT
+              fi
             else
               echo "Auto Version Bump did not complete successfully - skipping release"
               echo "proceed=false" >> $GITHUB_OUTPUT
             fi
             exit 0
           fi
-          
+
           # For push events - check for version change in the most recent commits
           if [ "${{ github.event_name }}" = "push" ]; then
             echo "This is a push event - checking recent version changes"
-            
+
             # Check existing GitHub releases
             export GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
-            
+
             # Get current version from package.json
             CURRENT_VERSION=$(jq -r '.version' package.json)
             echo "Current version in package.json: $CURRENT_VERSION"
-            
+
             # Check if this version already has a release
             if gh release view "v$CURRENT_VERSION" &> /dev/null; then
               echo "Release v$CURRENT_VERSION already exists - skipping release creation"
               echo "proceed=false" >> $GITHUB_OUTPUT
               exit 0
             fi
-            
+
             # If we've reached here, we have a version that needs releasing
             echo "Version $CURRENT_VERSION has no existing GitHub release - proceeding with release"
             echo "proceed=true" >> $GITHUB_OUTPUT
             exit 0
           fi
-          
+
           # Default fallback
           echo "Unknown event type - proceeding with release as fallback"
           echo "proceed=true" >> $GITHUB_OUTPUT
@@ -206,42 +236,44 @@ jobs:
     needs: check-version
     if: needs.check-version.outputs.proceed == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Full history for release notes
           ref: ${{ github.event_name == 'workflow_run' && 'main' || github.ref }}
-      
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '18'
           registry-url: 'https://registry.npmjs.org'
-      
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Display version info
         run: |
           echo "Working with version: ${{ needs.check-version.outputs.version }}"
-      
+
       - name: Build project
         run: |
           echo "TypeScript version:"
           npx tsc --version
-          
+
           echo "Checking for workers-types package:"
           npm list @cloudflare/workers-types || true
-          
+
           echo "Building project with verbose TypeScript output..."
           npx tsc --listEmittedFiles
           npx tsc -p tsconfig.cli.json --listEmittedFiles
           npm run build:tailwind
-      
+
       - name: Run tests
         run: npm test || echo "Tests skipped"
-      
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -252,25 +284,26 @@ jobs:
     needs: [check-version, build]
     if: needs.check-version.outputs.proceed == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '18'
-      
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Generate CycloneDX SBOM
         uses: CycloneDX/gh-node-module-generatebom@v1
         with:
           path: ./
           output: ./bom.json
-          format: json
-      
+
       - name: Upload SBOM
         uses: actions/upload-artifact@v4
         with:
@@ -281,6 +314,8 @@ jobs:
     needs: [check-version, build]
     if: needs.check-version.outputs.proceed == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       release_notes: ${{ steps.generate-notes.outputs.notes }}
     steps:
@@ -288,19 +323,19 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
       - name: Set version for release notes
         id: version
         run: |
           echo "version=${{ needs.check-version.outputs.version }}" >> $GITHUB_OUTPUT
           echo "Using version: ${{ needs.check-version.outputs.version }}"
-      
+
       - name: Get previous tag
         id: previoustag
         run: |
           PREVIOUS_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "none")
           echo "tag=$PREVIOUS_TAG" >> $GITHUB_OUTPUT
-      
+
       - name: Generate release notes
         id: generate-notes
         run: |
@@ -309,15 +344,15 @@ jobs:
           else
             COMMITS=$(git log ${{ steps.previoustag.outputs.tag }}..HEAD --pretty=format:"- %s (%h)")
           fi
-          
+
           PR_NUMBERS=$(echo "$COMMITS" | grep -o "#[0-9]\+" | sort -u | sed 's/#//')
-          
+
           echo "## What's Changed in v${{ steps.version.outputs.version }}" > RELEASE_NOTES.md
           echo "" >> RELEASE_NOTES.md
           echo "### Commits" >> RELEASE_NOTES.md
           echo "$COMMITS" >> RELEASE_NOTES.md
           echo "" >> RELEASE_NOTES.md
-          
+
           if [ ! -z "$PR_NUMBERS" ]; then
             echo "### Pull Requests" >> RELEASE_NOTES.md
             for PR in $PR_NUMBERS; do
@@ -330,11 +365,11 @@ jobs:
             done
             echo "" >> RELEASE_NOTES.md
           fi
-          
+
           echo "### SBOM Information" >> RELEASE_NOTES.md
           echo "This release includes a Software Bill of Materials (SBOM) in CycloneDX format." >> RELEASE_NOTES.md
           echo "" >> RELEASE_NOTES.md
-          
+
           # Escape special characters for GitHub Actions output
           NOTES=$(cat RELEASE_NOTES.md)
           NOTES="${NOTES//'%'/'%25'}"
@@ -342,7 +377,7 @@ jobs:
           NOTES="${NOTES//$'\n'/'%0A'}"
           NOTES="${NOTES//$'\r'/'%0D'}"
           echo "notes=$NOTES" >> $GITHUB_OUTPUT
-      
+
       - name: Upload release notes
         uses: actions/upload-artifact@v4
         with:
@@ -359,13 +394,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Set version for release
         id: version
         run: |
           echo "version=${{ needs.check-version.outputs.version }}" >> $GITHUB_OUTPUT
           echo "Using version: ${{ needs.check-version.outputs.version }}"
-      
+
       - name: Debug release information
         run: |
           echo "========== RELEASE DEBUG INFO =========="
@@ -373,29 +408,29 @@ jobs:
           echo "Creating tag: v${{ needs.check-version.outputs.version }}"
           echo "Checking if artifacts are available..."
           echo "========================================"
-      
+
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
           name: build-artifacts
           path: dist/
-      
+
       - name: Download SBOM
         uses: actions/download-artifact@v4
         with:
           name: sbom
           path: ./
-      
+
       - name: Download release notes
         uses: actions/download-artifact@v4
         with:
           name: release-notes
           path: ./
-      
-      - name: Verify artifacts  
+
+      - name: Verify artifacts
         run: |
           echo "Checking for downloaded artifacts..."
-          
+
           if [ -f "./RELEASE_NOTES.md" ]; then
             echo "✅ Release notes found"
             echo "Content preview:"
@@ -404,23 +439,23 @@ jobs:
             echo "❌ Release notes not found!"
             ls -la ./
           fi
-          
+
           if [ -f "./bom.json" ]; then
             echo "✅ SBOM file found"
           else
             echo "❌ SBOM file not found!"
             ls -la ./
           fi
-          
+
           echo "Build artifacts:"
           ls -la dist/ || echo "Dist directory not found!"
-      
+
       - name: Setup Node.js for publishing
         uses: actions/setup-node@v4
         with:
           node-version: '18'
           registry-url: 'https://registry.npmjs.org'
-      
+
       - name: Create GitHub Release
         id: create_release
         uses: softprops/action-gh-release@v2
@@ -436,29 +471,29 @@ jobs:
           fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Publish to NPM
         if: success()
         run: |
           echo "Version in package.json before publishing:"
           cat package.json | grep version
-          
+
           # Make sure all dependencies are installed correctly (including dev dependencies)
           echo "Reinstalling dependencies to ensure build works"
           npm ci
-          
+
           # Verify TypeScript is working
           echo "Checking TypeScript config"
           npx tsc --version
           npx tsc --listFiles
-          
+
           echo "Publishing to NPM with provenance and SBOM metadata"
           npm publish --provenance
-          
+
           echo "NPM publish complete"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      
+
       - name: Release complete
         run: |
           echo "✅ Release process complete"


### PR DESCRIPTION
## Problem
The release-with-sbom workflow is not being triggered after the version is bumped by the auto-version-bump workflow.

## Solution
This PR fixes the issue by:

1. Adding explicit permissions to the release-with-sbom workflow
   - Added workflow-level permissions to ensure all jobs have the necessary access rights
   - Added job-specific permissions to each job for more granular control

2. Fixing the CycloneDX SBOM generation
   - Removed the invalid format parameter that was causing errors

3. Enhancing the workflow_run event handling
   - Improved the logic in the check-version job to better handle workflow_run events
   - Added code to ensure the latest code is fetched from main
   - Added better version checking to avoid duplicate releases

4. Adding detailed debugging information
   - Enhanced debug output in both workflows to provide more information about the execution context
   - Added workflow permissions debugging to help diagnose permission issues

5. Improving the auto-version-bump workflow
   - Added more debug information to help diagnose triggering issues
   - Added a check to verify if the release workflow was triggered

These changes should ensure that when the auto-version-bump workflow completes successfully, the release-with-sbom workflow is properly triggered with the necessary permissions to create releases and publish to NPM.