### PR TITLE
fix: capture only the last line of determine_bump_type output

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -93,7 +93,8 @@ jobs:
               AUTO_BUMP_TYPE="patch"
             else
               echo "Found commits, analyzing conventional commit patterns"
-              AUTO_BUMP_TYPE=$(determine_bump_type "$PR_COMMITS")
+              # Capture only the last line of output from determine_bump_type
+              AUTO_BUMP_TYPE=$(determine_bump_type "$PR_COMMITS" | tail -n 1)
             fi
           fi
 


### PR DESCRIPTION
## Problem
After merging the previous PR to fix the release workflow triggering, the auto-version-bump workflow is failing at the check-label job with the error:

```
Error: Unable to process file command 'output' successfully.
Error: Invalid format 'Found fix - will use patch bump'
```

## Solution
This PR fixes the issue by modifying how the output of the `determine_bump_type` function is captured. The function outputs both log messages and the actual bump type, but only the last line (the actual bump type) should be used when setting the `AUTO_BUMP_TYPE` variable.

The fix adds `| tail -n 1` to ensure only the last line of output is captured, which contains just the bump type ('major', 'minor', or 'patch') without any log messages that would cause the invalid format error.