### PR TITLE
fix: Fix auto-version-bump workflow failures

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -34,7 +34,7 @@ jobs:
 
           # Determine conventional commit type from PR title or commits
           PR_TITLE="${{ github.event.pull_request.title }}"
-          PR_BODY="${{ github.event.pull_request.body }}"
+          # PR body is not used for version determination, so we don't need to include it
 
           # Simple, robust function to determine bump type from conventional commits
           determine_bump_type() {
@@ -136,7 +136,10 @@ jobs:
         with:
           node-version: '18'
 
-      - name: Install dependencies
+      - name: Install project dependencies
+        run: npm ci
+
+      - name: Install semver globally
         run: npm install -g semver
 
       - name: Bump version


### PR DESCRIPTION
## Summary
Fixes the failing auto-version-bump GitHub Actions workflow that was causing build/release pipeline failures.

## Problem
The workflow was failing with two main issues:
1. **Shell execution errors**: The PR body content containing backticks and file paths was being executed as shell commands, causing "Permission denied" errors
2. **Module resolution errors**: Missing project dependencies caused "Cannot find package" errors when the workflow tried to validate commits

## Solution
- Removed the PR body variable from the script since it wasn't being used for version determination
- Added `npm ci` step to install project dependencies before running version bump logic
- Separated dependency installation into project dependencies and global semver tool

## Testing
The workflow will be tested when this PR is merged, as it triggers on PR merge events.

## Impact
This fix will restore the automatic version bumping and release pipeline functionality.

Co-Authored-By: Claude <noreply@anthropic.com>