### PR TITLE
Fix: Remove build:tailwind from release pipeline

### DIFF
--- a/.github/workflows/release-with-sbom.yml
+++ b/.github/workflows/release-with-sbom.yml
@@ -298,7 +298,6 @@ jobs:
           echo "Building project with verbose TypeScript output..."
           npx tsc --listEmittedFiles
           npx tsc -p tsconfig.cli.json --listEmittedFiles
-          npm run build:tailwind
 
       - name: Run tests
         run: npm test || echo "Tests skipped"


### PR DESCRIPTION
## Summary
- Remove the non-existent `npm run build:tailwind` command from the GitHub Actions release workflow
- This command was removed during the MUI migration but the workflow wasn't updated

## Context
After migrating from Tailwind CSS to Material-UI, the build:tailwind script no longer exists in package.json, causing the release pipeline to fail.

## Changes
- Removed line 301 from `.github/workflows/release-with-sbom.yml` that was calling `npm run build:tailwind`

## Test plan
- [ ] Release workflow should now complete successfully
- [ ] TypeScript compilation still works as expected

🤖 Generated with Claude Code