### PR TITLE
feat: preserve file extensions in upload URLs

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1154,12 +1154,22 @@ Encryption:
       
       // Make the API request
       try {
+        // Extract filename if uploading a file
+        const filename = options.file ? path.basename(options.file) : '';
+
+        const headers: Record<string, string> = {
+          'Content-Type': contentType,
+          'User-Agent': `dedpaste-cli/${packageJson.version}`
+        };
+
+        // Include filename header if we have a file
+        if (filename) {
+          headers['X-Filename'] = filename;
+        }
+
         const response = await fetch(`${API_URL}${endpoint}`, {
           method: 'POST',
-          headers: {
-            'Content-Type': contentType,
-            'User-Agent': `dedpaste-cli/${packageJson.version}`
-          },
+          headers,
           body: content
         });
         
@@ -1739,13 +1749,23 @@ program
         const endpoint = options.temp ? '/e/temp' : '/e/upload';
         
         try {
+          // Extract filename if uploading a file
+          const filename = options.file ? path.basename(options.file) : '';
+
+          const headers: Record<string, string> = {
+            'Content-Type': contentType,
+            'User-Agent': `dedpaste-cli/${packageJson.version}`
+          };
+
+          // Include filename header if we have a file
+          if (filename) {
+            headers['X-Filename'] = filename;
+          }
+
           // Make the API request
           const response = await fetch(`${API_URL}${endpoint}`, {
             method: 'POST',
-            headers: {
-              'Content-Type': contentType,
-              'User-Agent': `dedpaste-cli/${packageJson.version}`
-            },
+            headers,
             body: content
           });
           
@@ -1795,13 +1815,23 @@ ${options.copy ? '📋 URL copied to clipboard: ' : '📋 '} ${url.trim()}
       const endpoint = options.temp ? '/temp' : '/upload';
       
       try {
+        // Extract filename if uploading a file
+        const filename = options.file ? path.basename(options.file) : '';
+
+        const headers: Record<string, string> = {
+          'Content-Type': contentType,
+          'User-Agent': `dedpaste-cli/${packageJson.version}`
+        };
+
+        // Include filename header if we have a file
+        if (filename) {
+          headers['X-Filename'] = filename;
+        }
+
         // Make the API request
         const response = await fetch(`${API_URL}${endpoint}`, {
           method: 'POST',
-          headers: {
-            'Content-Type': contentType,
-            'User-Agent': `dedpaste-cli/${packageJson.version}`
-          },
+          headers,
           body: content
         });
         

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dedpaste",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "CLI pastebin application using Cloudflare Workers and R2",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary
Fixes #90 - Adds proper file extension preservation for file uploads and downloads.

When uploading files using `dedpaste --file somefile.pdf`, the original filename and extension are now preserved in the retrieval URL, allowing proper file type identification upon download.

## Changes Made
- **CLI Updates**: Modified `cli/index.ts` to send `X-Filename` header with the basename of uploaded files
- **Three upload paths updated**:
  1. Send command (both encrypted and non-encrypted)
  2. Default command (encrypted uploads)
  3. Default command (non-encrypted uploads)
- **Version bump**: Updated to 1.18.0 (minor feature addition)

## Technical Details
The server-side code already supported this feature:
- Accepts `X-Filename` header and stores it in R2 metadata
- Supports optional filename in URL paths: `/{id}/{filename}` and `/e/{id}/{filename}`
- Returns URLs with filename when metadata contains it

The gap was that the CLI never sent the filename header. This PR closes that gap.

## Before/After Examples

### Before
```bash
$ dedpaste --file document.pdf
https://paste.d3d.dev/AbCdEfGh
```

### After
```bash
$ dedpaste --file document.pdf
https://paste.d3d.dev/AbCdEfGh/document.pdf

$ dedpaste --file photo.jpg --encrypt
https://paste.d3d.dev/e/XyZ123/photo.jpg

$ dedpaste --file data.json --temp
https://paste.d3d.dev/AbCdEfGh/data.json
```

## Use Cases Addressed
- ✅ Binary files (PDFs, images, videos) get proper extensions
- ✅ Automation scripts can determine file handling based on extension
- ✅ Cross-platform sharing with proper file type associations
- ✅ Web browsers can set proper MIME types and Content-Disposition headers

## Test Plan
- [x] Build succeeds with TypeScript compilation
- [x] CLI code review confirms proper header injection
- [x] All three upload code paths include the filename header
- [ ] Manual testing with actual file uploads (requires deployment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)