### PR TITLE
fix: prevent CLI from hanging after successful file upload

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -973,6 +973,8 @@ ${encryptionMessage}
 ${options.copy ? '📋 URL copied to clipboard: ' : '📋 '} ${url.trim()}
 `);
             }
+            // Exit successfully
+            process.exit(0);
         }
         catch (error) {
             console.error(`Network error: ${error.message}`);
@@ -1509,7 +1511,8 @@ ${options.temp ? '⚠️  This is a one-time paste that will be deleted after fi
 ${options.copy ? '📋 URL copied to clipboard: ' : '📋 '} ${url.trim()}
 `);
                 }
-                return;
+                // Exit successfully
+                process.exit(0);
             }
             catch (error) {
                 console.error(`Network error: ${error.message}`);
@@ -1576,6 +1579,8 @@ ${options.temp ? '⚠️  This is a one-time paste that will be deleted after fi
 ${options.copy ? '📋 URL copied to clipboard: ' : '📋 '} ${url.trim()}
 `);
             }
+            // Exit successfully
+            process.exit(0);
         }
         catch (error) {
             console.error(`Network error: ${error.message}`);

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1225,6 +1225,9 @@ ${encryptionMessage}
 ${options.copy ? '📋 URL copied to clipboard: ' : '📋 '} ${url.trim()}
 `);
         }
+
+        // Exit successfully
+        process.exit(0);
       } catch (error: any) {
         console.error(`Network error: ${error.message}`);
         console.error('If you just want to test encryption without uploading, use the --debug flag');
@@ -1804,7 +1807,9 @@ ${options.temp ? '⚠️  This is a one-time paste that will be deleted after fi
 ${options.copy ? '📋 URL copied to clipboard: ' : '📋 '} ${url.trim()}
 `);
           }
-          return;
+
+          // Exit successfully
+          process.exit(0);
         } catch (error: any) {
           console.error(`Network error: ${error.message}`);
           process.exit(1);
@@ -1877,6 +1882,9 @@ ${options.temp ? '⚠️  This is a one-time paste that will be deleted after fi
 ${options.copy ? '📋 URL copied to clipboard: ' : '📋 '} ${url.trim()}
 `);
         }
+
+        // Exit successfully
+        process.exit(0);
       } catch (error: any) {
         console.error(`Network error: ${error.message}`);
         process.exit(1);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dedpaste",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "description": "CLI pastebin application using Cloudflare Workers and R2",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Add process.exit(0) after successful paste creation in all upload code paths. Previously, the CLI would output the URL but hang indefinitely, requiring Ctrl+C to terminate.

Root cause: Node.js event loop remained active due to open stdin handle and pending async operations, even though the upload was complete.

Fixed in three locations:
- Send command upload (~line 1230)
- Default command encrypted upload (~line 1812)
- Default command non-encrypted upload (~line 1887)

Resolves hanging behavior reported in feature/preserve-file-extensions testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)