### PR TITLE
feat: Add GitHub GPG key integration with JIT fetching

### DIFF
--- a/cli/githubUtils.ts
+++ b/cli/githubUtils.ts
@@ -1,0 +1,224 @@
+// GitHub integration utilities
+import fetch from 'node-fetch';
+import { promises as fsPromises } from 'fs';
+import path from 'path';
+import { importPgpKey } from './pgpUtils.js';
+import { addGitHubKey as addGitHubKeyToManager } from './keyManager.js';
+import type { GitHubUser } from '../src/types/index.js';
+
+// GitHub URLs
+const GITHUB_BASE_URL = 'https://github.com';
+const GITHUB_API_URL = 'https://api.github.com';
+
+/**
+ * Fetch GitHub user's GPG public keys
+ * Uses the simple .gpg endpoint for direct PGP import
+ * @param username GitHub username
+ * @returns PGP armored public key data
+ */
+export async function fetchGitHubGpgKey(username: string): Promise<string> {
+  const url = `${GITHUB_BASE_URL}/${username}.gpg`;
+
+  try {
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        throw new Error(
+          `GitHub user "${username}" not found or has no GPG keys.\n` +
+          `Users can add GPG keys at https://github.com/settings/keys`
+        );
+      }
+      throw new Error(`Failed to fetch GPG key: ${response.status} ${response.statusText}`);
+    }
+
+    const keyData = await response.text();
+
+    if (!keyData || keyData.trim().length === 0) {
+      throw new Error(
+        `User "${username}" has no GPG keys on GitHub.\n` +
+        `GPG keys can be added at https://github.com/settings/keys`
+      );
+    }
+
+    // Validate it looks like a PGP key
+    if (!keyData.includes('-----BEGIN PGP PUBLIC KEY BLOCK-----')) {
+      throw new Error(
+        `Invalid GPG key data received for user "${username}". ` +
+        `Please ensure the user has a valid GPG key on GitHub.`
+      );
+    }
+
+    return keyData;
+  } catch (error: any) {
+    if (error.message.includes('fetch failed') || error.code === 'ENOTFOUND') {
+      throw new Error(
+        `Network error: Unable to connect to GitHub. ` +
+        `Please check your internet connection.`
+      );
+    }
+    throw error;
+  }
+}
+
+/**
+ * Fetch GitHub user metadata
+ * @param username GitHub username
+ * @returns User information
+ */
+export async function fetchGitHubUser(username: string): Promise<GitHubUser> {
+  const url = `${GITHUB_API_URL}/users/${username}`;
+
+  try {
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        throw new Error(`GitHub user "${username}" not found`);
+      }
+      throw new Error(`Failed to fetch user info: ${response.status} ${response.statusText}`);
+    }
+
+    const data: any = await response.json();
+
+    return {
+      username: data.login,
+      name: data.name || undefined,
+      bio: data.bio || undefined,
+      location: data.location || undefined,
+      publicRepos: data.public_repos,
+      followers: data.followers,
+      following: data.following,
+      createdAt: data.created_at ? new Date(data.created_at) : undefined,
+      updatedAt: data.updated_at ? new Date(data.updated_at) : undefined
+    };
+  } catch (error: any) {
+    if (error.message.includes('fetch failed') || error.code === 'ENOTFOUND') {
+      throw new Error(
+        `Network error: Unable to connect to GitHub API. ` +
+        `Please check your internet connection.`
+      );
+    }
+    throw error;
+  }
+}
+
+/**
+ * Verify GitHub user exists and is active
+ * @param username GitHub username
+ * @returns true if user exists and is valid
+ */
+export async function verifyGitHubUser(username: string): Promise<boolean> {
+  try {
+    const user = await fetchGitHubUser(username);
+    return !!user.username;
+  } catch (error) {
+    return false;
+  }
+}
+
+/**
+ * Main function: Fetch and add GitHub GPG key to local storage
+ * @param username GitHub username
+ * @param customName Optional custom name for the key
+ * @param verify Whether to verify the user first
+ * @param silent Whether to suppress console output
+ */
+export async function addGitHubKey(
+  username: string,
+  customName?: string,
+  verify: boolean = false,
+  silent: boolean = false
+): Promise<{ name: string; fingerprint: string; email?: string }> {
+  // Validate username
+  if (!username || username.trim().length === 0) {
+    throw new Error('GitHub username cannot be empty');
+  }
+
+  // Sanitize username (GitHub usernames are alphanumeric + hyphens)
+  const sanitizedUsername = username.trim();
+  if (!/^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$/.test(sanitizedUsername)) {
+    throw new Error(
+      `Invalid GitHub username: "${username}". ` +
+      `Usernames can only contain alphanumeric characters and hyphens.`
+    );
+  }
+
+  // Optional verification
+  if (verify && !silent) {
+    console.log(`Verifying GitHub user: ${sanitizedUsername}...`);
+    const isValid = await verifyGitHubUser(sanitizedUsername);
+    if (!isValid) {
+      throw new Error(`Cannot verify GitHub user: ${sanitizedUsername}`);
+    }
+    console.log(`✓ User verified`);
+  }
+
+  // Fetch GPG key
+  if (!silent) {
+    console.log(`Fetching GPG key for GitHub user: ${sanitizedUsername}...`);
+  }
+  const gpgKeyData = await fetchGitHubGpgKey(sanitizedUsername);
+
+  // Import and validate PGP key
+  if (!silent) {
+    console.log(`Importing PGP key...`);
+  }
+  const keyInfo = await importPgpKey(gpgKeyData);
+
+  // Generate key name
+  const keyName = customName || `github:${sanitizedUsername}`;
+
+  // Add to key manager
+  await addGitHubKeyToManager(keyName, sanitizedUsername, keyInfo, gpgKeyData);
+
+  if (!silent) {
+    console.log(`✓ GitHub key added: ${keyName}`);
+    console.log(`  Fingerprint: ${keyInfo.fingerprint}`);
+    if (keyInfo.email) {
+      console.log(`  Email: ${keyInfo.email}`);
+    }
+  }
+
+  return {
+    name: keyName,
+    fingerprint: keyInfo.fingerprint,
+    email: keyInfo.email
+  };
+}
+
+/**
+ * Fetch GitHub key just-in-time (used during encryption)
+ * Checks if key exists in database, fetches if not
+ * @param username GitHub username (without github: prefix)
+ * @param silent Whether to suppress console output
+ * @returns Key name and metadata
+ */
+export async function ensureGitHubKey(
+  username: string,
+  silent: boolean = false
+): Promise<{ name: string; fingerprint: string; email?: string }> {
+  const keyName = `github:${username}`;
+
+  // Check if key already exists
+  const { getKey } = await import('./keyManager.js');
+  const existingKey = await getKey('github', keyName);
+
+  if (existingKey) {
+    if (!silent) {
+      console.log(`Using cached GitHub key: ${keyName}`);
+    }
+    return {
+      name: keyName,
+      fingerprint: existingKey.fingerprint,
+      email: existingKey.email
+    };
+  }
+
+  // Key doesn't exist, fetch it
+  if (!silent) {
+    console.log(`GitHub key not found locally, fetching from GitHub...`);
+  }
+
+  return await addGitHubKey(username, undefined, false, silent);
+}

--- a/cli/index.js
+++ b/cli/index.js
@@ -155,6 +155,9 @@ program
     .option('--keybase <username>', 'Fetch and add a Keybase user\'s PGP key')
     .option('--keybase-name <name>', 'Custom name for the Keybase user\'s key (optional)')
     .option('--no-verify', 'Skip verification of Keybase proofs')
+    // GitHub options
+    .option('--github <username>', 'Fetch and add a GitHub user\'s GPG public key')
+    .option('--github-name <name>', 'Custom name for the GitHub user\'s key (optional)')
     // Debugging and logging options
     .option('--verbose', 'Enable verbose logging (same as --log-level debug)')
     .option('--debug', 'Enable debug mode with extensive logging (same as --log-level trace)')
@@ -179,12 +182,17 @@ Keybase Integration:
   $ dedpaste keys --keybase username                      # Add a Keybase user's key
   $ dedpaste keys --keybase username --keybase-name bob   # Add with custom name
   $ dedpaste keys --keybase username --no-verify          # Skip verification of proofs
-  
+
+GitHub Integration:
+  $ dedpaste keys --github username                       # Add a GitHub user's GPG key
+  $ dedpaste keys --github username --github-name bob     # Add with custom name
+
 Key Storage:
   - Your keys are stored in ~/.dedpaste/keys/
   - Friend keys are stored in ~/.dedpaste/friends/
   - PGP keys are stored in ~/.dedpaste/pgp/
   - Keybase keys are stored in ~/.dedpaste/keybase/
+  - GitHub keys are stored in ~/.dedpaste/github/
   - Key database is at ~/.dedpaste/keydb.json
 `)
     .action(async (options) => {
@@ -650,6 +658,32 @@ Key Storage:
             }
             return;
         }
+        // Fetch and add a GitHub user's key
+        if (options.github) {
+            logger.debug('Fetching GitHub key', { username: options.github });
+            try {
+                const { addGitHubKey } = await import('./githubUtils.js');
+                console.log(`Fetching GPG key for GitHub user "${options.github}"...`);
+                if (options.verify) {
+                    console.log('Verifying GitHub user...');
+                }
+                const customName = options.githubName;
+                const result = await addGitHubKey(options.github, customName, options.verify);
+                console.log(`
+✓ Added GitHub key:
+  - Name: ${result.name}
+  - GitHub username: ${options.github}
+  - Email: ${result.email || 'Not specified'}
+  - Fingerprint: ${result.fingerprint}
+`);
+            }
+            catch (error) {
+                logger.error('Failed to fetch GitHub key', { error: error.message });
+                console.error(`Error fetching GitHub key: ${error.message}`);
+                process.exit(1);
+            }
+            return;
+        }
         // Generate a new key pair
         if (options.genKey) {
             logger.debug('Generating new key pair');
@@ -723,14 +757,20 @@ Examples:
   $ dedpaste send --interactive --encrypt                          # Interactive encrypted message
   $ dedpaste send --enhanced --encrypt                             # Enhanced interactive mode with full key support
   $ dedpaste send --list-friends                                   # List available recipients
-  
+
 PGP Options:
   $ dedpaste send --encrypt --for alice@example.com --pgp          # Encrypt for PGP key (REQUIRED: specify recipient)
   $ dedpaste send --encrypt --for alice --pgp --pgp-key-file friend.asc  # Use specific PGP key file
   $ dedpaste send --enhanced --encrypt --pgp                       # Use enhanced mode with GPG keyring support
-  
+
+Keybase Integration:
+  $ dedpaste send --encrypt --for keybase:username --pgp           # Encrypt for Keybase user
+
+GitHub Integration:
+  $ dedpaste send --encrypt --for github:username --pgp            # Encrypt for GitHub user (auto-fetches GPG key)
+
 IMPORTANT: PGP encryption always requires specifying a recipient with --for
-  
+
 Encryption:
   - Standard encryption uses RSA for key exchange and AES-256-GCM for content
   - PGP encryption (--pgp) uses OpenPGP standard compatible with GnuPG/GPG

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dedpaste",
-  "version": "1.17.0",
+  "version": "1.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dedpaste",
-      "version": "1.17.0",
+      "version": "1.19.1",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,7 +2,7 @@
 
 // Key types
 export interface KeyInfo {
-  type: "self" | "friend" | "pgp" | "keybase" | "gpg";
+  type: "self" | "friend" | "pgp" | "keybase" | "github" | "gpg";
   name: string;
   path: string | { public: string; private: string };
   public?: string;
@@ -14,7 +14,7 @@ export interface KeyInfo {
   lastUsed?: string | Date | null;
   addedDate?: string;
   id?: string;
-  source?: "self" | "friend" | "pgp" | "keybase" | "gpg";
+  source?: "self" | "friend" | "pgp" | "keybase" | "github" | "gpg";
   expires?: string | Date;
   trust?: string;
   uids?: Array<{ uid?: string; trust?: string }>;
@@ -26,6 +26,7 @@ export interface KeyDatabase {
     friends: Record<string, KeyInfo>;
     pgp: Record<string, KeyInfo>;
     keybase: Record<string, KeyInfo>;
+    github: Record<string, KeyInfo>;
   };
   default_friend: string | null;
   last_used: string | null;
@@ -39,7 +40,7 @@ export interface EncryptionResult {
 }
 
 export interface RecipientInfo {
-  type: "self" | "friend" | "pgp" | "keybase";
+  type: "self" | "friend" | "pgp" | "keybase" | "github";
   name: string;
   fingerprint: string;
   username?: string;
@@ -115,6 +116,26 @@ export interface KeybaseProof {
   serviceUrl?: string;
   proofUrl?: string;
   humanUrl?: string;
+}
+
+// GitHub types
+export interface GitHubUser {
+  username: string;
+  name?: string;
+  bio?: string;
+  location?: string;
+  publicRepos?: number;
+  followers?: number;
+  following?: number;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export interface GitHubKeyInfo {
+  id: number;
+  key: string;
+  title?: string;
+  createdAt?: Date;
 }
 
 // Interactive mode types
@@ -300,7 +321,7 @@ export interface SearchOptions {
 }
 
 export interface KeySearchResult extends KeyInfo {
-  source: "self" | "friend" | "pgp" | "keybase" | "gpg";
+  source: "self" | "friend" | "pgp" | "keybase" | "github" | "gpg";
 }
 
 export interface ImportKeyOptions {
@@ -308,6 +329,7 @@ export interface ImportKeyOptions {
     | "file"
     | "pgp-server"
     | "keybase"
+    | "github"
     | "gpg-keyring"
     | "gpg-import"
     | "paste";


### PR DESCRIPTION
## Summary

Implements GitHub public key fetching to enable encryption for GitHub users, as requested in issue #94. Users can now fetch and use GPG keys from any GitHub user's public profile, with support for just-in-time fetching during encryption.

### Key Features

- **Fetch GitHub GPG keys**: `dedpaste keys --github <username>`
- **Just-in-time fetching**: Auto-fetches keys when encrypting with `--for github:username`
- **Custom naming**: Support for `--github-name` option
- **User verification**: Optional `--verify` flag
- **Full UI integration**: Enhanced interactive mode includes GitHub key support

### Implementation Details

**New Files:**
- `cli/githubUtils.ts` - GitHub API integration (224 lines)
  - Fetches GPG keys from `https://github.com/{username}.gpg`
  - User verification via GitHub API
  - Comprehensive error handling

**Modified Files:**
- `src/types/index.ts` - GitHub types and database schema
- `cli/keyManager.ts` - GitHub key storage in `~/.dedpaste/github/`
- `cli/encryptionUtils.ts` - JIT key fetching during encryption
- `cli/index.ts` - CLI commands and help text
- `cli/enhancedInteractiveMode.ts` - Interactive mode support
- `cli/unifiedKeyManager.ts` - Unified key management

### Usage Examples

```bash
# Add a GitHub user's GPG key
dedpaste keys --github anoncam

# Add with custom name
dedpaste keys --github anoncam --github-name bob

# Encrypt for GitHub user (auto-fetches if needed)
echo "Secret password" | dedpaste send --encrypt --for github:anoncam --pgp

# Use enhanced interactive mode
dedpaste keys:enhanced  # GitHub appears in import sources