### PR TITLE
fix: Resolve TypeScript compilation errors in GitHub integration

### DIFF
--- a/cli/githubUtils.ts
+++ b/cli/githubUtils.ts
@@ -169,21 +169,28 @@ export async function addGitHubKey(
   // Generate key name
   const keyName = customName || `github:${sanitizedUsername}`;
 
+  // Map the PGP key info to GitHub key format
+  // importPgpKey returns keyId, but we use it as fingerprint for GitHub keys
+  const githubKeyInfo = {
+    fingerprint: keyInfo.keyId,
+    email: keyInfo.email ?? undefined
+  };
+
   // Add to key manager
-  await addGitHubKeyToManager(keyName, sanitizedUsername, keyInfo, gpgKeyData);
+  await addGitHubKeyToManager(keyName, sanitizedUsername, githubKeyInfo, gpgKeyData);
 
   if (!silent) {
     console.log(`✓ GitHub key added: ${keyName}`);
-    console.log(`  Fingerprint: ${keyInfo.fingerprint}`);
-    if (keyInfo.email) {
-      console.log(`  Email: ${keyInfo.email}`);
+    console.log(`  Fingerprint: ${githubKeyInfo.fingerprint}`);
+    if (githubKeyInfo.email) {
+      console.log(`  Email: ${githubKeyInfo.email}`);
     }
   }
 
   return {
     name: keyName,
-    fingerprint: keyInfo.fingerprint,
-    email: keyInfo.email
+    fingerprint: githubKeyInfo.fingerprint,
+    email: githubKeyInfo.email
   };
 }
 

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -125,6 +125,8 @@ interface KeysOptions {
   nativePgp?: boolean;
   keybase?: string;
   keybaseName?: string;
+  github?: string;
+  githubName?: string;
   verify?: boolean;
   verbose?: boolean;
   debug?: boolean;

--- a/cli/unifiedKeyManager.ts
+++ b/cli/unifiedKeyManager.ts
@@ -65,7 +65,7 @@ export interface ExecResult {
 }
 
 export interface ImportOptions {
-  source: 'file' | 'pgp-server' | 'keybase' | 'gpg-import' | 'gpg-keyring';
+  source: 'file' | 'pgp-server' | 'keybase' | 'github' | 'gpg-import' | 'gpg-keyring';
   content?: string;
   name?: string;
   file?: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dedpaste",
-  "version": "1.19.1",
+  "version": "1.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dedpaste",
-      "version": "1.19.1",
+      "version": "1.20.0",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
## Summary

Fixes the TypeScript compilation errors that were causing the release build to fail after merging PR #95 (GitHub GPG key integration). This enables the release workflow to complete successfully.

## Issues Fixed

This PR resolves all TypeScript errors from the failed release build:

1. ✅ `Property 'github' does not exist on type 'KeysOptions'` (cli/index.ts:885-903)
2. ✅ `Property 'githubName' does not exist on type 'KeysOptions'` (cli/index.ts:897)
3. ✅ `Property 'fingerprint' does not exist on type 'PgpKeyInfo'` (cli/githubUtils.ts:177, 185)
4. ✅ `Type 'string | null' is not assignable to type 'string | undefined'` (cli/githubUtils.ts:186)
5. ✅ `Argument of type 'PgpKeyInfo' is not assignable to parameter of type 'GitHubKeyAddInfo'` (cli/githubUtils.ts:173)
6. ✅ `Type '"github"' is not comparable to ImportOptions source types` (cli/unifiedKeyManager.ts:664)

## Changes Made

### 1. cli/index.ts
- Added `github?: string` and `githubName?: string` properties to `KeysOptions` interface

### 2. cli/githubUtils.ts
- Fixed type mismatch by creating proper mapping from `PgpKeyInfo` to `GitHubKeyAddInfo`
- Map `keyId` → `fingerprint` (importPgpKey returns keyId, not fingerprint)
- Convert `email: string | null` → `email?: string` using nullish coalescing operator

### 3. cli/unifiedKeyManager.ts
- Added `'github'` to the `ImportOptions.source` union type

### 4. package-lock.json
- Updated from running `npm install` during verification

## Test Plan

- [x] Run `npm install` to ensure dependencies are installed
- [x] Run `npm run build` to verify TypeScript compilation succeeds
- [x] Verify no TypeScript errors are reported

## Related

- Fixes build failure from PR #95
- Related to issue #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)