### PR TITLE
fix(security): resolve GitHub code scanning vulnerabilities

### DIFF
--- a/.github/workflows/release-with-sbom.yml
+++ b/.github/workflows/release-with-sbom.yml
@@ -129,8 +129,10 @@ jobs:
 
       - name: Check for existing GitHub release
         id: check-release
+        env:
+          VERSION_INPUT: ${{ steps.get-version.outputs.version }}
         run: |
-          VERSION="${{ steps.get-version.outputs.version }}"
+          VERSION="${VERSION_INPUT}"
           echo "Checking if GitHub release v$VERSION already exists..."
 
           # Set GH_TOKEN for gh CLI
@@ -425,15 +427,19 @@ jobs:
 
       - name: Set version for release
         id: version
+        env:
+          VERSION_INPUT: ${{ needs.check-version.outputs.version }}
         run: |
-          echo "version=${{ needs.check-version.outputs.version }}" >> $GITHUB_OUTPUT
-          echo "Using version: ${{ needs.check-version.outputs.version }}"
+          echo "version=${VERSION_INPUT}" >> $GITHUB_OUTPUT
+          echo "Using version: ${VERSION_INPUT}"
 
       - name: Debug release information
+        env:
+          VERSION_INPUT: ${{ needs.check-version.outputs.version }}
         run: |
           echo "========== RELEASE DEBUG INFO =========="
-          echo "Release version: v${{ needs.check-version.outputs.version }}"
-          echo "Creating tag: v${{ needs.check-version.outputs.version }}"
+          echo "Release version: v${VERSION_INPUT}"
+          echo "Creating tag: v${VERSION_INPUT}"
           echo "Checking if artifacts are available..."
           echo "========================================"
 

--- a/cli/pgpUtils.ts
+++ b/cli/pgpUtils.ts
@@ -292,9 +292,9 @@ async function importPgpKey(pgpKeyString: string, identifier: string | null = nu
       
       // Extract name (everything before the email)
       let nameStr = userIdStr;
-      // Remove email in angle brackets
+      // Remove email in angle brackets (use global flag to remove all occurrences)
       if (nameStr.includes('<') && nameStr.includes('>')) {
-        nameStr = nameStr.replace(/<[^>]*>/, '');
+        nameStr = nameStr.replace(/<[^>]*>/g, '');
       }
       // Remove any remaining email address format
       nameStr = nameStr.replace(/\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/, '');
@@ -349,9 +349,10 @@ async function importPgpKey(pgpKeyString: string, identifier: string | null = nu
             }
             
             // Extract name (everything before the comment and email)
+            // Use global flag to remove all occurrences for complete sanitization
             let nameStr = userIdStr;
-            if (commentMatch) nameStr = nameStr.replace(/\s*\([^)]+\)\s*/, ' ');
-            if (emailMatch) nameStr = nameStr.replace(/\s*<[^>]+>\s*/, '');
+            if (commentMatch) nameStr = nameStr.replace(/\s*\([^)]+\)\s*/g, ' ');
+            if (emailMatch) nameStr = nameStr.replace(/\s*<[^>]+>\s*/g, '');
             name = nameStr.trim() || name;
           }
         } catch (error: any) {

--- a/cli/unifiedKeyManager.ts
+++ b/cli/unifiedKeyManager.ts
@@ -284,11 +284,12 @@ export async function searchKeys(query: string, options: SearchOptions = {}): Pr
           }
           
           // Extract name from UID (if present)
+          // Use global flag to remove all occurrences for complete sanitization
           let name = uidString;
           if (emailMatch) {
-            name = uidString.replace(/<[^>]+>/, '').trim();
+            name = uidString.replace(/<[^>]+>/g, '').trim();
           }
-          
+
           // Check if it matches the query
           if (
             fieldMatches(key.id) || 
@@ -428,11 +429,12 @@ export async function getKeyById(id: string, options: SearchOptions = {}): Promi
           }
           
           // Extract name from UID (if present)
+          // Use global flag to remove all occurrences for complete sanitization
           let name = uidString;
           if (emailMatch) {
-            name = uidString.replace(/<[^>]+>/, '').trim();
+            name = uidString.replace(/<[^>]+>/g, '').trim();
           }
-          
+
           return {
             id: gpgKey.id,
             name: name,


### PR DESCRIPTION
- Fix critical GitHub Actions code injection (5 alerts)
  - Use environment variables instead of direct interpolation
  - Affected: release-with-sbom.yml (lines 133, 429-444)

- Fix high-severity incomplete multi-character sanitization (4 alerts)
  - Add global flag 'g' to .replace() calls to sanitize all occurrences
  - Affected: cli/pgpUtils.ts (lines 297, 354-355)
  - Affected: cli/unifiedKeyManager.ts (lines 289, 435)

🤖 Generated with [Claude Code](https://claude.com/claude-code)