### PR TITLE
feat(ci): migrate to npm Trusted Publishers (OIDC)

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '24'
 
       - name: Install project dependencies
         run: npm ci

--- a/.github/workflows/release-with-sbom.yml
+++ b/.github/workflows/release-with-sbom.yml
@@ -279,7 +279,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
@@ -323,7 +323,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '24'
 
       - name: Install dependencies
         run: npm ci
@@ -487,7 +487,7 @@ jobs:
       - name: Setup Node.js for publishing
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Create GitHub Release
@@ -521,12 +521,11 @@ jobs:
           npx tsc --version
           npx tsc --listFiles
 
-          echo "Publishing to NPM with provenance and SBOM metadata"
-          npm publish --provenance
+          echo "Publishing to NPM with provenance (using OIDC Trusted Publisher)"
+          npm publish --provenance --access public
 
           echo "NPM publish complete"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # No NODE_AUTH_TOKEN needed - using npm Trusted Publishers (OIDC)
 
       - name: Release complete
         run: |


### PR DESCRIPTION
- Upgrade Node.js from 18 to 24 for npm 11.5+ OIDC support
- Remove NODE_AUTH_TOKEN secret from publish step
- Use OIDC-based authentication for npm publishing
- Add --access public flag for explicit public package publishing

This eliminates the need for long-lived npm tokens and improves supply chain security by using short-lived, workflow-specific OIDC credentials.