### PR TITLE
feat(upload): add multipart upload support for large files up to 5GB

### DIFF
--- a/cli/encryptionUtils.ts
+++ b/cli/encryptionUtils.ts
@@ -454,3 +454,210 @@ async function decryptV2Content(encryptedData: EncryptedDataV2): Promise<Decrypt
     senderInfo: metadata.recipient
   };
 }
+
+// ============================================
+// Version 4: Streaming Encryption for Large Files
+// ============================================
+
+import type { EncryptedFileHeader, EncryptedChunkHeader } from '../src/types/index.js';
+
+/**
+ * Version 4 encrypted file structure.
+ * Designed for streaming encryption of large files.
+ */
+interface EncryptedDataV4 {
+  version: 4;
+  header: EncryptedFileHeader;
+  // Chunks are stored separately, not in this structure
+}
+
+/**
+ * Chunk header size: 16 (IV) + 16 (authTag) + 4 (length) = 36 bytes
+ */
+const CHUNK_HEADER_SIZE = 36;
+
+/**
+ * Create an encrypted file header for streaming encryption.
+ * This should be stored as the first part of a multipart upload.
+ */
+export async function createEncryptedHeader(
+  recipientName: string,
+  totalChunks: number,
+  originalSize: number,
+  chunkSize: number,
+  filename?: string,
+): Promise<{ header: EncryptedFileHeader; symmetricKey: Buffer }> {
+  // Get recipient's public key
+  const keyInfo = await getKey(recipientName);
+  if (!keyInfo || !keyInfo.public) {
+    throw new Error(`No public key found for recipient: ${recipientName}`);
+  }
+
+  const publicKey = await fsPromises.readFile(keyInfo.public, 'utf8');
+
+  // Generate a random symmetric key
+  const symmetricKey = crypto.randomBytes(32);
+
+  // Encrypt the symmetric key with the recipient's public key
+  const encryptedKey = crypto.publicEncrypt(
+    {
+      key: publicKey,
+      padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+      oaepHash: 'sha256',
+    },
+    symmetricKey,
+  );
+
+  const recipientInfo: RecipientInfo = {
+    type: keyInfo.type as any,
+    name: recipientName,
+    fingerprint: keyInfo.fingerprint,
+    username: keyInfo.username,
+    email: keyInfo.email,
+  };
+
+  const header: EncryptedFileHeader = {
+    version: 4,
+    metadata: {
+      sender: 'self',
+      recipient: recipientInfo,
+      timestamp: new Date().toISOString(),
+      totalChunks,
+      originalSize,
+      chunkSize,
+      filename,
+    },
+    encryptedKey: encryptedKey.toString('base64'),
+  };
+
+  await updateLastUsed(recipientName);
+
+  return { header, symmetricKey };
+}
+
+/**
+ * Encrypt a single chunk using the symmetric key.
+ * Returns the chunk with prepended header (IV + authTag + length + encrypted data).
+ */
+export function encryptChunk(
+  chunk: Buffer,
+  symmetricKey: Buffer,
+): Buffer {
+  // Generate unique IV for this chunk
+  const iv = crypto.randomBytes(16);
+
+  // Encrypt the chunk
+  const cipher = crypto.createCipheriv('aes-256-gcm', symmetricKey, iv);
+  let encrypted = cipher.update(chunk);
+  encrypted = Buffer.concat([encrypted, cipher.final()]);
+  const authTag = cipher.getAuthTag();
+
+  // Create header: IV (16) + authTag (16) + length (4)
+  const header = Buffer.alloc(CHUNK_HEADER_SIZE);
+  iv.copy(header, 0);
+  authTag.copy(header, 16);
+  header.writeUInt32BE(encrypted.length, 32);
+
+  // Combine header and encrypted data
+  return Buffer.concat([header, encrypted]);
+}
+
+/**
+ * Decrypt a single chunk using the symmetric key.
+ * Expects chunk format: [16-byte IV][16-byte authTag][4-byte length][encrypted data]
+ */
+export function decryptChunk(
+  encryptedChunk: Buffer,
+  symmetricKey: Buffer,
+): Buffer {
+  if (encryptedChunk.length < CHUNK_HEADER_SIZE) {
+    throw new Error('Invalid encrypted chunk: too short for header');
+  }
+
+  // Extract header components
+  const iv = encryptedChunk.subarray(0, 16);
+  const authTag = encryptedChunk.subarray(16, 32);
+  const encryptedLength = encryptedChunk.readUInt32BE(32);
+  const encryptedData = encryptedChunk.subarray(CHUNK_HEADER_SIZE, CHUNK_HEADER_SIZE + encryptedLength);
+
+  if (encryptedData.length !== encryptedLength) {
+    throw new Error(`Invalid encrypted chunk: expected ${encryptedLength} bytes, got ${encryptedData.length}`);
+  }
+
+  // Decrypt
+  const decipher = crypto.createDecipheriv('aes-256-gcm', symmetricKey, iv);
+  decipher.setAuthTag(authTag);
+  let decrypted = decipher.update(encryptedData);
+  decrypted = Buffer.concat([decrypted, decipher.final()]);
+
+  return decrypted;
+}
+
+/**
+ * Parse an encrypted file header from JSON.
+ */
+export function parseEncryptedHeader(headerJson: string): EncryptedFileHeader {
+  const parsed = JSON.parse(headerJson);
+  if (parsed.version !== 4) {
+    throw new Error(`Unsupported encryption version: ${parsed.version}`);
+  }
+  return parsed as EncryptedFileHeader;
+}
+
+/**
+ * Decrypt the symmetric key from an encrypted file header.
+ */
+export async function decryptSymmetricKey(
+  header: EncryptedFileHeader,
+  privateKeyPath?: string,
+): Promise<Buffer> {
+  // Get private key
+  let privateKey: string;
+
+  if (privateKeyPath) {
+    privateKey = await fsPromises.readFile(privateKeyPath, 'utf8');
+  } else {
+    // Try to get self key
+    const selfKey = await getKey('self');
+    if (!selfKey) {
+      throw new Error('No private key available for decryption');
+    }
+    const keyPath = typeof selfKey.path === 'string' ? selfKey.path : selfKey.path.private;
+    privateKey = await fsPromises.readFile(keyPath, 'utf8');
+  }
+
+  // Decrypt the symmetric key
+  const encryptedKey = Buffer.from(header.encryptedKey, 'base64');
+  const symmetricKey = crypto.privateDecrypt(
+    {
+      key: privateKey,
+      padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+      oaepHash: 'sha256',
+    },
+    encryptedKey,
+  );
+
+  return symmetricKey;
+}
+
+/**
+ * Check if encrypted data is version 4 (streaming format).
+ */
+export function isStreamingEncryption(data: Buffer | string): boolean {
+  try {
+    const str = typeof data === 'string' ? data : data.toString('utf8');
+    const parsed = JSON.parse(str);
+    return parsed.version === 4;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Calculate the encrypted size of a chunk (for planning purposes).
+ * Encryption adds: 16 (IV) + 16 (authTag) + 4 (length) + padding overhead
+ * AES-GCM doesn't add padding, so encrypted size = original size + header
+ */
+export function calculateEncryptedChunkSize(plainChunkSize: number): number {
+  return CHUNK_HEADER_SIZE + plainChunkSize;
+}

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -45,6 +45,20 @@ try {
 // Import analytics
 import { analytics } from './analytics.js';
 
+// Import large file upload modules
+import {
+  shouldUseMultipart,
+  uploadLargeFile,
+  resumeUpload,
+  abortUpload,
+} from './largeFileUpload.js';
+import { LARGE_FILE_CONSTANTS } from '../src/types/index.js';
+import {
+  listResumeStates,
+  formatResumeState,
+  cleanupResumeStates,
+} from './resumeState.js';
+
 // Import our core modules
 import {
   generateKeyPair,
@@ -157,6 +171,12 @@ interface SendOptions {
   pgpKeyFile?: string;
   pgpArmor?: boolean;
   refreshGithubKeys?: boolean;
+  // Large file upload options
+  chunkSize?: string;
+  resume?: string;
+  progress?: boolean;  // --no-progress sets this to false
+  listUploads?: boolean;
+  abortUpload?: string;
 }
 
 interface GetOptions {
@@ -1105,6 +1125,12 @@ program
   .option('--enhanced', 'Use enhanced interactive mode with advanced key selection features')
   .option('--debug', 'Debug mode: show encrypted content without uploading')
   .option('-c, --copy', 'Copy the URL to clipboard automatically')
+  // Large file options
+  .option('--chunk-size <mb>', 'Chunk size in MB for large file uploads (default: 10, min: 5)')
+  .option('--resume <file>', 'Resume an interrupted upload from a saved state file')
+  .option('--no-progress', 'Disable progress bar for large file uploads')
+  .option('--list-uploads', 'List interrupted uploads that can be resumed')
+  .option('--abort-upload <sessionId>', 'Abort an interrupted upload by session ID')
   // PGP options
   .option('--pgp', 'Use PGP encryption instead of hybrid RSA/AES')
   .option('--pgp-key-file <path>', 'Use a specific PGP public key file for encryption')
@@ -1156,17 +1182,85 @@ Encryption:
       if (options.listFriends) {
         const db = await listKeys();
         const friendNames = Object.keys(db.keys.friends);
-        
+
         if (friendNames.length === 0) {
           console.log('No friend keys found. Add one with "dedpaste keys add-friend"');
           return;
         }
-        
+
         console.log('\nAvailable friends:');
         for (const name of friendNames) {
           const friend = db.keys.friends[name];
           const lastUsed = friend.lastUsed ? new Date(friend.lastUsed).toLocaleString() : 'Never';
           console.log(`  - ${name} (last used: ${lastUsed})`);
+        }
+        return;
+      }
+
+      // ============================================
+      // Large File Upload Handlers
+      // ============================================
+
+      // List interrupted uploads
+      if (options.listUploads) {
+        const states = await listResumeStates();
+        if (states.length === 0) {
+          console.log('No interrupted uploads found.');
+        } else {
+          console.log(`Found ${states.length} interrupted upload(s):\n`);
+          for (const state of states) {
+            console.log(formatResumeState(state));
+            console.log('---');
+          }
+          console.log('\nTo resume: dedpaste send --resume <session-id-or-path>');
+          console.log('To abort:  dedpaste send --abort-upload <session-id>');
+        }
+        return;
+      }
+
+      // Abort an interrupted upload
+      if (options.abortUpload) {
+        try {
+          await abortUpload(options.abortUpload);
+          console.log('Upload aborted successfully.');
+        } catch (error: any) {
+          console.error(`Failed to abort upload: ${error.message}`);
+          process.exit(1);
+        }
+        return;
+      }
+
+      // Resume an interrupted upload
+      if (options.resume) {
+        try {
+          console.log('Resuming interrupted upload...');
+          const url = await resumeUpload(options.resume, {
+            showProgress: options.progress !== false,
+          });
+
+          // Handle clipboard and output
+          if (options.copy) {
+            try {
+              const cleanUrl = url.trim();
+              if (clipboard.default) {
+                clipboard.default.writeSync(cleanUrl);
+              } else {
+                clipboard.writeSync(cleanUrl);
+              }
+            } catch (error: any) {
+              console.error(`Unable to copy to clipboard: ${error.message}`);
+            }
+          }
+
+          if (options.output) {
+            console.log(url.trim());
+          } else {
+            console.log(`\n✓ Upload resumed and completed!\n${options.copy ? '📋 URL copied to clipboard: ' : '📋 '} ${url.trim()}\n`);
+          }
+          process.exit(0);
+        } catch (error: any) {
+          console.error(`Failed to resume upload: ${error.message}`);
+          process.exit(1);
         }
         return;
       }
@@ -1345,40 +1439,88 @@ Encryption:
       try {
         // Extract filename if uploading a file
         const filename = options.file ? path.basename(options.file) : '';
+        let url: string;
 
-        const headers: Record<string, string> = {
-          'Content-Type': contentType,
-          'User-Agent': `dedpaste-cli/${packageJson.version}`
-        };
+        // Check if we should use multipart upload for large files
+        // Only use multipart for file uploads (not stdin) and files over threshold
+        const useMultipart = options.file &&
+          !shouldEncrypt && // Encrypted large files not yet supported in multipart
+          shouldUseMultipart(options.file);
 
-        // Include filename header if we have a file
-        if (filename) {
-          headers['X-Filename'] = filename;
+        if (useMultipart) {
+          // Large file - use multipart upload
+          console.log(`Large file detected (>${LARGE_FILE_CONSTANTS.MULTIPART_THRESHOLD / (1024 * 1024)}MB). Using multipart upload...`);
+
+          // Parse chunk size if provided
+          let chunkSize: number | undefined;
+          if (options.chunkSize) {
+            const chunkMb = parseInt(options.chunkSize, 10);
+            if (isNaN(chunkMb) || chunkMb < 5) {
+              console.error('Error: Chunk size must be at least 5 MB');
+              process.exit(1);
+            }
+            chunkSize = chunkMb * 1024 * 1024;
+          }
+
+          try {
+            url = await uploadLargeFile(options.file!, {
+              apiUrl: API_URL,
+              chunkSize,
+              isOneTime: options.temp,
+              isEncrypted: false, // Encryption handled separately
+              showProgress: options.progress !== false,
+            });
+          } catch (uploadError: any) {
+            console.error(`Large file upload failed: ${uploadError.message}`);
+            console.error('You can resume the upload later with: dedpaste send --resume <session-id>');
+            console.error('To see interrupted uploads: dedpaste send --list-uploads');
+            process.exit(1);
+          }
+
+          // Track paste creation for large files
+          analytics.trackPasteCreated({
+            type: options.temp ? 'one_time' : 'regular',
+            content_type: contentType,
+            size_bytes: fs.statSync(options.file!).size,
+            encryption_type: 'none',
+            method: 'file'  // Use 'file' as the method type
+          });
+        } else {
+          // Standard upload (small files or stdin)
+          const headers: Record<string, string> = {
+            'Content-Type': contentType,
+            'User-Agent': `dedpaste-cli/${packageJson.version}`
+          };
+
+          // Include filename header if we have a file
+          if (filename) {
+            headers['X-Filename'] = filename;
+          }
+
+          const response = await fetch(`${API_URL}${endpoint}`, {
+            method: 'POST',
+            headers,
+            body: content
+          });
+
+          if (!response.ok) {
+            console.error(`Error: ${response.status} ${response.statusText}`);
+            const errorText = await response.text();
+            console.error(errorText);
+            process.exit(1);
+          }
+
+          url = await response.text();
+
+          // Track paste creation
+          analytics.trackPasteCreated({
+            type: options.temp ? 'one_time' : 'regular',
+            content_type: contentType,
+            size_bytes: content.length,
+            encryption_type: options.encrypt ? 'RSA' : 'none',
+            method: options.file ? 'file' : 'stdin'
+          });
         }
-
-        const response = await fetch(`${API_URL}${endpoint}`, {
-          method: 'POST',
-          headers,
-          body: content
-        });
-        
-        if (!response.ok) {
-          console.error(`Error: ${response.status} ${response.statusText}`);
-          const errorText = await response.text();
-          console.error(errorText);
-          process.exit(1);
-        }
-        
-        const url = await response.text();
-
-        // Track paste creation
-        analytics.trackPasteCreated({
-          type: options.temp ? 'one_time' : 'regular',
-          content_type: contentType,
-          size_bytes: content.length,
-          encryption_type: options.encrypt ? 'RSA' : 'none',
-          method: options.file ? 'file' : 'stdin'
-        });
 
         // Copy to clipboard if requested
         if (options.copy) {
@@ -1393,7 +1535,7 @@ Encryption:
             console.error(`Unable to copy to clipboard: ${error.message}`);
           }
         }
-        
+
         // Output the result
         if (options.output) {
           console.log(url.trim());
@@ -1406,9 +1548,10 @@ Encryption:
               encryptionMessage = '🔒 This paste is encrypted and can only be decrypted with your private key\n';
             }
           }
-          
+
+          const isLargeFile = useMultipart;
           console.log(`
-✓ Paste created successfully!
+✓ Paste created successfully!${isLargeFile ? ' (multipart upload)' : ''}
 ${options.temp ? '⚠️  This is a one-time paste that will be deleted after first view\n' : ''}
 ${encryptionMessage}
 ${options.copy ? '📋 URL copied to clipboard: ' : '📋 '} ${url.trim()}

--- a/cli/largeFileUpload.ts
+++ b/cli/largeFileUpload.ts
@@ -1,0 +1,584 @@
+/**
+ * Large file upload module with multipart support.
+ * Handles streaming uploads with progress, resume, and parallel chunk uploads.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { lookup } from "mime-types";
+import { Readable } from "stream";
+import type {
+  LargeUploadOptions,
+  UploadProgress,
+  MultipartInitResponse,
+  PartUploadResponse,
+  MultipartCompleteResponse,
+  UploadStatusResponse,
+  ResumeState,
+} from "../src/types/index.js";
+import { LARGE_FILE_CONSTANTS } from "../src/types/index.js";
+import { ProgressBar, createProgressCallback } from "./progressDisplay.js";
+import {
+  createResumeState,
+  saveResumeState,
+  loadResumeState,
+  deleteResumeState,
+  updateResumeStatePart,
+  verifyResumeState,
+  verifyServerSession,
+  registerInterruptHandler,
+  getResumeFilePath,
+} from "./resumeState.js";
+
+/**
+ * Check if a file should use multipart upload based on size.
+ */
+export function shouldUseMultipart(filePath: string): boolean {
+  const stats = fs.statSync(filePath);
+  return stats.size > LARGE_FILE_CONSTANTS.MULTIPART_THRESHOLD;
+}
+
+/**
+ * Calculate optimal chunk size based on file size.
+ * Aims for reasonable number of parts (100-500) while respecting limits.
+ */
+export function calculateChunkSize(totalSize: number): number {
+  // Target around 200 parts for optimal parallelism and progress granularity
+  const targetParts = 200;
+  let chunkSize = Math.ceil(totalSize / targetParts);
+
+  // Enforce minimum and maximum chunk sizes
+  chunkSize = Math.max(chunkSize, LARGE_FILE_CONSTANTS.MIN_CHUNK_SIZE);
+  chunkSize = Math.min(chunkSize, LARGE_FILE_CONSTANTS.MAX_CHUNK_SIZE);
+
+  // Round to nearest MB for cleaner numbers
+  const MB = 1024 * 1024;
+  chunkSize = Math.ceil(chunkSize / MB) * MB;
+
+  return chunkSize;
+}
+
+/**
+ * Calculate total number of parts for a file.
+ */
+export function calculateTotalParts(totalSize: number, chunkSize: number): number {
+  return Math.ceil(totalSize / chunkSize);
+}
+
+/**
+ * Upload a large file using multipart upload.
+ */
+export async function uploadLargeFile(
+  filePath: string,
+  options: LargeUploadOptions,
+): Promise<string> {
+  const {
+    apiUrl,
+    chunkSize: customChunkSize,
+    isOneTime = false,
+    isEncrypted = false,
+    showProgress = true,
+    maxConcurrent = LARGE_FILE_CONSTANTS.MAX_CONCURRENT_UPLOADS,
+    onProgress,
+  } = options;
+
+  // Validate file exists
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`File not found: ${filePath}`);
+  }
+
+  const stats = fs.statSync(filePath);
+  const totalSize = stats.size;
+  const filename = path.basename(filePath);
+  const contentType = lookup(filePath) || "application/octet-stream";
+
+  // Validate file size
+  if (totalSize > LARGE_FILE_CONSTANTS.MAX_FILE_SIZE) {
+    throw new Error(
+      `File too large. Maximum size is ${LARGE_FILE_CONSTANTS.MAX_FILE_SIZE / (1024 * 1024 * 1024)}GB`,
+    );
+  }
+
+  // Calculate chunk size
+  const chunkSize = customChunkSize || calculateChunkSize(totalSize);
+  const totalParts = calculateTotalParts(totalSize, chunkSize);
+
+  // Set up progress tracking
+  let progressBar: ProgressBar | undefined;
+  let uploadedBytes = 0;
+
+  if (showProgress) {
+    progressBar = new ProgressBar();
+  }
+
+  const updateProgress = (currentPart: number, partBytes: number = 0) => {
+    const progress: UploadProgress = {
+      totalBytes: totalSize,
+      uploadedBytes: uploadedBytes + partBytes,
+      currentPart,
+      totalParts,
+      speed: 0, // Calculated by progress bar
+      eta: 0, // Calculated by progress bar
+      percent: ((uploadedBytes + partBytes) / totalSize) * 100,
+    };
+
+    if (progressBar) {
+      progressBar.update(progress);
+    }
+    if (onProgress) {
+      onProgress(progress);
+    }
+  };
+
+  // Initialize multipart upload
+  const initEndpoint = isEncrypted
+    ? `${apiUrl}/e/upload/init`
+    : `${apiUrl}/upload/init`;
+
+  const initResponse = await fetch(initEndpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      filename,
+      contentType: isEncrypted ? "application/json" : contentType,
+      totalSize,
+      totalParts,
+      isOneTime,
+      isEncrypted,
+    }),
+  });
+
+  if (!initResponse.ok) {
+    const error = await initResponse.json().catch(() => ({ error: "Unknown error" }));
+    throw new Error(
+      `Failed to initialize upload: ${(error as { error?: string }).error || initResponse.statusText}`,
+    );
+  }
+
+  const { sessionId, pasteId } = (await initResponse.json()) as MultipartInitResponse;
+
+  // Create resume state
+  const resumeState = await createResumeState(sessionId, filePath, {
+    apiUrl,
+    chunkSize,
+    isEncrypted,
+    isOneTime,
+    filename,
+    contentType,
+  });
+
+  // Save initial state
+  await saveResumeState(resumeState);
+
+  // Register interrupt handler
+  const removeHandler = registerInterruptHandler(resumeState);
+
+  try {
+    // Upload parts with concurrency control
+    const uploadedParts: Array<{ partNumber: number; etag: string }> = [];
+    const partQueue: number[] = [];
+
+    // Build queue of parts to upload
+    for (let i = 1; i <= totalParts; i++) {
+      partQueue.push(i);
+    }
+
+    // Process queue with concurrency limit
+    const activeUploads: Map<number, Promise<void>> = new Map();
+
+    const uploadPart = async (partNumber: number): Promise<void> => {
+      const start = (partNumber - 1) * chunkSize;
+      const end = Math.min(start + chunkSize, totalSize);
+      const partSize = end - start;
+
+      // Read chunk from file
+      const buffer = Buffer.alloc(partSize);
+      const fd = fs.openSync(filePath, "r");
+      try {
+        fs.readSync(fd, buffer, 0, partSize, start);
+      } finally {
+        fs.closeSync(fd);
+      }
+
+      // Upload with retry
+      let lastError: Error | undefined;
+      for (
+        let attempt = 0;
+        attempt <= LARGE_FILE_CONSTANTS.RETRY.MAX_RETRIES;
+        attempt++
+      ) {
+        try {
+          const partEndpoint = isEncrypted
+            ? `${apiUrl}/e/upload/${sessionId}/part/${partNumber}`
+            : `${apiUrl}/upload/${sessionId}/part/${partNumber}`;
+
+          const response = await fetch(partEndpoint, {
+            method: "PUT",
+            headers: {
+              "Content-Type": "application/octet-stream",
+              "Content-Length": String(partSize),
+            },
+            body: buffer,
+          });
+
+          if (!response.ok) {
+            const error = await response.json().catch(() => ({ error: "Unknown error" }));
+            throw new Error(
+              (error as { error?: string }).error || `HTTP ${response.status}`,
+            );
+          }
+
+          const { etag } = (await response.json()) as PartUploadResponse;
+
+          // Update state
+          uploadedParts.push({ partNumber, etag });
+          await updateResumeStatePart(resumeState, partNumber, etag);
+          uploadedBytes += partSize;
+          updateProgress(partNumber);
+
+          return;
+        } catch (error) {
+          lastError = error instanceof Error ? error : new Error(String(error));
+
+          if (attempt < LARGE_FILE_CONSTANTS.RETRY.MAX_RETRIES) {
+            const delay = Math.min(
+              LARGE_FILE_CONSTANTS.RETRY.BASE_DELAY_MS *
+                Math.pow(LARGE_FILE_CONSTANTS.RETRY.BACKOFF_MULTIPLIER, attempt),
+              LARGE_FILE_CONSTANTS.RETRY.MAX_DELAY_MS,
+            );
+            await new Promise((resolve) => setTimeout(resolve, delay));
+          }
+        }
+      }
+
+      throw new Error(`Failed to upload part ${partNumber}: ${lastError?.message}`);
+    };
+
+    // Process queue
+    while (partQueue.length > 0 || activeUploads.size > 0) {
+      // Start new uploads up to concurrency limit
+      while (partQueue.length > 0 && activeUploads.size < maxConcurrent) {
+        const partNumber = partQueue.shift()!;
+        const promise = uploadPart(partNumber).finally(() => {
+          activeUploads.delete(partNumber);
+        });
+        activeUploads.set(partNumber, promise);
+      }
+
+      // Wait for at least one upload to complete
+      if (activeUploads.size > 0) {
+        await Promise.race(activeUploads.values());
+      }
+    }
+
+    // Sort parts by number
+    uploadedParts.sort((a, b) => a.partNumber - b.partNumber);
+
+    // Complete the upload
+    const completeEndpoint = isEncrypted
+      ? `${apiUrl}/e/upload/${sessionId}/complete`
+      : `${apiUrl}/upload/${sessionId}/complete`;
+
+    const completeResponse = await fetch(completeEndpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ parts: uploadedParts }),
+    });
+
+    if (!completeResponse.ok) {
+      const error = await completeResponse.json().catch(() => ({ error: "Unknown error" }));
+      throw new Error(
+        `Failed to complete upload: ${(error as { error?: string }).error || completeResponse.statusText}`,
+      );
+    }
+
+    const { url } = (await completeResponse.json()) as MultipartCompleteResponse;
+
+    // Clean up
+    removeHandler();
+    await deleteResumeState(sessionId);
+
+    if (progressBar) {
+      progressBar.complete(totalSize);
+    }
+
+    return url;
+  } catch (error) {
+    removeHandler();
+    if (progressBar) {
+      progressBar.fail(error instanceof Error ? error.message : "Upload failed");
+    }
+    throw error;
+  }
+}
+
+/**
+ * Resume an interrupted upload.
+ */
+export async function resumeUpload(
+  resumeFileOrId: string,
+  options: Partial<LargeUploadOptions> = {},
+): Promise<string> {
+  // Load resume state
+  const resumeState = await loadResumeState(resumeFileOrId);
+  if (!resumeState) {
+    throw new Error(`Resume state not found: ${resumeFileOrId}`);
+  }
+
+  // Verify file hasn't changed
+  const fileCheck = await verifyResumeState(resumeState);
+  if (!fileCheck.valid) {
+    throw new Error(`Cannot resume: ${fileCheck.error}`);
+  }
+
+  // Verify server session is still valid
+  const serverCheck = await verifyServerSession(resumeState);
+  if (!serverCheck.valid) {
+    throw new Error(`Cannot resume: ${serverCheck.error}`);
+  }
+
+  const {
+    showProgress = true,
+    maxConcurrent = LARGE_FILE_CONSTANTS.MAX_CONCURRENT_UPLOADS,
+    onProgress,
+  } = options;
+
+  const { sessionId, filePath, chunkSize, totalSize, isEncrypted, apiUrl } =
+    resumeState;
+
+  const totalParts = calculateTotalParts(totalSize, chunkSize);
+
+  // Calculate already uploaded bytes
+  let uploadedBytes = resumeState.uploadedParts.length * chunkSize;
+  // Adjust for last part potentially being smaller
+  const lastUploadedPart = Math.max(
+    ...resumeState.uploadedParts.map((p) => p.partNumber),
+    0,
+  );
+  if (lastUploadedPart === totalParts) {
+    const lastPartSize = totalSize - (totalParts - 1) * chunkSize;
+    uploadedBytes = (totalParts - 1) * chunkSize + lastPartSize;
+  }
+
+  // Set up progress tracking
+  let progressBar: ProgressBar | undefined;
+
+  if (showProgress) {
+    progressBar = new ProgressBar();
+    console.log(
+      `Resuming upload: ${resumeState.uploadedParts.length}/${totalParts} parts already uploaded`,
+    );
+  }
+
+  const updateProgress = (currentPart: number, partBytes: number = 0) => {
+    const progress: UploadProgress = {
+      totalBytes: totalSize,
+      uploadedBytes: uploadedBytes + partBytes,
+      currentPart,
+      totalParts,
+      speed: 0,
+      eta: 0,
+      percent: ((uploadedBytes + partBytes) / totalSize) * 100,
+    };
+
+    if (progressBar) {
+      progressBar.update(progress);
+    }
+    if (onProgress) {
+      onProgress(progress);
+    }
+  };
+
+  // Register interrupt handler
+  const removeHandler = registerInterruptHandler(resumeState);
+
+  try {
+    // Build queue of parts that still need to be uploaded
+    const uploadedPartNumbers = new Set(
+      resumeState.uploadedParts.map((p) => p.partNumber),
+    );
+    const partQueue: number[] = [];
+
+    for (let i = 1; i <= totalParts; i++) {
+      if (!uploadedPartNumbers.has(i)) {
+        partQueue.push(i);
+      }
+    }
+
+    // Upload remaining parts
+    const activeUploads: Map<number, Promise<void>> = new Map();
+
+    const uploadPart = async (partNumber: number): Promise<void> => {
+      const start = (partNumber - 1) * chunkSize;
+      const end = Math.min(start + chunkSize, totalSize);
+      const partSize = end - start;
+
+      // Read chunk from file
+      const buffer = Buffer.alloc(partSize);
+      const fd = fs.openSync(filePath, "r");
+      try {
+        fs.readSync(fd, buffer, 0, partSize, start);
+      } finally {
+        fs.closeSync(fd);
+      }
+
+      // Upload with retry
+      let lastError: Error | undefined;
+      for (
+        let attempt = 0;
+        attempt <= LARGE_FILE_CONSTANTS.RETRY.MAX_RETRIES;
+        attempt++
+      ) {
+        try {
+          const partEndpoint = isEncrypted
+            ? `${apiUrl}/e/upload/${sessionId}/part/${partNumber}`
+            : `${apiUrl}/upload/${sessionId}/part/${partNumber}`;
+
+          const response = await fetch(partEndpoint, {
+            method: "PUT",
+            headers: {
+              "Content-Type": "application/octet-stream",
+              "Content-Length": String(partSize),
+            },
+            body: buffer,
+          });
+
+          if (!response.ok) {
+            const error = await response.json().catch(() => ({ error: "Unknown error" }));
+            throw new Error(
+              (error as { error?: string }).error || `HTTP ${response.status}`,
+            );
+          }
+
+          const { etag } = (await response.json()) as PartUploadResponse;
+
+          // Update state
+          await updateResumeStatePart(resumeState, partNumber, etag);
+          uploadedBytes += partSize;
+          updateProgress(partNumber);
+
+          return;
+        } catch (error) {
+          lastError = error instanceof Error ? error : new Error(String(error));
+
+          if (attempt < LARGE_FILE_CONSTANTS.RETRY.MAX_RETRIES) {
+            const delay = Math.min(
+              LARGE_FILE_CONSTANTS.RETRY.BASE_DELAY_MS *
+                Math.pow(LARGE_FILE_CONSTANTS.RETRY.BACKOFF_MULTIPLIER, attempt),
+              LARGE_FILE_CONSTANTS.RETRY.MAX_DELAY_MS,
+            );
+            await new Promise((resolve) => setTimeout(resolve, delay));
+          }
+        }
+      }
+
+      throw new Error(`Failed to upload part ${partNumber}: ${lastError?.message}`);
+    };
+
+    // Process queue
+    while (partQueue.length > 0 || activeUploads.size > 0) {
+      while (partQueue.length > 0 && activeUploads.size < maxConcurrent) {
+        const partNumber = partQueue.shift()!;
+        const promise = uploadPart(partNumber).finally(() => {
+          activeUploads.delete(partNumber);
+        });
+        activeUploads.set(partNumber, promise);
+      }
+
+      if (activeUploads.size > 0) {
+        await Promise.race(activeUploads.values());
+      }
+    }
+
+    // Build complete parts list
+    const allParts = resumeState.uploadedParts
+      .map((p) => ({ partNumber: p.partNumber, etag: p.etag }))
+      .sort((a, b) => a.partNumber - b.partNumber);
+
+    // Complete the upload
+    const completeEndpoint = isEncrypted
+      ? `${apiUrl}/e/upload/${sessionId}/complete`
+      : `${apiUrl}/upload/${sessionId}/complete`;
+
+    const completeResponse = await fetch(completeEndpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ parts: allParts }),
+    });
+
+    if (!completeResponse.ok) {
+      const error = await completeResponse.json().catch(() => ({ error: "Unknown error" }));
+      throw new Error(
+        `Failed to complete upload: ${(error as { error?: string }).error || completeResponse.statusText}`,
+      );
+    }
+
+    const { url } = (await completeResponse.json()) as MultipartCompleteResponse;
+
+    // Clean up
+    removeHandler();
+    await deleteResumeState(sessionId);
+
+    if (progressBar) {
+      progressBar.complete(totalSize);
+    }
+
+    return url;
+  } catch (error) {
+    removeHandler();
+    if (progressBar) {
+      progressBar.fail(error instanceof Error ? error.message : "Upload failed");
+    }
+    throw error;
+  }
+}
+
+/**
+ * Abort an in-progress upload.
+ */
+export async function abortUpload(
+  resumeFileOrId: string,
+): Promise<void> {
+  const resumeState = await loadResumeState(resumeFileOrId);
+  if (!resumeState) {
+    console.log("Resume state not found - may already be cleaned up");
+    return;
+  }
+
+  try {
+    const abortEndpoint = resumeState.isEncrypted
+      ? `${resumeState.apiUrl}/e/upload/${resumeState.sessionId}/abort`
+      : `${resumeState.apiUrl}/upload/${resumeState.sessionId}/abort`;
+
+    await fetch(abortEndpoint, { method: "POST" });
+  } catch (error) {
+    // Ignore abort errors
+  }
+
+  await deleteResumeState(resumeState.sessionId);
+  console.log("Upload aborted and cleaned up");
+}
+
+/**
+ * Get upload status from server.
+ */
+export async function getUploadStatus(
+  apiUrl: string,
+  sessionId: string,
+  isEncrypted: boolean = false,
+): Promise<UploadStatusResponse> {
+  const statusEndpoint = isEncrypted
+    ? `${apiUrl}/e/upload/${sessionId}/status`
+    : `${apiUrl}/upload/${sessionId}/status`;
+
+  const response = await fetch(statusEndpoint);
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: "Unknown error" }));
+    throw new Error(
+      (error as { error?: string }).error || `HTTP ${response.status}`,
+    );
+  }
+
+  return (await response.json()) as UploadStatusResponse;
+}

--- a/cli/progressDisplay.ts
+++ b/cli/progressDisplay.ts
@@ -1,0 +1,255 @@
+/**
+ * Progress display module for large file uploads.
+ * Provides a visual progress bar with speed and ETA calculations.
+ */
+
+import type { UploadProgress } from "../src/types/index.js";
+
+/**
+ * Format bytes to human-readable string.
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const k = 1024;
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  const value = bytes / Math.pow(k, i);
+  return `${value.toFixed(i > 0 ? 1 : 0)} ${units[i]}`;
+}
+
+/**
+ * Format seconds to human-readable time string.
+ */
+export function formatTime(seconds: number): string {
+  if (!isFinite(seconds) || seconds < 0) return "--:--";
+  if (seconds < 60) return `${Math.ceil(seconds)}s`;
+  if (seconds < 3600) {
+    const mins = Math.floor(seconds / 60);
+    const secs = Math.ceil(seconds % 60);
+    return `${mins}m ${secs}s`;
+  }
+  const hours = Math.floor(seconds / 3600);
+  const mins = Math.floor((seconds % 3600) / 60);
+  return `${hours}h ${mins}m`;
+}
+
+/**
+ * Progress bar configuration.
+ */
+export interface ProgressBarOptions {
+  /** Width of the progress bar in characters (default: 30) */
+  width?: number;
+  /** Character for filled portion (default: █) */
+  filledChar?: string;
+  /** Character for empty portion (default: ░) */
+  emptyChar?: string;
+  /** Whether to show speed (default: true) */
+  showSpeed?: boolean;
+  /** Whether to show ETA (default: true) */
+  showEta?: boolean;
+  /** Whether to show part progress (default: true) */
+  showParts?: boolean;
+  /** Stream to write to (default: process.stderr) */
+  stream?: NodeJS.WriteStream;
+}
+
+/**
+ * Progress bar for upload tracking.
+ */
+export class ProgressBar {
+  private width: number;
+  private filledChar: string;
+  private emptyChar: string;
+  private showSpeed: boolean;
+  private showEta: boolean;
+  private showParts: boolean;
+  private stream: NodeJS.WriteStream;
+  private startTime: number;
+  private lastUpdate: number;
+  private lastBytes: number;
+  private speedSamples: number[] = [];
+  private maxSamples = 10;
+
+  constructor(options: ProgressBarOptions = {}) {
+    this.width = options.width ?? 30;
+    this.filledChar = options.filledChar ?? "█";
+    this.emptyChar = options.emptyChar ?? "░";
+    this.showSpeed = options.showSpeed ?? true;
+    this.showEta = options.showEta ?? true;
+    this.showParts = options.showParts ?? true;
+    this.stream = options.stream ?? process.stderr;
+    this.startTime = Date.now();
+    this.lastUpdate = this.startTime;
+    this.lastBytes = 0;
+  }
+
+  /**
+   * Calculate smoothed upload speed using moving average.
+   */
+  private calculateSpeed(currentBytes: number): number {
+    const now = Date.now();
+    const timeDiff = (now - this.lastUpdate) / 1000;
+
+    if (timeDiff > 0.1) {
+      // Only update every 100ms
+      const bytesDiff = currentBytes - this.lastBytes;
+      const instantSpeed = bytesDiff / timeDiff;
+
+      this.speedSamples.push(instantSpeed);
+      if (this.speedSamples.length > this.maxSamples) {
+        this.speedSamples.shift();
+      }
+
+      this.lastUpdate = now;
+      this.lastBytes = currentBytes;
+    }
+
+    // Return average speed
+    if (this.speedSamples.length === 0) {
+      const elapsed = (now - this.startTime) / 1000;
+      return elapsed > 0 ? currentBytes / elapsed : 0;
+    }
+    return (
+      this.speedSamples.reduce((a, b) => a + b, 0) / this.speedSamples.length
+    );
+  }
+
+  /**
+   * Update the progress display.
+   */
+  update(progress: UploadProgress): void {
+    const { totalBytes, uploadedBytes, currentPart, totalParts } = progress;
+
+    // Calculate percentage
+    const percent = totalBytes > 0 ? (uploadedBytes / totalBytes) * 100 : 0;
+
+    // Calculate speed and ETA
+    const speed = this.calculateSpeed(uploadedBytes);
+    const remainingBytes = totalBytes - uploadedBytes;
+    const eta = speed > 0 ? remainingBytes / speed : Infinity;
+
+    // Build progress bar
+    const filled = Math.round((this.width * percent) / 100);
+    const empty = this.width - filled;
+    const bar =
+      this.filledChar.repeat(filled) + this.emptyChar.repeat(empty);
+
+    // Build status line
+    let status = `\r[${bar}] ${percent.toFixed(1)}%`;
+    status += ` | ${formatBytes(uploadedBytes)}/${formatBytes(totalBytes)}`;
+
+    if (this.showSpeed) {
+      status += ` | ${formatBytes(speed)}/s`;
+    }
+
+    if (this.showEta) {
+      status += ` | ETA: ${formatTime(eta)}`;
+    }
+
+    if (this.showParts) {
+      status += ` | Part ${currentPart}/${totalParts}`;
+    }
+
+    // Pad to overwrite any previous longer line
+    const padding = " ".repeat(Math.max(0, 100 - status.length));
+    this.stream.write(status + padding);
+  }
+
+  /**
+   * Mark progress as complete.
+   */
+  complete(totalBytes: number): void {
+    const elapsed = (Date.now() - this.startTime) / 1000;
+    const avgSpeed = elapsed > 0 ? totalBytes / elapsed : 0;
+
+    // Clear the line and write final message
+    this.stream.write("\r" + " ".repeat(120) + "\r");
+    console.log(
+      `✓ Upload complete: ${formatBytes(totalBytes)} in ${formatTime(elapsed)} (${formatBytes(avgSpeed)}/s average)`,
+    );
+  }
+
+  /**
+   * Mark progress as failed.
+   */
+  fail(error: string): void {
+    this.stream.write("\r" + " ".repeat(120) + "\r");
+    console.error(`✗ Upload failed: ${error}`);
+  }
+
+  /**
+   * Clear the progress line.
+   */
+  clear(): void {
+    this.stream.write("\r" + " ".repeat(120) + "\r");
+  }
+}
+
+/**
+ * Create a progress callback function that updates the progress bar.
+ */
+export function createProgressCallback(
+  options: ProgressBarOptions = {},
+): {
+  callback: (progress: UploadProgress) => void;
+  complete: (totalBytes: number) => void;
+  fail: (error: string) => void;
+  bar: ProgressBar;
+} {
+  const bar = new ProgressBar(options);
+
+  return {
+    callback: (progress: UploadProgress) => bar.update(progress),
+    complete: (totalBytes: number) => bar.complete(totalBytes),
+    fail: (error: string) => bar.fail(error),
+    bar,
+  };
+}
+
+/**
+ * Simple spinner for indeterminate progress.
+ */
+export class Spinner {
+  private frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+  private frameIndex = 0;
+  private interval: NodeJS.Timeout | null = null;
+  private message: string;
+  private stream: NodeJS.WriteStream;
+
+  constructor(message: string, stream: NodeJS.WriteStream = process.stderr) {
+    this.message = message;
+    this.stream = stream;
+  }
+
+  start(): void {
+    this.interval = setInterval(() => {
+      this.stream.write(
+        `\r${this.frames[this.frameIndex]} ${this.message}`,
+      );
+      this.frameIndex = (this.frameIndex + 1) % this.frames.length;
+    }, 80);
+  }
+
+  update(message: string): void {
+    this.message = message;
+  }
+
+  stop(finalMessage?: string): void {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+    this.stream.write("\r" + " ".repeat(80) + "\r");
+    if (finalMessage) {
+      console.log(finalMessage);
+    }
+  }
+
+  succeed(message: string): void {
+    this.stop(`✓ ${message}`);
+  }
+
+  fail(message: string): void {
+    this.stop(`✗ ${message}`);
+  }
+}

--- a/cli/resumeState.ts
+++ b/cli/resumeState.ts
@@ -1,0 +1,342 @@
+/**
+ * Resume state management for interrupted large file uploads.
+ * Persists upload state to disk for resume capability.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import * as crypto from "crypto";
+import * as os from "os";
+import type { ResumeState, UploadStatusResponse } from "../src/types/index.js";
+
+/**
+ * Directory for storing resume state files.
+ */
+const RESUME_DIR = path.join(os.homedir(), ".dedpaste", "uploads");
+
+/**
+ * Ensure the resume directory exists.
+ */
+export function ensureResumeDir(): void {
+  if (!fs.existsSync(RESUME_DIR)) {
+    fs.mkdirSync(RESUME_DIR, { recursive: true, mode: 0o700 });
+  }
+}
+
+/**
+ * Get the path to a resume state file.
+ */
+export function getResumeFilePath(sessionId: string): string {
+  return path.join(RESUME_DIR, `${sessionId}.json`);
+}
+
+/**
+ * Calculate MD5 hash of the first 1MB of a file.
+ * Used to verify file hasn't changed when resuming.
+ */
+export async function hashFileHead(filePath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = crypto.createHash("md5");
+    const stream = fs.createReadStream(filePath, {
+      start: 0,
+      end: 1024 * 1024 - 1, // First 1MB
+    });
+
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("end", () => resolve(hash.digest("hex")));
+    stream.on("error", reject);
+  });
+}
+
+/**
+ * Save resume state to disk.
+ */
+export async function saveResumeState(state: ResumeState): Promise<string> {
+  ensureResumeDir();
+
+  const filePath = getResumeFilePath(state.sessionId);
+  state.lastUpdatedAt = Date.now();
+
+  await fs.promises.writeFile(filePath, JSON.stringify(state, null, 2), {
+    mode: 0o600,
+  });
+
+  return filePath;
+}
+
+/**
+ * Load resume state from disk.
+ */
+export async function loadResumeState(
+  sessionIdOrPath: string,
+): Promise<ResumeState | null> {
+  let filePath: string;
+
+  // Check if it's a path or session ID
+  if (
+    sessionIdOrPath.includes(path.sep) ||
+    sessionIdOrPath.endsWith(".json")
+  ) {
+    filePath = sessionIdOrPath;
+  } else {
+    filePath = getResumeFilePath(sessionIdOrPath);
+  }
+
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+
+  try {
+    const content = await fs.promises.readFile(filePath, "utf-8");
+    return JSON.parse(content) as ResumeState;
+  } catch (error) {
+    console.error(`Failed to load resume state from ${filePath}:`, error);
+    return null;
+  }
+}
+
+/**
+ * Delete resume state file.
+ */
+export async function deleteResumeState(sessionId: string): Promise<void> {
+  const filePath = getResumeFilePath(sessionId);
+  if (fs.existsSync(filePath)) {
+    await fs.promises.unlink(filePath);
+  }
+}
+
+/**
+ * List all resume state files.
+ */
+export async function listResumeStates(): Promise<ResumeState[]> {
+  ensureResumeDir();
+
+  const files = await fs.promises.readdir(RESUME_DIR);
+  const states: ResumeState[] = [];
+
+  for (const file of files) {
+    if (file.endsWith(".json")) {
+      const state = await loadResumeState(path.join(RESUME_DIR, file));
+      if (state) {
+        states.push(state);
+      }
+    }
+  }
+
+  return states;
+}
+
+/**
+ * Clean up expired or completed resume states.
+ */
+export async function cleanupResumeStates(maxAgeMs: number): Promise<number> {
+  const states = await listResumeStates();
+  let cleaned = 0;
+  const now = Date.now();
+
+  for (const state of states) {
+    const age = now - state.createdAt;
+    if (age > maxAgeMs) {
+      await deleteResumeState(state.sessionId);
+      cleaned++;
+    }
+  }
+
+  return cleaned;
+}
+
+/**
+ * Verify a resume state is valid for the given file.
+ * Checks that the file exists and hasn't changed.
+ */
+export async function verifyResumeState(
+  state: ResumeState,
+): Promise<{ valid: boolean; error?: string }> {
+  // Check file exists
+  if (!fs.existsSync(state.filePath)) {
+    return { valid: false, error: "File not found" };
+  }
+
+  // Check file size matches
+  const stats = fs.statSync(state.filePath);
+  if (stats.size !== state.totalSize) {
+    return {
+      valid: false,
+      error: `File size changed (expected ${state.totalSize}, got ${stats.size})`,
+    };
+  }
+
+  // Check file hash
+  const currentHash = await hashFileHead(state.filePath);
+  if (currentHash !== state.fileHash) {
+    return { valid: false, error: "File content has changed" };
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Verify session is still valid on the server.
+ */
+export async function verifyServerSession(
+  state: ResumeState,
+): Promise<{ valid: boolean; serverState?: UploadStatusResponse; error?: string }> {
+  try {
+    const response = await fetch(
+      `${state.apiUrl}/upload/${state.sessionId}/status`,
+    );
+
+    if (!response.ok) {
+      const body = await response.json().catch(() => ({}));
+      return {
+        valid: false,
+        error: (body as { error?: string }).error || `Server returned ${response.status}`,
+      };
+    }
+
+    const serverState = (await response.json()) as UploadStatusResponse;
+    return { valid: serverState.isValid, serverState };
+  } catch (error) {
+    return {
+      valid: false,
+      error: `Failed to contact server: ${error instanceof Error ? error.message : "Unknown error"}`,
+    };
+  }
+}
+
+/**
+ * Create initial resume state for a new upload.
+ */
+export async function createResumeState(
+  sessionId: string,
+  filePath: string,
+  options: {
+    apiUrl: string;
+    chunkSize: number;
+    isEncrypted: boolean;
+    isOneTime: boolean;
+    filename: string;
+    contentType: string;
+    encryptedKey?: string;
+  },
+): Promise<ResumeState> {
+  const stats = fs.statSync(filePath);
+  const fileHash = await hashFileHead(filePath);
+
+  const state: ResumeState = {
+    sessionId,
+    filePath: path.resolve(filePath),
+    fileHash,
+    totalSize: stats.size,
+    chunkSize: options.chunkSize,
+    uploadedParts: [],
+    isEncrypted: options.isEncrypted,
+    encryptedKey: options.encryptedKey,
+    createdAt: Date.now(),
+    lastUpdatedAt: Date.now(),
+    apiUrl: options.apiUrl,
+    isOneTime: options.isOneTime,
+    filename: options.filename,
+    contentType: options.contentType,
+  };
+
+  return state;
+}
+
+/**
+ * Update resume state with a newly uploaded part.
+ */
+export async function updateResumeStatePart(
+  state: ResumeState,
+  partNumber: number,
+  etag: string,
+): Promise<void> {
+  // Add part if not already present
+  const existingIndex = state.uploadedParts.findIndex(
+    (p) => p.partNumber === partNumber,
+  );
+  if (existingIndex >= 0) {
+    state.uploadedParts[existingIndex] = { partNumber, etag };
+  } else {
+    state.uploadedParts.push({ partNumber, etag });
+  }
+
+  // Sort parts by number
+  state.uploadedParts.sort((a, b) => a.partNumber - b.partNumber);
+
+  // Save updated state
+  await saveResumeState(state);
+}
+
+/**
+ * Format resume state for display.
+ */
+export function formatResumeState(state: ResumeState): string {
+  const uploadedParts = state.uploadedParts.length;
+  const totalParts = Math.ceil(state.totalSize / state.chunkSize);
+  const uploadedBytes = state.uploadedParts.length * state.chunkSize;
+  const percent = ((uploadedParts / totalParts) * 100).toFixed(1);
+  const age = Date.now() - state.createdAt;
+  const ageStr = formatDuration(age);
+
+  return [
+    `Session: ${state.sessionId}`,
+    `File: ${state.filePath}`,
+    `Progress: ${uploadedParts}/${totalParts} parts (${percent}%)`,
+    `Size: ${formatBytes(uploadedBytes)} / ${formatBytes(state.totalSize)}`,
+    `Started: ${ageStr} ago`,
+    `Encrypted: ${state.isEncrypted ? "Yes" : "No"}`,
+    `One-time: ${state.isOneTime ? "Yes" : "No"}`,
+  ].join("\n");
+}
+
+/**
+ * Format bytes to human-readable string.
+ */
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const k = 1024;
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  const value = bytes / Math.pow(k, i);
+  return `${value.toFixed(i > 0 ? 1 : 0)} ${units[i]}`;
+}
+
+/**
+ * Format duration in milliseconds to human-readable string.
+ */
+function formatDuration(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return `${hours}h ${remainingMinutes}m`;
+}
+
+/**
+ * Register SIGINT handler for graceful interruption.
+ * Returns a function to remove the handler.
+ */
+export function registerInterruptHandler(
+  state: ResumeState,
+  onInterrupt?: () => void,
+): () => void {
+  const handler = async () => {
+    console.log("\n⚠️  Upload interrupted. Saving state for resume...");
+    await saveResumeState(state);
+    const resumeFile = getResumeFilePath(state.sessionId);
+    console.log(`Resume with: dedpaste upload --resume "${resumeFile}"`);
+    if (onInterrupt) {
+      onInterrupt();
+    }
+    process.exit(1);
+  };
+
+  process.on("SIGINT", handler);
+
+  return () => {
+    process.removeListener("SIGINT", handler);
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,10 +45,24 @@ hljs.registerLanguage("rust", rust);
 hljs.registerLanguage("ruby", ruby);
 hljs.registerLanguage("php", php);
 
+// Import multipart upload types
+import type {
+  UploadSession,
+  UploadedPart,
+  MultipartInitRequest,
+  MultipartInitResponse,
+  PartUploadResponse,
+  MultipartCompleteRequest,
+  MultipartCompleteResponse,
+  UploadStatusResponse,
+} from "./types";
+import { LARGE_FILE_CONSTANTS } from "./types";
+
 // Define the environment interface for Cloudflare Workers
 type Env = {
   PASTE_BUCKET: R2Bucket;
   PASTE_METADATA?: KVNamespace; // Optional KV namespace for metadata storage
+  UPLOAD_SESSIONS?: KVNamespace; // KV namespace for multipart upload sessions
 };
 
 type PasteMetadata = {
@@ -167,11 +181,56 @@ export default {
         return await handleUpload(request, env, isOneTime, true, analytics);
       }
 
+      // ============================================
+      // Multipart Upload Endpoints (Large Files)
+      // ============================================
+
+      // Initialize multipart upload
+      if (path === "/upload/init" || path === "/e/upload/init") {
+        const isEncrypted = path.startsWith("/e/");
+        return await handleMultipartInit(request, env, isEncrypted);
+      }
+
+      // Complete multipart upload
+      const completeMatch = path.match(/^(\/e)?\/upload\/([a-zA-Z0-9_-]+)\/complete$/);
+      if (completeMatch) {
+        const isEncrypted = !!completeMatch[1];
+        const sessionId = completeMatch[2];
+        return await handleMultipartComplete(request, env, sessionId, isEncrypted);
+      }
+
+      // Abort multipart upload
+      const abortMatch = path.match(/^(\/e)?\/upload\/([a-zA-Z0-9_-]+)\/abort$/);
+      if (abortMatch) {
+        const sessionId = abortMatch[2];
+        return await handleMultipartAbort(request, env, sessionId);
+      }
+
+      return new Response("Not found", { status: 404 });
+    }
+
+    // Handle PUT requests for multipart upload parts
+    if (request.method === "PUT") {
+      const partMatch = path.match(/^(\/e)?\/upload\/([a-zA-Z0-9_-]+)\/part\/(\d+)$/);
+      if (partMatch) {
+        const isEncrypted = !!partMatch[1];
+        const sessionId = partMatch[2];
+        const partNumber = parseInt(partMatch[3], 10);
+        return await handleMultipartPartUpload(request, env, sessionId, partNumber);
+      }
+
       return new Response("Not found", { status: 404 });
     }
 
     // Get a paste
     if (request.method === "GET") {
+      // Handle multipart upload status (for resume)
+      const statusMatch = path.match(/^(\/e)?\/upload\/([a-zA-Z0-9_-]+)\/status$/);
+      if (statusMatch) {
+        const sessionId = statusMatch[2];
+        return await handleMultipartStatus(env, sessionId);
+      }
+
       // Handle API decryption for web interface
       const decryptMatch = path.match(/^\/api\/decrypt\/([a-zA-Z0-9]{8})$/);
       if (decryptMatch) {
@@ -2153,4 +2212,631 @@ async function handleWebDecrypt(
   // For now, just redirect to the regular GET handler
   // In the future, this would handle decryption with provided keys
   return await handleGet(id, env, ctx, false, request);
+}
+
+// ============================================
+// Multipart Upload Handlers (Large File Support)
+// ============================================
+
+/**
+ * Generate a unique session ID for multipart uploads.
+ */
+function generateSessionId(): string {
+  const timestamp = Date.now().toString(36);
+  const random = generateId(12);
+  return `sess_${timestamp}_${random}`;
+}
+
+/**
+ * Get upload session from KV storage.
+ */
+async function getUploadSession(
+  env: Env,
+  sessionId: string,
+): Promise<UploadSession | null> {
+  if (!env.UPLOAD_SESSIONS) {
+    return null;
+  }
+  const data = await env.UPLOAD_SESSIONS.get(sessionId);
+  if (!data) {
+    return null;
+  }
+  return JSON.parse(data) as UploadSession;
+}
+
+/**
+ * Save upload session to KV storage.
+ */
+async function saveUploadSession(
+  env: Env,
+  sessionId: string,
+  session: UploadSession,
+): Promise<void> {
+  if (!env.UPLOAD_SESSIONS) {
+    throw new Error("UPLOAD_SESSIONS KV namespace not configured");
+  }
+  // Set TTL to session expiration time
+  const ttlSeconds = Math.max(
+    60,
+    Math.floor((session.expiresAt - Date.now()) / 1000),
+  );
+  await env.UPLOAD_SESSIONS.put(sessionId, JSON.stringify(session), {
+    expirationTtl: ttlSeconds,
+  });
+}
+
+/**
+ * Delete upload session from KV storage.
+ */
+async function deleteUploadSession(
+  env: Env,
+  sessionId: string,
+): Promise<void> {
+  if (env.UPLOAD_SESSIONS) {
+    await env.UPLOAD_SESSIONS.delete(sessionId);
+  }
+}
+
+/**
+ * Initialize a new multipart upload session.
+ * POST /upload/init or POST /e/upload/init
+ */
+async function handleMultipartInit(
+  request: Request,
+  env: Env,
+  isEncrypted: boolean,
+): Promise<Response> {
+  // Check if UPLOAD_SESSIONS is configured
+  if (!env.UPLOAD_SESSIONS) {
+    return new Response(
+      JSON.stringify({
+        error: "Large file uploads not configured. UPLOAD_SESSIONS KV namespace required.",
+      }),
+      {
+        status: 503,
+        headers: {
+          "Content-Type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+        },
+      },
+    );
+  }
+
+  try {
+    const body = (await request.json()) as MultipartInitRequest;
+    const {
+      filename,
+      contentType,
+      totalSize,
+      totalParts,
+      isOneTime = false,
+      encryptionMetadata,
+    } = body;
+
+    // Validate request
+    if (!filename || !contentType || !totalSize || !totalParts) {
+      return new Response(
+        JSON.stringify({ error: "Missing required fields: filename, contentType, totalSize, totalParts" }),
+        {
+          status: 400,
+          headers: {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+          },
+        },
+      );
+    }
+
+    // Validate file size
+    if (totalSize > LARGE_FILE_CONSTANTS.MAX_FILE_SIZE) {
+      return new Response(
+        JSON.stringify({
+          error: `File too large. Maximum size is ${LARGE_FILE_CONSTANTS.MAX_FILE_SIZE / (1024 * 1024 * 1024)}GB`,
+        }),
+        {
+          status: 400,
+          headers: {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+          },
+        },
+      );
+    }
+
+    // Generate paste ID and storage key
+    const pasteId = generateId();
+    const key = isOneTime ? `${ONE_TIME_PREFIX}${pasteId}` : pasteId;
+
+    // Create multipart upload in R2
+    const multipartUpload = await env.PASTE_BUCKET.createMultipartUpload(key, {
+      customMetadata: {
+        contentType: isEncrypted ? "application/json" : contentType,
+        isOneTime: String(isOneTime),
+        createdAt: String(Date.now()),
+        filename: filename,
+        isMultipart: "true",
+      },
+    });
+
+    // Generate session ID
+    const sessionId = generateSessionId();
+
+    // Create session state
+    const session: UploadSession = {
+      uploadId: multipartUpload.uploadId,
+      key,
+      filename,
+      contentType: isEncrypted ? "application/json" : contentType,
+      totalSize,
+      totalParts,
+      uploadedParts: [],
+      isOneTime,
+      isEncrypted,
+      createdAt: Date.now(),
+      expiresAt: Date.now() + LARGE_FILE_CONSTANTS.SESSION_TTL_MS,
+      encryptionMetadata,
+    };
+
+    // Save session to KV
+    await saveUploadSession(env, sessionId, session);
+
+    console.log(
+      `[MULTIPART] Initialized upload session ${sessionId} for paste ${pasteId}, ` +
+        `size=${totalSize}, parts=${totalParts}, encrypted=${isEncrypted}, oneTime=${isOneTime}`,
+    );
+
+    const response: MultipartInitResponse = {
+      sessionId,
+      uploadId: multipartUpload.uploadId,
+      pasteId,
+      expiresAt: new Date(session.expiresAt).toISOString(),
+    };
+
+    return new Response(JSON.stringify(response), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Access-Control-Allow-Origin": "*",
+      },
+    });
+  } catch (error) {
+    console.error("[MULTIPART] Init error:", error);
+    return new Response(
+      JSON.stringify({ error: "Failed to initialize multipart upload" }),
+      {
+        status: 500,
+        headers: {
+          "Content-Type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+        },
+      },
+    );
+  }
+}
+
+/**
+ * Upload a single part of a multipart upload.
+ * PUT /upload/:sessionId/part/:partNumber or PUT /e/upload/:sessionId/part/:partNumber
+ */
+async function handleMultipartPartUpload(
+  request: Request,
+  env: Env,
+  sessionId: string,
+  partNumber: number,
+): Promise<Response> {
+  try {
+    // Get session
+    const session = await getUploadSession(env, sessionId);
+    if (!session) {
+      return new Response(
+        JSON.stringify({ error: "Upload session not found or expired" }),
+        {
+          status: 404,
+          headers: {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+          },
+        },
+      );
+    }
+
+    // Check if session has expired
+    if (Date.now() > session.expiresAt) {
+      await deleteUploadSession(env, sessionId);
+      return new Response(
+        JSON.stringify({ error: "Upload session has expired" }),
+        {
+          status: 410,
+          headers: {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+          },
+        },
+      );
+    }
+
+    // Validate part number
+    if (partNumber < 1 || partNumber > session.totalParts) {
+      return new Response(
+        JSON.stringify({
+          error: `Invalid part number. Expected 1-${session.totalParts}, got ${partNumber}`,
+        }),
+        {
+          status: 400,
+          headers: {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+          },
+        },
+      );
+    }
+
+    // Check if part already uploaded
+    const existingPart = session.uploadedParts.find(
+      (p) => p.partNumber === partNumber,
+    );
+    if (existingPart) {
+      // Return existing etag (idempotent)
+      const response: PartUploadResponse = {
+        etag: existingPart.etag,
+        partNumber,
+      };
+      return new Response(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+        },
+      });
+    }
+
+    // Resume multipart upload in R2
+    const multipartUpload = env.PASTE_BUCKET.resumeMultipartUpload(
+      session.key,
+      session.uploadId,
+    );
+
+    // Get content length
+    const contentLength = parseInt(
+      request.headers.get("Content-Length") || "0",
+      10,
+    );
+
+    // Validate minimum part size (except for last part)
+    if (
+      partNumber < session.totalParts &&
+      contentLength < LARGE_FILE_CONSTANTS.MIN_CHUNK_SIZE
+    ) {
+      return new Response(
+        JSON.stringify({
+          error: `Part size too small. Minimum is ${LARGE_FILE_CONSTANTS.MIN_CHUNK_SIZE / (1024 * 1024)}MB (except for last part)`,
+        }),
+        {
+          status: 400,
+          headers: {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+          },
+        },
+      );
+    }
+
+    // Upload the part - stream the request body directly to R2
+    const uploadedPart = await multipartUpload.uploadPart(
+      partNumber,
+      request.body as ReadableStream,
+    );
+
+    // Update session with uploaded part
+    session.uploadedParts.push({
+      partNumber,
+      etag: uploadedPart.etag,
+      size: contentLength,
+    });
+
+    // Sort parts by part number for consistency
+    session.uploadedParts.sort((a, b) => a.partNumber - b.partNumber);
+
+    // Save updated session
+    await saveUploadSession(env, sessionId, session);
+
+    console.log(
+      `[MULTIPART] Uploaded part ${partNumber}/${session.totalParts} for session ${sessionId}, ` +
+        `size=${contentLength}, etag=${uploadedPart.etag}`,
+    );
+
+    const response: PartUploadResponse = {
+      etag: uploadedPart.etag,
+      partNumber,
+    };
+
+    return new Response(JSON.stringify(response), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Access-Control-Allow-Origin": "*",
+      },
+    });
+  } catch (error) {
+    console.error(`[MULTIPART] Part upload error for session ${sessionId}:`, error);
+    return new Response(
+      JSON.stringify({ error: "Failed to upload part" }),
+      {
+        status: 500,
+        headers: {
+          "Content-Type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+        },
+      },
+    );
+  }
+}
+
+/**
+ * Complete a multipart upload.
+ * POST /upload/:sessionId/complete or POST /e/upload/:sessionId/complete
+ */
+async function handleMultipartComplete(
+  request: Request,
+  env: Env,
+  sessionId: string,
+  isEncrypted: boolean,
+): Promise<Response> {
+  try {
+    // Get session
+    const session = await getUploadSession(env, sessionId);
+    if (!session) {
+      return new Response(
+        JSON.stringify({ error: "Upload session not found or expired" }),
+        {
+          status: 404,
+          headers: {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+          },
+        },
+      );
+    }
+
+    // Parse request body
+    const body = (await request.json()) as MultipartCompleteRequest;
+    const { parts } = body;
+
+    // Validate all parts are uploaded
+    if (!parts || parts.length !== session.totalParts) {
+      return new Response(
+        JSON.stringify({
+          error: `Expected ${session.totalParts} parts, got ${parts?.length || 0}`,
+        }),
+        {
+          status: 400,
+          headers: {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+          },
+        },
+      );
+    }
+
+    // Resume multipart upload in R2
+    const multipartUpload = env.PASTE_BUCKET.resumeMultipartUpload(
+      session.key,
+      session.uploadId,
+    );
+
+    // Complete the upload
+    // Parts must be sorted by part number
+    const sortedParts = parts
+      .map((p) => ({
+        partNumber: p.partNumber,
+        etag: p.etag,
+      }))
+      .sort((a, b) => a.partNumber - b.partNumber);
+
+    await multipartUpload.complete(sortedParts);
+
+    // Calculate total uploaded size
+    const totalSize = session.uploadedParts.reduce((sum, p) => sum + p.size, 0);
+
+    // Delete session from KV
+    await deleteUploadSession(env, sessionId);
+
+    // Extract paste ID from key (remove onetime- prefix if present)
+    const pasteId = session.key.startsWith(ONE_TIME_PREFIX)
+      ? session.key.slice(ONE_TIME_PREFIX.length)
+      : session.key;
+
+    // Generate URL
+    const baseUrl = new URL(request.url).origin;
+    const encodedFilename = encodeURIComponent(session.filename);
+    const url = isEncrypted
+      ? `${baseUrl}/e/${pasteId}/${encodedFilename}`
+      : `${baseUrl}/${pasteId}/${encodedFilename}`;
+
+    console.log(
+      `[MULTIPART] Completed upload for session ${sessionId}, paste=${pasteId}, ` +
+        `totalSize=${totalSize}, encrypted=${isEncrypted}`,
+    );
+
+    const response: MultipartCompleteResponse = {
+      url,
+      id: pasteId,
+      size: totalSize,
+    };
+
+    return new Response(JSON.stringify(response), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Access-Control-Allow-Origin": "*",
+      },
+    });
+  } catch (error) {
+    console.error(`[MULTIPART] Complete error for session ${sessionId}:`, error);
+    return new Response(
+      JSON.stringify({ error: "Failed to complete multipart upload" }),
+      {
+        status: 500,
+        headers: {
+          "Content-Type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+        },
+      },
+    );
+  }
+}
+
+/**
+ * Abort a multipart upload and clean up.
+ * POST /upload/:sessionId/abort or POST /e/upload/:sessionId/abort
+ */
+async function handleMultipartAbort(
+  request: Request,
+  env: Env,
+  sessionId: string,
+): Promise<Response> {
+  try {
+    // Get session
+    const session = await getUploadSession(env, sessionId);
+    if (!session) {
+      // Session not found - may already be aborted or expired
+      return new Response(
+        JSON.stringify({ success: true, message: "Session not found or already cleaned up" }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+          },
+        },
+      );
+    }
+
+    try {
+      // Resume and abort the R2 multipart upload
+      const multipartUpload = env.PASTE_BUCKET.resumeMultipartUpload(
+        session.key,
+        session.uploadId,
+      );
+      await multipartUpload.abort();
+    } catch (e) {
+      // Ignore abort errors - upload may already be completed or aborted
+      console.log(`[MULTIPART] Abort R2 upload warning for session ${sessionId}:`, e);
+    }
+
+    // Delete session from KV
+    await deleteUploadSession(env, sessionId);
+
+    console.log(`[MULTIPART] Aborted upload session ${sessionId}`);
+
+    return new Response(
+      JSON.stringify({ success: true, message: "Upload session aborted and cleaned up" }),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+        },
+      },
+    );
+  } catch (error) {
+    console.error(`[MULTIPART] Abort error for session ${sessionId}:`, error);
+    return new Response(
+      JSON.stringify({ error: "Failed to abort multipart upload" }),
+      {
+        status: 500,
+        headers: {
+          "Content-Type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+        },
+      },
+    );
+  }
+}
+
+/**
+ * Get upload session status (for resume support).
+ * GET /upload/:sessionId/status or GET /e/upload/:sessionId/status
+ */
+async function handleMultipartStatus(
+  env: Env,
+  sessionId: string,
+): Promise<Response> {
+  try {
+    // Get session
+    const session = await getUploadSession(env, sessionId);
+    if (!session) {
+      return new Response(
+        JSON.stringify({
+          error: "Upload session not found or expired",
+          isValid: false,
+        }),
+        {
+          status: 404,
+          headers: {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+          },
+        },
+      );
+    }
+
+    // Check if session has expired
+    const isExpired = Date.now() > session.expiresAt;
+    if (isExpired) {
+      await deleteUploadSession(env, sessionId);
+      return new Response(
+        JSON.stringify({
+          error: "Upload session has expired",
+          isValid: false,
+        }),
+        {
+          status: 410,
+          headers: {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+          },
+        },
+      );
+    }
+
+    // Extract paste ID from key
+    const pasteId = session.key.startsWith(ONE_TIME_PREFIX)
+      ? session.key.slice(ONE_TIME_PREFIX.length)
+      : session.key;
+
+    // Calculate uploaded bytes
+    const uploadedBytes = session.uploadedParts.reduce((sum, p) => sum + p.size, 0);
+
+    const response: UploadStatusResponse = {
+      sessionId,
+      pasteId,
+      totalParts: session.totalParts,
+      uploadedParts: session.uploadedParts,
+      uploadedBytes,
+      totalSize: session.totalSize,
+      expiresAt: new Date(session.expiresAt).toISOString(),
+      isValid: true,
+    };
+
+    return new Response(JSON.stringify(response), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Access-Control-Allow-Origin": "*",
+      },
+    });
+  } catch (error) {
+    console.error(`[MULTIPART] Status error for session ${sessionId}:`, error);
+    return new Response(
+      JSON.stringify({ error: "Failed to get upload status", isValid: false }),
+      {
+        status: 500,
+        headers: {
+          "Content-Type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+        },
+      },
+    );
+  }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -379,3 +379,291 @@ export interface DecryptionOptions {
   keyId?: string;
   private?: boolean;
 }
+
+// ============================================
+// Large File / Multipart Upload Types
+// ============================================
+
+/**
+ * Server-side upload session stored in KV.
+ * Tracks the state of an in-progress multipart upload.
+ */
+export interface UploadSession {
+  /** R2 multipart upload ID (from createMultipartUpload) */
+  uploadId: string;
+  /** R2 object key (the paste ID, possibly with onetime- prefix) */
+  key: string;
+  /** Original filename from client */
+  filename: string;
+  /** MIME content type */
+  contentType: string;
+  /** Total file size in bytes */
+  totalSize: number;
+  /** Expected number of parts */
+  totalParts: number;
+  /** Parts that have been successfully uploaded */
+  uploadedParts: UploadedPart[];
+  /** Whether this is a one-time paste */
+  isOneTime: boolean;
+  /** Whether the content is encrypted */
+  isEncrypted: boolean;
+  /** Session creation timestamp (ms since epoch) */
+  createdAt: number;
+  /** Session expiration timestamp (ms since epoch) */
+  expiresAt: number;
+  /** Encryption metadata for encrypted uploads */
+  encryptionMetadata?: EncryptedFileHeader;
+}
+
+/**
+ * Information about a successfully uploaded part.
+ */
+export interface UploadedPart {
+  /** Part number (1-indexed, as per S3/R2 spec) */
+  partNumber: number;
+  /** ETag returned by R2 for this part */
+  etag: string;
+  /** Size of this part in bytes */
+  size: number;
+}
+
+/**
+ * Request body for initializing a multipart upload.
+ */
+export interface MultipartInitRequest {
+  /** Original filename */
+  filename: string;
+  /** MIME content type */
+  contentType: string;
+  /** Total file size in bytes */
+  totalSize: number;
+  /** Expected number of parts */
+  totalParts: number;
+  /** Whether this is a one-time paste */
+  isOneTime?: boolean;
+  /** Whether the content is encrypted */
+  isEncrypted?: boolean;
+  /** Encryption metadata for encrypted uploads */
+  encryptionMetadata?: EncryptedFileHeader;
+}
+
+/**
+ * Response from initializing a multipart upload.
+ */
+export interface MultipartInitResponse {
+  /** Session ID for subsequent operations */
+  sessionId: string;
+  /** R2 upload ID (exposed for debugging) */
+  uploadId: string;
+  /** The paste ID that will be used in the final URL */
+  pasteId: string;
+  /** When this session expires */
+  expiresAt: string;
+}
+
+/**
+ * Response from uploading a single part.
+ */
+export interface PartUploadResponse {
+  /** ETag for this part (required for completion) */
+  etag: string;
+  /** Part number that was uploaded */
+  partNumber: number;
+}
+
+/**
+ * Request body for completing a multipart upload.
+ */
+export interface MultipartCompleteRequest {
+  /** List of parts with their ETags */
+  parts: Array<{ partNumber: number; etag: string }>;
+}
+
+/**
+ * Response from completing a multipart upload.
+ */
+export interface MultipartCompleteResponse {
+  /** Full URL to access the paste */
+  url: string;
+  /** The paste ID */
+  id: string;
+  /** Total size in bytes */
+  size: number;
+}
+
+/**
+ * Response from the upload status endpoint.
+ */
+export interface UploadStatusResponse {
+  /** Session ID */
+  sessionId: string;
+  /** The paste ID */
+  pasteId: string;
+  /** Total expected parts */
+  totalParts: number;
+  /** Parts that have been uploaded */
+  uploadedParts: UploadedPart[];
+  /** Total bytes uploaded so far */
+  uploadedBytes: number;
+  /** Total file size */
+  totalSize: number;
+  /** When this session expires */
+  expiresAt: string;
+  /** Whether the session is still valid */
+  isValid: boolean;
+}
+
+// ============================================
+// Streaming Encryption Types (v4)
+// ============================================
+
+/**
+ * Header for streaming encrypted files (v4 format).
+ * Stored as the first part of the multipart upload.
+ */
+export interface EncryptedFileHeader {
+  /** Version identifier (4 for streaming encryption) */
+  version: 4;
+  /** Metadata about the encrypted file */
+  metadata: {
+    /** Sender identifier */
+    sender?: string;
+    /** Recipient information */
+    recipient?: RecipientInfo;
+    /** Encryption timestamp */
+    timestamp: string;
+    /** Total number of encrypted chunks */
+    totalChunks: number;
+    /** Original (unencrypted) file size */
+    originalSize: number;
+    /** Size of each chunk before encryption */
+    chunkSize: number;
+    /** Original filename */
+    filename?: string;
+  };
+  /** Symmetric key encrypted with recipient's public key (base64) */
+  encryptedKey: string;
+}
+
+/**
+ * Per-chunk encryption header (prepended to each encrypted chunk).
+ * Total header size: 36 bytes (16 + 16 + 4)
+ */
+export interface EncryptedChunkHeader {
+  /** Initialization vector (16 bytes) */
+  iv: Uint8Array;
+  /** Authentication tag (16 bytes) */
+  authTag: Uint8Array;
+  /** Length of encrypted data (4 bytes, big-endian uint32) */
+  encryptedLength: number;
+}
+
+// ============================================
+// CLI Resume State Types
+// ============================================
+
+/**
+ * State saved to disk for resuming interrupted uploads.
+ * Stored in ~/.dedpaste/uploads/<sessionId>.json
+ */
+export interface ResumeState {
+  /** Server session ID */
+  sessionId: string;
+  /** Path to the file being uploaded */
+  filePath: string;
+  /** MD5 hash of first 1MB (to verify file hasn't changed) */
+  fileHash: string;
+  /** Total file size in bytes */
+  totalSize: number;
+  /** Chunk size used for this upload */
+  chunkSize: number;
+  /** Parts that have been uploaded */
+  uploadedParts: Array<{ partNumber: number; etag: string }>;
+  /** Whether this is an encrypted upload */
+  isEncrypted: boolean;
+  /** For encrypted uploads: the encrypted symmetric key */
+  encryptedKey?: string;
+  /** Session creation timestamp */
+  createdAt: number;
+  /** Last update timestamp */
+  lastUpdatedAt: number;
+  /** API URL used for this upload */
+  apiUrl: string;
+  /** Whether this is a one-time paste */
+  isOneTime: boolean;
+  /** Original filename */
+  filename: string;
+  /** Content type */
+  contentType: string;
+}
+
+/**
+ * Progress information during upload.
+ */
+export interface UploadProgress {
+  /** Total file size in bytes */
+  totalBytes: number;
+  /** Bytes uploaded so far */
+  uploadedBytes: number;
+  /** Current part being uploaded */
+  currentPart: number;
+  /** Total number of parts */
+  totalParts: number;
+  /** Upload speed in bytes per second */
+  speed: number;
+  /** Estimated time remaining in seconds */
+  eta: number;
+  /** Percentage complete (0-100) */
+  percent: number;
+}
+
+/**
+ * Options for large file uploads.
+ */
+export interface LargeUploadOptions {
+  /** API URL to upload to */
+  apiUrl: string;
+  /** Chunk size in bytes (default: 10MB, min: 5MB) */
+  chunkSize?: number;
+  /** Whether this is a one-time paste */
+  isOneTime?: boolean;
+  /** Whether to encrypt the content */
+  isEncrypted?: boolean;
+  /** Recipient for encryption */
+  recipient?: string;
+  /** Path to resume state file (for resuming) */
+  resumeFile?: string;
+  /** Whether to show progress (default: true) */
+  showProgress?: boolean;
+  /** Maximum concurrent uploads (default: 4) */
+  maxConcurrent?: number;
+  /** Callback for progress updates */
+  onProgress?: (progress: UploadProgress) => void;
+}
+
+/**
+ * Configuration constants for large file uploads.
+ */
+export const LARGE_FILE_CONSTANTS = {
+  /** Default chunk size: 10MB */
+  DEFAULT_CHUNK_SIZE: 10 * 1024 * 1024,
+  /** Minimum chunk size: 5MB (R2 requirement) */
+  MIN_CHUNK_SIZE: 5 * 1024 * 1024,
+  /** Maximum chunk size: 100MB */
+  MAX_CHUNK_SIZE: 100 * 1024 * 1024,
+  /** Threshold for using multipart upload: 50MB */
+  MULTIPART_THRESHOLD: 50 * 1024 * 1024,
+  /** Maximum file size: 5GB */
+  MAX_FILE_SIZE: 5 * 1024 * 1024 * 1024,
+  /** Maximum concurrent part uploads */
+  MAX_CONCURRENT_UPLOADS: 4,
+  /** Session TTL: 24 hours in milliseconds */
+  SESSION_TTL_MS: 24 * 60 * 60 * 1000,
+  /** Retry configuration */
+  RETRY: {
+    MAX_RETRIES: 3,
+    BASE_DELAY_MS: 1000,
+    MAX_DELAY_MS: 30000,
+    BACKOFF_MULTIPLIER: 2,
+  },
+} as const;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -20,3 +20,9 @@ preview_bucket_name = "dedpaste-bucket-preview"
 binding = "PASTE_METADATA"
 id = "0d25f4b9e61a44ab92634e7941cea0a0"
 preview_id = "0d25f4b9e61a44ab92634e7941cea0a0"
+
+# KV namespace for multipart upload session state (large file support)
+[[kv_namespaces]]
+binding = "UPLOAD_SESSIONS"
+id = "c0251d912bb045df9c363b1b00be81a1"
+preview_id = "3e505a5b19a14816ba1105c7772a2a4c"


### PR DESCRIPTION
## Summary

This PR adds support for uploading large files (up to 5GB) using Cloudflare R2's multipart upload API. Files larger than 50MB are automatically uploaded using chunked multipart uploads with progress tracking and resume capability.

### Key Features

- **Automatic large file detection**: Files >50MB automatically use multipart upload
- **Progress tracking**: Real-time progress bar with upload speed and ETA
- **Resume support**: Interrupted uploads can be resumed from where they left off
- **Parallel uploads**: 4 concurrent chunk uploads for maximum throughput
- **Configurable chunk size**: Default 10MB, customizable via `--chunk-size`

### New CLI Options

```bash
# Large files are auto-detected and use multipart
dedpaste send --file large-video.mp4

# Custom chunk size (in MB)
dedpaste send --chunk-size 20 --file archive.tar.gz

# Resume an interrupted upload
dedpaste send --resume ~/.dedpaste/uploads/sess_xxx.json

# List interrupted uploads
dedpaste send --list-uploads

# Abort and cleanup a failed upload
dedpaste send --abort-upload <session-id>

# Disable progress bar
dedpaste send --no-progress --file data.bin
```

### Architecture

```
CLI (Node.js)          Cloudflare Worker           R2 Storage
     │                       │                         │
     │  POST /upload/init    │                         │
     │──────────────────────>│ createMultipartUpload() │
     │  {sessionId}          │────────────────────────>│
     │<──────────────────────│                         │
     │                       │                         │
     │  PUT /upload/:id/part/:n (streamed chunks)      │
     │──────────────────────>│ uploadPart()            │
     │  {etag}               │────────────────────────>│
     │<──────────────────────│                         │
     │  ... parallel uploads │                         │
     │                       │                         │
     │  POST /upload/:id/complete                      │
     │──────────────────────>│ completeMultipartUpload()│
     │  {url}                │────────────────────────>│
     │<──────────────────────│                         │
```

### Files Changed

| File | Description |
|------|-------------|
| `src/index.ts` | Added multipart upload endpoints |
| `src/types/index.ts` | Added UploadSession, ResumeState, and related types |
| `wrangler.toml` | Added UPLOAD_SESSIONS KV namespace |
| `cli/largeFileUpload.ts` | **New** - Core multipart upload logic |
| `cli/progressDisplay.ts` | **New** - Progress bar utilities |
| `cli/resumeState.ts` | **New** - Resume state persistence |
| `cli/encryptionUtils.ts` | Added streaming encryption v4 framework |
| `cli/index.ts` | Integrated large file options and detection |

### Technical Details

- **Chunk size**: Default 10MB (configurable), minimum 5MB (R2 requirement)
- **Max file size**: 5GB (configurable via `LARGE_FILE_CONSTANTS`)
- **Session TTL**: 24 hours for resume capability
- **Concurrency**: 4 parallel chunk uploads
- **Retry logic**: 3 attempts with exponential backoff

### Testing

- ✅ Verified 60MB file upload completes successfully
- ✅ Verified file integrity via MD5 checksum comparison
- ✅ Verified progress bar displays correctly
- ✅ Verified `--list-uploads` command works
- ✅ Deployed and tested on production

### Known Limitations

- Encrypted large file uploads currently fall back to regular upload (streaming encryption v4 framework is in place for future implementation)

## Test plan

- [ ] Upload a file <50MB (should use regular upload)
- [ ] Upload a file >50MB (should auto-detect and use multipart)
- [ ] Interrupt upload with Ctrl+C, verify resume state saved
- [ ] Resume upload with `--resume`, verify completion
- [ ] Test `--list-uploads` shows interrupted uploads
- [ ] Test `--abort-upload` cleans up properly
- [ ] Verify downloaded file matches original (checksum)

🤖 Generated with [Claude Code](https://claude.com/claude-code)