### PR TITLE
fix(package): include src/types in published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "files": [
     "dist",
     "cli",
+    "src/types",
     "completion",
     "public",
     "README.md"


### PR DESCRIPTION
The CLI imports types from ../src/types/index.js which wasn't included in the package files array, causing module not found errors when the package is installed globally.