### PR TITLE
fix(deps): bump serialize-javascript to 7.0.5 (high-severity RCE/DoS)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dedpaste",
-  "version": "1.24.4",
+  "version": "1.24.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dedpaste",
-      "version": "1.24.4",
+      "version": "1.24.6",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
@@ -7313,16 +7313,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/react": {
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
@@ -7461,27 +7451,6 @@
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -7508,13 +7477,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/sharp": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "node": ">=18"
   },
   "overrides": {
-    "undici": "7.24.4"
+    "undici": "7.24.4",
+    "serialize-javascript": "7.0.5"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250303.0",


### PR DESCRIPTION
## Summary

Forces `serialize-javascript` to **7.0.5** via an `overrides` entry, resolving:
- **CVE-2026-34043** (7.5) — RCE via `RegExp.flags` / `Date.prototype.toISOString()`
- **sonatype-2026-000632** (8.1) — CPU-exhaustion DoS via crafted array-like objects

Target version confirmed by Sonatype (trust score 98, no remaining vulns).

## Why an override

`serialize-javascript` is pulled **only** by `mocha@^6.0.2` (devDependency), which pins the `^6` major. A plain `npm update` can't cross to 7.x, so an `overrides` entry is required to force the patched major.

## Risk assessment

Low. `serialize-javascript` is used by mocha solely to serialize data across **parallel** test workers. This project's test script (`mocha test/**/*.test.js`) runs **serially** — no `--parallel` flag — so the package is never invoked at runtime. The override only improves the dependency tree's security posture.

## Verification
- `npm run build` ✅ passes
- `npm test`: no regression — failures are confined to the pre-existing flaky friend-encryption / PGP suites (verified identical on `main` across multiple runs; which ones fail varies due to key-generation entropy).

## Note
Touches the same `overrides` block as #123 (undici). Whichever merges second will need a trivial rebase to combine the two override keys.