### PR TITLE
fix(deps): bump ws to 8.21.0 and diff to 8.0.3 (clears remaining audit findings)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dedpaste",
-  "version": "1.24.6",
+  "version": "1.24.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dedpaste",
-      "version": "1.24.6",
+      "version": "1.24.8",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
@@ -4494,9 +4494,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -8240,9 +8240,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
   },
   "overrides": {
     "undici": "7.24.4",
-    "serialize-javascript": "7.0.5"
+    "serialize-javascript": "7.0.5",
+    "ws": "8.21.0",
+    "diff": "8.0.3"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250303.0",


### PR DESCRIPTION
## Summary

Patches the final two transitive vulnerabilities via `overrides`. **`npm audit` now reports 0 vulnerabilities** (down from 8 at the start of this security pass).

| Package | From | To | Sonatype severity | Pulled by |
|---|---|---|---|---|
| ws | 8.18.0 | **8.21.0** | CVE-2026-48779 **8.7** + sonatype-2026-003100 (7.5) | `miniflare` (hard-pins 8.18.0) |
| diff | 7.0.0 | **8.0.3** | sonatype-2026-000159 **8.7** (DoS in `parsePatch`) | `mocha@^7.0.0` |

### Notes
- **Severity correction:** `npm audit` rated these moderate/low, but Sonatype scores both as **8.7 high**. Targets are the highest-trust clean versions per Sonatype (ws 8.21.0 → trust 94; diff 8.0.3 → trust 98).
- Both required `overrides`: `miniflare` hard-pins ws@8.18.0, and `diff` 8.0.3 is a major bump beyond mocha's `^7` range.
- **Dev-only blast radius:** ws backs miniflare's local dev WebSocket; diff backs mocha's assertion-diff rendering. Neither ships in the deployed Worker.

## Verification
- `npm run build` ✅ passes
- `npm audit` ✅ **0 vulnerabilities**
- `npm test`: mocha runs and renders assertion diffs correctly under the diff 8 major (verified via the existing failures' diff output). No regression — the 2 failures are the pre-existing flaky friend-encryption / PGP tests, identical to `main` (21 passing / 2 failing).