### PR TITLE
feat: web UX overhaul — paste creation UI, browser viewing pipeline, homepage polish

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2116,13 +2116,31 @@ function escapeHtml(unsafe: string): string {
  * and dangerous attributes (on*, javascript: URLs, data: URLs).
  */
 function sanitizeHtml(html: string): string {
-  // Remove dangerous tags entirely (including content for script/style)
-  html = html.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '');
-  html = html.replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, '');
+  // Apply the strip pass repeatedly until a fixpoint: a single pass can
+  // construct new dangerous markup from fragments (e.g. removing the inner
+  // tag of <scr<script></script>ipt> yields <script>). Every replacement
+  // strictly shrinks the string, so this terminates.
+  let previous: string;
+  do {
+    previous = html;
+    html = stripDangerousMarkup(html);
+  } while (html !== previous);
+  return html;
+}
+
+/** Single sanitization pass used by sanitizeHtml's fixpoint loop. */
+function stripDangerousMarkup(html: string): string {
+  // Remove dangerous tags entirely (including content for script/style).
+  // End tags may contain whitespace or attributes (</script foo>), so match
+  // <\/tag\b[^>]*> rather than a literal </tag>.
+  html = html.replace(/<script\b[^<]*(?:(?!<\/script\b[^>]*>)<[^<]*)*<\/script\b[^>]*>/gi, '');
+  html = html.replace(/<style\b[^<]*(?:(?!<\/style\b[^>]*>)<[^<]*)*<\/style\b[^>]*>/gi, '');
 
   // Remove dangerous self-closing/void tags. svg/math open foreign-content
   // parsing contexts where script execution is possible, so they are banned too.
   const dangerousTags = [
+    'script',
+    'style',
     'iframe',
     'object',
     'embed',
@@ -2139,10 +2157,14 @@ function sanitizeHtml(html: string): string {
     'math',
   ];
   for (const tag of dangerousTags) {
-    const openClose = new RegExp(`<${tag}\\b[^<]*(?:(?!<\\/${tag}>)<[^<]*)*<\\/${tag}>`, 'gi');
+    const openClose = new RegExp(
+      `<${tag}\\b[^<]*(?:(?!<\\/${tag}\\b[^>]*>)<[^<]*)*<\\/${tag}\\b[^>]*>`,
+      'gi'
+    );
     html = html.replace(openClose, '');
-    const selfClose = new RegExp(`<${tag}\\b[^>]*\\/?>`, 'gi');
-    html = html.replace(selfClose, '');
+    // Stray open, close, or self-closing tags without a matched pair
+    const single = new RegExp(`<\\/?${tag}\\b[^>]*>`, 'gi');
+    html = html.replace(single, '');
   }
 
   // Remove event handler attributes (on*). The leading character may be
@@ -2181,10 +2203,12 @@ function safeJsonEmbed(value: string): string {
  * Removes characters that could cause header injection.
  */
 function sanitizeFilename(filename: string): string {
-  // Remove path traversal, quotes, control characters, and newlines
+  // Replace quotes, control characters, and all path separators. Replacing
+  // separators (rather than deleting "../" sequences) means traversal
+  // sequences cannot survive or be reconstructed.
   return filename
-    .replace(/["\\\r\n]/g, '_')
-    .replace(/\.\.\//g, '')
+    .replace(/["\r\n]/g, '_')
+    .replace(/[/\\]/g, '_')
     .replace(/[^\x20-\x7E]/g, '_');
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,15 @@ import php from 'highlight.js/lib/languages/php';
 // Import MUI styles
 import { getHomepageHTML, getMuiCSS, getMarkdownStyles } from './muiStyles';
 
+// Import browser viewer templates
+import {
+  renderTextViewerPage,
+  renderEncryptedLandingPage,
+  renderOneTimeInterstitialPage,
+  renderErrorPage,
+  getHljsThemeStyles,
+} from './viewerTemplates';
+
 // Import analytics
 import { createAnalytics, WorkerAnalytics } from './analytics';
 
@@ -98,6 +107,211 @@ const ONE_TIME_PREFIX = 'onetime-';
 
 // Maximum upload size for standard (non-multipart) uploads: 25MB
 const MAX_STANDARD_UPLOAD_SIZE = 25 * 1024 * 1024;
+
+// Pastes larger than this skip server-side syntax highlighting (escaped <pre> only)
+const VIEWER_HIGHLIGHT_MAX_SIZE = 500 * 1024;
+
+// Pastes larger than this skip the HTML viewer entirely and stream raw bytes
+const VIEWER_MAX_SIZE = 5 * 1024 * 1024;
+
+// Map of filename extensions to registered highlight.js language names
+const EXTENSION_LANGUAGE_MAP: Record<string, string> = {
+  js: 'javascript',
+  mjs: 'javascript',
+  cjs: 'javascript',
+  jsx: 'javascript',
+  ts: 'typescript',
+  tsx: 'typescript',
+  py: 'python',
+  json: 'json',
+  xml: 'xml',
+  html: 'html',
+  htm: 'html',
+  svg: 'xml',
+  css: 'css',
+  md: 'markdown',
+  markdown: 'markdown',
+  sh: 'bash',
+  bash: 'bash',
+  zsh: 'bash',
+  yml: 'yaml',
+  yaml: 'yaml',
+  sql: 'sql',
+  java: 'java',
+  c: 'cpp',
+  h: 'cpp',
+  cc: 'cpp',
+  cpp: 'cpp',
+  cxx: 'cpp',
+  hpp: 'cpp',
+  go: 'go',
+  rs: 'rust',
+  rb: 'ruby',
+  php: 'php',
+};
+
+// Map of content types to registered highlight.js language names
+const CONTENT_TYPE_LANGUAGE_MAP: Record<string, string> = {
+  'application/json': 'json',
+  'application/javascript': 'javascript',
+  'application/xml': 'xml',
+  'text/javascript': 'javascript',
+  'text/html': 'html',
+  'text/css': 'css',
+  'text/xml': 'xml',
+  'text/x-python': 'python',
+  'text/x-shellscript': 'bash',
+  'text/yaml': 'yaml',
+  'text/x-yaml': 'yaml',
+};
+
+/**
+ * Normalizes a string read from R2 custom metadata. Undefined values can be
+ * stringified to "undefined" on write, so treat those as empty.
+ */
+function cleanMetadataString(value: string | undefined): string {
+  if (!value || value === 'undefined' || value === 'null') {
+    return '';
+  }
+  return value;
+}
+
+/**
+ * Strips undefined values from a metadata object so they are not stringified
+ * to the literal "undefined" when stored as R2 custom metadata.
+ */
+function toCustomMetadata(metadata: PasteMetadata): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    if (value !== undefined && value !== null) {
+      result[key] = String(value);
+    }
+  }
+  return result;
+}
+
+/**
+ * Determines whether the client is a browser expecting an HTML page.
+ * Browsers send Accept headers containing "text/html"; curl and node fetch
+ * default to "*\/*", so CLI/programmatic clients keep receiving raw content.
+ */
+function requestAcceptsHtml(request: Request): boolean {
+  return (request.headers.get('Accept') || '').includes('text/html');
+}
+
+/**
+ * Determines whether a content type is text-like and eligible for the
+ * universal browser text viewer.
+ */
+function isTextualContentType(contentType: string): boolean {
+  const ct = contentType.toLowerCase().split(';')[0].trim();
+  return (
+    ct.startsWith('text/') ||
+    ct === 'application/json' ||
+    ct === 'application/xml' ||
+    ct === 'application/javascript'
+  );
+}
+
+/**
+ * Picks a highlight.js language for a paste based on its filename extension,
+ * falling back to its content type. Returns null when unknown (auto-detect).
+ */
+function detectViewerLanguage(filename: string, contentType: string): string | null {
+  const extMatch = filename.toLowerCase().match(/\.([a-z0-9]+)$/);
+  if (extMatch && EXTENSION_LANGUAGE_MAP[extMatch[1]]) {
+    return EXTENSION_LANGUAGE_MAP[extMatch[1]];
+  }
+  const ct = contentType.toLowerCase().split(';')[0].trim();
+  return CONTENT_TYPE_LANGUAGE_MAP[ct] || null;
+}
+
+/**
+ * Builds the universal text viewer HTML for a text-like paste, applying
+ * server-side syntax highlighting with safe fallbacks.
+ * @param textContent Decoded paste text
+ * @param pasteId Paste ID
+ * @param filename Filename for display/language detection (may be empty)
+ * @param contentType Stored content type
+ * @param sizeBytes Paste size in bytes
+ * @param isOneTime Whether the paste is one-time
+ */
+function buildTextViewerHtml(
+  textContent: string,
+  pasteId: string,
+  filename: string,
+  contentType: string,
+  sizeBytes: number,
+  isOneTime: boolean
+): string {
+  let highlightedHtml: string;
+  let language = 'plaintext';
+  const highlightingSkipped = sizeBytes > VIEWER_HIGHLIGHT_MAX_SIZE;
+
+  if (highlightingSkipped) {
+    highlightedHtml = escapeHtml(textContent);
+  } else {
+    try {
+      const knownLanguage = detectViewerLanguage(filename, contentType);
+      if (knownLanguage && hljs.getLanguage(knownLanguage)) {
+        highlightedHtml = hljs.highlight(textContent, {
+          language: knownLanguage,
+        }).value;
+        language = knownLanguage;
+      } else {
+        const result = hljs.highlightAuto(textContent);
+        highlightedHtml = result.value;
+        language = result.language || 'plaintext';
+      }
+    } catch (err) {
+      console.error(`[VIEWER] Syntax highlighting failed for ${pasteId}:`, err);
+      highlightedHtml = escapeHtml(textContent);
+      language = 'plaintext';
+    }
+  }
+
+  return renderTextViewerPage({
+    pasteId,
+    filename,
+    contentType,
+    sizeBytes,
+    highlightedHtml,
+    lineCount: textContent.split('\n').length,
+    language,
+    highlightingSkipped,
+    isOneTime,
+  });
+}
+
+/** Standard headers for browser-facing viewer HTML responses */
+function htmlViewerHeaders(extra: Record<string, string> = {}): Record<string, string> {
+  return {
+    'Content-Type': 'text/html; charset=utf-8',
+    'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0',
+    'CDN-Cache-Control': 'no-store',
+    'Surrogate-Control': 'no-store',
+    Pragma: 'no-cache',
+    Expires: '0',
+    ...extra,
+  };
+}
+
+/**
+ * Builds a "paste not found" response: a styled HTML page for browsers,
+ * plain text for CLI/programmatic clients.
+ */
+function notFoundResponse(
+  request: Request,
+  message = 'Paste not found - it may have expired or was a one-time paste that has already been viewed.'
+): Response {
+  if (requestAcceptsHtml(request)) {
+    return new Response(renderErrorPage({ title: 'Paste not found', message }), {
+      status: 404,
+      headers: htmlViewerHeaders(),
+    });
+  }
+  return new Response('Paste not found', { status: 404 });
+}
 
 // Allowed CORS origin (restrict from wildcard)
 const ALLOWED_ORIGIN = 'https://paste.d3d.dev';
@@ -358,12 +572,23 @@ async function handleRequest(request: Request, env: Env, ctx: ExecutionContext):
       // Track homepage view
       await analytics.trackHomepageView(request);
 
-      return new Response(generateHomepage(url.origin), {
+      return new Response(generateHomepage(), {
         headers: {
           'Content-Type': 'text/html',
           'Access-Control-Allow-Origin': '*',
         },
       });
+    }
+
+    if (requestAcceptsHtml(request)) {
+      return new Response(
+        renderErrorPage({
+          title: 'Page not found',
+          message:
+            'The page you requested does not exist. If you followed a paste link, it may have expired or was a one-time paste that has already been viewed.',
+        }),
+        { status: 404, headers: htmlViewerHeaders() }
+      );
     }
 
     return new Response('Not found', { status: 404 });
@@ -372,299 +597,11 @@ async function handleRequest(request: Request, env: Env, ctx: ExecutionContext):
   return new Response('Method not allowed', { status: 405 });
 }
 
-function generateHomepage(origin: string): string {
-  // Use the MUI styled homepage HTML
+/**
+ * Generates the homepage HTML using the MUI styled template.
+ */
+function generateHomepage(): string {
   return getHomepageHTML();
-  /* REMOVED TAILWIND HTML - Replaced with MUI version from muiStyles.ts
-<html lang="en">
-<head>
-  <title>DedPaste - Secure Pastebin Service</title>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="DedPaste - A secure pastebin service with end-to-end encryption, PGP integration, and CLI client">
-  <link rel="stylesheet" href="/styles.css">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500&display=swap">
-</head>
-<body class="bg-dark-900 text-gray-100 min-h-screen">
-  <header class="border-b border-dark-700 py-6">
-    <div class="container mx-auto px-4 md:px-6">
-      <div class="flex items-center justify-between">
-        <h1 class="text-3xl md:text-4xl font-bold text-white">
-          <span class="text-primary-400">Ded</span>Paste
-        </h1>
-        <div class="flex items-center space-x-4">
-          <a href="https://github.com/anoncam/dedpaste" target="_blank" rel="noopener noreferrer" class="btn-secondary">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="w-5 h-5 mr-2">
-              <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path>
-            </svg>
-            GitHub
-          </a>
-          <a href="#install" class="btn-primary">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="w-5 h-5 mr-2">
-              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-              <polyline points="7 10 12 15 17 10"></polyline>
-              <line x1="12" y1="15" x2="12" y2="3"></line>
-            </svg>
-            Install
-          </a>
-        </div>
-      </div>
-    </div>
-  </header>
-
-  <main class="container mx-auto px-4 md:px-6 py-8">
-    <section class="mb-16">
-      <div class="max-w-3xl mx-auto text-center mb-12">
-        <h2 class="text-3xl md:text-4xl font-bold text-white mb-4">Secure Pastebin with Advanced Encryption</h2>
-        <p class="text-xl text-gray-300">A powerful CLI tool for sharing text and files with end-to-end encryption, PGP support, and one-time pastes.</p>
-      </div>
-
-      <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-        <div class="card">
-          <div class="mb-4">
-            <span class="feature-tag">End-to-End Encryption</span>
-          </div>
-          <h3 class="text-xl font-semibold text-white mb-2">Keep Your Content Private</h3>
-          <p class="text-gray-300">All encryption happens client-side. The server never sees your unencrypted content or keys.</p>
-        </div>
-        
-        <div class="card">
-          <div class="mb-4">
-            <span class="feature-tag">PGP Integration</span>
-          </div>
-          <h3 class="text-xl font-semibold text-white mb-2">Use Your Existing Keys</h3>
-          <p class="text-gray-300">Leverage PGP keys from keyservers, GPG keyring, or Keybase for trusted communications.</p>
-        </div>
-        
-        <div class="card">
-          <div class="mb-4">
-            <span class="feature-tag">One-Time Pastes</span>
-          </div>
-          <h3 class="text-xl font-semibold text-white mb-2">Self-Destructing Content</h3>
-          <p class="text-gray-300">Create pastes that automatically delete after being viewed once.</p>
-        </div>
-        
-        <div class="card">
-          <div class="mb-4">
-            <span class="feature-tag">Binary Support</span>
-          </div>
-          <h3 class="text-xl font-semibold text-white mb-2">Beyond Just Text</h3>
-          <p class="text-gray-300">Upload and share binary files with proper content type detection.</p>
-        </div>
-        
-        <div class="card">
-          <div class="mb-4">
-            <span class="feature-tag">Friend-to-Friend</span>
-          </div>
-          <h3 class="text-xl font-semibold text-white mb-2">Secure Sharing</h3>
-          <p class="text-gray-300">Easily manage keys for your friends and encrypt content specifically for them.</p>
-        </div>
-        
-        <div class="card">
-          <div class="mb-4">
-            <span class="feature-tag">CLI Power</span>
-          </div>
-          <h3 class="text-xl font-semibold text-white mb-2">Advanced Scripting</h3>
-          <p class="text-gray-300">Command-line interface for easy integration with your existing scripts and workflows.</p>
-        </div>
-      </div>
-    </section>
-
-    <section id="install" class="mb-16">
-      <div class="max-w-3xl mx-auto">
-        <h2 class="text-2xl md:text-3xl font-bold text-white mb-6 pb-2 border-b border-dark-700">Installation</h2>
-        
-        <div class="mb-8">
-          <h3 class="text-xl font-semibold text-white mb-4">Using npm (recommended)</h3>
-          <pre><code>npm install -g dedpaste</code></pre>
-        </div>
-        
-        <div class="mb-8">
-          <h3 class="text-xl font-semibold text-white mb-4">From source</h3>
-          <pre><code>git clone https://github.com/anoncam/dedpaste.git
-cd dedpaste
-npm install
-npm link</code></pre>
-        </div>
-      </div>
-    </section>
-
-    <section class="mb-16">
-      <div class="max-w-4xl mx-auto">
-        <h2 class="text-2xl md:text-3xl font-bold text-white mb-6 pb-2 border-b border-dark-700">Quick Start Examples</h2>
-        
-        <div class="grid md:grid-cols-2 gap-6 mb-8">
-          <div class="card">
-            <h3 class="text-xl font-semibold text-white mb-4">Basic Usage</h3>
-            <pre><code># Create a paste from stdin
-echo "Hello, World!" | dedpaste
-
-# Create a paste from a file
-dedpaste < file.txt
-
-# Create a one-time paste
-echo "Secret content" | dedpaste --temp
-
-# Specify file explicitly
-dedpaste --file path/to/file.txt</code></pre>
-          </div>
-          
-          <div class="card">
-            <h3 class="text-xl font-semibold text-white mb-4">Encryption</h3>
-            <pre><code># Generate your key pair first
-dedpaste keys --gen-key
-
-# Create encrypted paste
-echo "Secret data" | dedpaste --encrypt
-
-# Encrypt for a friend
-echo "For Alice" | dedpaste send --encrypt --for alice
-
-# Use PGP encryption
-echo "PGP Secret" | dedpaste send --encrypt --for user@example.com --pgp</code></pre>
-          </div>
-        </div>
-        
-        <div class="grid md:grid-cols-2 gap-6">
-          <div class="card">
-            <h3 class="text-xl font-semibold text-white mb-4">Key Management</h3>
-            <pre><code># Enhanced interactive key management (recommended)
-dedpaste keys:enhanced
-
-# List all your keys
-dedpaste keys --list
-
-# Add a friend's public key
-dedpaste keys --add-friend alice --key-file alice.pem
-
-# Add a PGP key from keyservers
-dedpaste keys --pgp-key user@example.com
-
-# Add a Keybase user's key
-dedpaste keys --keybase username</code></pre>
-          </div>
-          
-          <div class="card">
-            <h3 class="text-xl font-semibold text-white mb-4">Retrieving Pastes</h3>
-            <pre><code># Get and display a paste
-dedpaste get https://paste.d3d.dev/AbCdEfGh
-
-# Get and decrypt an encrypted paste
-dedpaste get https://paste.d3d.dev/e/AbCdEfGh
-
-# Use a specific key file
-dedpaste get https://paste.d3d.dev/e/AbCdEfGh --key-file private.pem</code></pre>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <section class="mb-16">
-      <div class="max-w-4xl mx-auto">
-        <h2 class="text-2xl md:text-3xl font-bold text-white mb-6 pb-2 border-b border-dark-700">Troubleshooting</h2>
-        
-        <div class="space-y-6">
-          <div class="card">
-            <h3 class="text-xl font-semibold text-white mb-4">Common PGP Errors</h3>
-            <div class="space-y-4">
-              <div>
-                <p class="text-danger font-semibold mb-1">Error: PGP encryption requires a recipient</p>
-                <p class="text-gray-300">Always specify a recipient when using PGP encryption:</p>
-                <pre><code>echo "secret" | dedpaste send --encrypt --for user@example.com --pgp</code></pre>
-              </div>
-              
-              <div>
-                <p class="text-danger font-semibold mb-1">Error: Failed to find PGP key for recipient</p>
-                <p class="text-gray-300">Make sure you've added the recipient's PGP key first:</p>
-                <pre><code>dedpaste keys --pgp-key user@example.com</code></pre>
-              </div>
-            </div>
-          </div>
-          
-          <div class="card">
-            <h3 class="text-xl font-semibold text-white mb-4">Key Management Issues</h3>
-            <div class="space-y-4">
-              <div>
-                <p class="text-danger font-semibold mb-1">Error: No personal key found</p>
-                <p class="text-gray-300">Generate your key pair first:</p>
-                <pre><code>dedpaste keys --gen-key</code></pre>
-              </div>
-              
-              <div>
-                <p class="text-danger font-semibold mb-1">Error: Friend not found in key database</p>
-                <p class="text-gray-300">Add the friend's key before encrypting for them:</p>
-                <pre><code>dedpaste keys --add-friend name --key-file path/to/key.pem</code></pre>
-              </div>
-            </div>
-          </div>
-          
-          <div class="card">
-            <h3 class="text-xl font-semibold text-white mb-4">CLI Parameter Issues</h3>
-            <div class="space-y-4">
-              <div>
-                <p class="text-danger font-semibold mb-1">Error: File not found with --file flag</p>
-                <p class="text-gray-300">Double-check the file path and use quotes for paths with spaces:</p>
-                <pre><code>dedpaste --file "path/to/my file.txt"</code></pre>
-              </div>
-              
-              <div>
-                <p class="text-danger font-semibold mb-1">Error: --for is required when using --pgp</p>
-                <p class="text-gray-300">PGP encryption always requires specifying a recipient:</p>
-                <pre><code>dedpaste send --encrypt --for recipient@example.com --pgp</code></pre>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <section class="mb-16">
-      <div class="max-w-3xl mx-auto">
-        <h2 class="text-2xl md:text-3xl font-bold text-white mb-6 pb-2 border-b border-dark-700">API Usage</h2>
-        
-        <pre><code># Post content
-curl -X POST -H "Content-Type: text/plain" --data "Your content here" ${origin}/upload
-
-# Post one-time content
-curl -X POST -H "Content-Type: text/plain" --data "Your content here" ${origin}/temp
-
-# Post encrypted content (client-side encryption)
-curl -X POST -H "Content-Type: text/plain" --data "Your encrypted content" ${origin}/e/upload
-
-# Post encrypted one-time content
-curl -X POST -H "Content-Type: text/plain" --data "Your encrypted content" ${origin}/e/temp
-
-# Get content
-curl ${origin}/{paste-id}
-
-# Get encrypted content (requires client-side decryption)
-curl ${origin}/e/{paste-id}</code></pre>
-      </div>
-    </section>
-  </main>
-
-  <footer class="bg-dark-800 border-t border-dark-700 py-8">
-    <div class="container mx-auto px-4 md:px-6">
-      <div class="grid md:grid-cols-2 gap-8">
-        <div>
-          <h3 class="text-xl font-semibold text-white mb-4">DedPaste</h3>
-          <p class="text-gray-300 mb-4">A secure pastebin service with end-to-end encryption and advanced PGP integration.</p>
-          <p class="text-gray-400">&copy; ${new Date().getFullYear()} - ISC License</p>
-        </div>
-        
-        <div>
-          <h3 class="text-xl font-semibold text-white mb-4">Resources</h3>
-          <ul class="space-y-2">
-            <li><a href="https://github.com/anoncam/dedpaste" class="text-primary-400 hover:text-primary-300">GitHub Repository</a></li>
-            <li><a href="https://github.com/anoncam/dedpaste/issues" class="text-primary-400 hover:text-primary-300">Report Issues</a></li>
-            <li><a href="https://github.com/anoncam/dedpaste#contributing" class="text-primary-400 hover:text-primary-300">Contributing Guide</a></li>
-            <li><a href="https://www.npmjs.com/package/dedpaste" class="text-primary-400 hover:text-primary-300">NPM Package</a></li>
-          </ul>
-        </div>
-      </div>
-    </div>
-  */
 }
 
 async function handleUpload(
@@ -730,7 +667,7 @@ async function handleUpload(
 
     // Store the content in R2 with the prefixed key
     await env.PASTE_BUCKET.put(storageKey, content, {
-      customMetadata: metadata as any,
+      customMetadata: toCustomMetadata(metadata),
     });
 
     console.log(
@@ -751,7 +688,7 @@ async function handleUpload(
 
     // Store the content in R2 with metadata
     await env.PASTE_BUCKET.put(id, content, {
-      customMetadata: metadata as any,
+      customMetadata: toCustomMetadata(metadata),
     });
 
     console.log(
@@ -810,6 +747,12 @@ async function handleGet(
   // Check for raw parameter to bypass markdown rendering
   const url = new URL(request.url);
   const wantsRaw = url.searchParams.get('raw') === 'true';
+  // download=true forces a Content-Disposition: attachment on raw responses
+  const wantsDownload = url.searchParams.get('download') === 'true';
+  // confirm=true acknowledges the one-time interstitial and consumes the paste
+  const confirmedOneTime = url.searchParams.get('confirm') === 'true';
+  // Browser clients (Accept: text/html) get HTML viewer pages unless raw was requested
+  const wantsBrowserView = requestAcceptsHtml(request) && !wantsRaw;
   // First, check if this is a one-time paste by trying to get it with the one-time prefix
   const oneTimeKey = `${ONE_TIME_PREFIX}${id}`;
   console.log(
@@ -834,6 +777,22 @@ async function handleGet(
         // Ignore errors
       }
 
+      if (requestAcceptsHtml(request)) {
+        return new Response(
+          renderErrorPage({
+            title: 'Paste not found',
+            message: 'This one-time paste has already been viewed and is no longer available.',
+          }),
+          {
+            status: 404,
+            headers: htmlViewerHeaders({
+              'X-One-Time': 'true',
+              'X-Already-Viewed': 'true',
+            }),
+          }
+        );
+      }
+
       return new Response(
         'This one-time paste has already been viewed and is no longer available.',
         {
@@ -848,6 +807,45 @@ async function handleGet(
             'X-Already-Viewed': 'true',
           },
         }
+      );
+    }
+
+    // For browser page loads, never consume the paste immediately.
+    // Encrypted one-time pastes get the encrypted landing page; all others
+    // get a confirmation interstitial whose reveal button re-requests the
+    // paste with ?confirm=true&raw=true (that request runs the normal
+    // consume-and-delete flow below). Link-preview bots don't execute JS,
+    // so they can no longer burn one-time pastes before the recipient.
+    if (wantsBrowserView && (isEncrypted || !confirmedOneTime)) {
+      let metaContentType = 'text/plain';
+      let metaFilename = '';
+      try {
+        const metadata = oneTimePaste.customMetadata as unknown as PasteMetadata;
+        metaContentType = cleanMetadataString(metadata.contentType) || 'text/plain';
+        metaFilename = cleanMetadataString(metadata.filename);
+      } catch (err) {
+        console.error(`[TEMP PASTE] Error reading metadata for interstitial ${id}: ${err}`);
+      }
+
+      if (isEncrypted) {
+        return new Response(
+          renderEncryptedLandingPage({
+            pasteId: id,
+            pasteUrl: `${url.origin}/e/${id}`,
+            isOneTime: true,
+          }),
+          { headers: htmlViewerHeaders({ 'X-One-Time': 'true' }) }
+        );
+      }
+
+      return new Response(
+        renderOneTimeInterstitialPage({
+          pasteId: id,
+          filename: urlFilename || metaFilename,
+          contentType: metaContentType,
+          sizeBytes: oneTimePaste.size,
+        }),
+        { headers: htmlViewerHeaders({ 'X-One-Time': 'true' }) }
       );
     }
 
@@ -876,8 +874,8 @@ async function handleGet(
 
     try {
       const metadata = oneTimePaste.customMetadata as unknown as PasteMetadata;
-      contentType = metadata.contentType || 'text/plain';
-      filename = metadata.filename || '';
+      contentType = cleanMetadataString(metadata.contentType) || 'text/plain';
+      filename = cleanMetadataString(metadata.filename);
       console.log(`[TEMP PASTE] Content type from metadata: ${contentType}, filename: ${filename}`);
     } catch (err) {
       console.error(`[TEMP PASTE] Error retrieving metadata for one-time paste ${id}: ${err}`);
@@ -1030,11 +1028,40 @@ async function handleGet(
       });
     }
 
-    // Determine if content should be displayed inline or downloaded
-    const isViewableInBrowser = isViewableContentType(contentType);
-    const disposition = isViewableInBrowser ? 'inline' : 'attachment';
     const effectiveFilename =
       urlFilename || filename || `${id}${getExtensionForContentType(contentType)}`;
+
+    // Universal text viewer for browsers that confirmed the interstitial
+    // (direct navigation to ?confirm=true; the interstitial's JS fetch
+    // requests raw content instead, so it never reaches this branch)
+    if (
+      wantsBrowserView &&
+      !isEncrypted &&
+      isTextualContentType(contentType) &&
+      content.byteLength <= VIEWER_MAX_SIZE
+    ) {
+      const textContent = new TextDecoder().decode(content);
+      const viewerHtml = buildTextViewerHtml(
+        textContent,
+        id,
+        effectiveFilename,
+        contentType,
+        content.byteLength,
+        true
+      );
+
+      return new Response(viewerHtml, {
+        headers: htmlViewerHeaders({
+          'X-Original-Content-Type': contentType,
+          'X-One-Time': 'true',
+          'X-Paste-Viewed-At': new Date().toISOString(),
+        }),
+      });
+    }
+
+    // Determine if content should be displayed inline or downloaded
+    const isViewableInBrowser = isViewableContentType(contentType);
+    const disposition = wantsDownload || !isViewableInBrowser ? 'attachment' : 'inline';
 
     // Return the content with stronger cache control headers
     return new Response(content, {
@@ -1059,7 +1086,7 @@ async function handleGet(
   const paste = await env.PASTE_BUCKET.get(id);
 
   if (!paste) {
-    return new Response('Paste not found', { status: 404 });
+    return notFoundResponse(request);
   }
 
   // Regular paste - get metadata (available without reading the body)
@@ -1068,8 +1095,8 @@ async function handleGet(
 
   try {
     const metadata = paste.customMetadata as unknown as PasteMetadata;
-    contentType = metadata.contentType || 'text/plain';
-    filename = metadata.filename || '';
+    contentType = cleanMetadataString(metadata.contentType) || 'text/plain';
+    filename = cleanMetadataString(metadata.filename);
     console.log(
       `[REGULAR PASTE] Content type from metadata: ${contentType}, filename: ${filename}`
     );
@@ -1088,6 +1115,20 @@ async function handleGet(
       `[REGULAR PASTE] Overriding content type for encrypted paste from ${contentType} to application/json`
     );
     contentType = 'application/json';
+  }
+
+  // Encrypted pastes: browsers get a landing page explaining client-side
+  // decryption via the CLI; CLI/curl clients (and ?raw=true) keep receiving
+  // the raw ciphertext JSON exactly as before.
+  if (isEncrypted && wantsBrowserView) {
+    return new Response(
+      renderEncryptedLandingPage({
+        pasteId: id,
+        pasteUrl: `${url.origin}/e/${id}`,
+        isOneTime: false,
+      }),
+      { headers: htmlViewerHeaders({ 'X-Encrypted': 'true' }) }
+    );
   }
 
   // Check if this is markdown content that should be rendered as HTML
@@ -1116,9 +1157,36 @@ async function handleGet(
     });
   }
 
+  // Universal text viewer: browsers get a styled, syntax-highlighted page
+  // for any text-like paste. CLI/curl clients and ?raw=true requests keep
+  // receiving the raw bytes. Very large pastes fall through to raw streaming.
+  if (
+    wantsBrowserView &&
+    !isEncrypted &&
+    isTextualContentType(contentType) &&
+    paste.size <= VIEWER_MAX_SIZE
+  ) {
+    const content = await paste.arrayBuffer();
+    const textContent = new TextDecoder().decode(content);
+    const viewerHtml = buildTextViewerHtml(
+      textContent,
+      id,
+      effectiveFilename,
+      contentType,
+      content.byteLength,
+      false
+    );
+
+    return new Response(viewerHtml, {
+      headers: htmlViewerHeaders({
+        'X-Original-Content-Type': contentType,
+      }),
+    });
+  }
+
   // Determine if content should be displayed inline or downloaded
   const isViewableInBrowser = isViewableContentType(contentType);
-  const disposition = isViewableInBrowser ? 'inline' : 'attachment';
+  const disposition = wantsDownload || !isViewableInBrowser ? 'attachment' : 'inline';
 
   // Stream the R2 object body directly to avoid buffering large files in memory.
   // This is critical for multipart-uploaded files which can be up to 5GB.
@@ -1533,99 +1601,9 @@ async function renderMarkdownAsHTML(
       color: #f3f4f6;
     }
     
-    /* Highlight.js theme - GitHub Dark */
-    .hljs {
-      color: #e1e4e8;
-      background: #18171c;
-    }
-    
-    .hljs-doctag,
-    .hljs-keyword,
-    .hljs-meta .hljs-keyword,
-    .hljs-template-tag,
-    .hljs-template-variable,
-    .hljs-type,
-    .hljs-variable.language_ {
-      color: #ff7b72;
-    }
-    
-    .hljs-title,
-    .hljs-title.class_,
-    .hljs-title.class_.inherited__,
-    .hljs-title.function_ {
-      color: #d2a8ff;
-    }
-    
-    .hljs-attr,
-    .hljs-attribute,
-    .hljs-literal,
-    .hljs-meta,
-    .hljs-number,
-    .hljs-operator,
-    .hljs-selector-attr,
-    .hljs-selector-class,
-    .hljs-selector-id,
-    .hljs-variable {
-      color: #79c0ff;
-    }
-    
-    .hljs-meta .hljs-string,
-    .hljs-regexp,
-    .hljs-string {
-      color: #a5d6ff;
-    }
-    
-    .hljs-built_in,
-    .hljs-symbol {
-      color: #ffa657;
-    }
-    
-    .hljs-code,
-    .hljs-comment,
-    .hljs-formula {
-      color: #8b949e;
-    }
-    
-    .hljs-name,
-    .hljs-quote,
-    .hljs-selector-pseudo,
-    .hljs-selector-tag {
-      color: #7ee83f;
-    }
-    
-    .hljs-subst {
-      color: #e1e4e8;
-    }
-    
-    .hljs-section {
-      color: #1f6feb;
-      font-weight: bold;
-    }
-    
-    .hljs-bullet {
-      color: #f2cc60;
-    }
-    
-    .hljs-emphasis {
-      color: #e1e4e8;
-      font-style: italic;
-    }
-    
-    .hljs-strong {
-      color: #e1e4e8;
-      font-weight: bold;
-    }
-    
-    .hljs-addition {
-      color: #aff5b4;
-      background-color: #033a16;
-    }
-    
-    .hljs-deletion {
-      color: #ffdcd7;
-      background-color: #67060c;
-    }
-    
+    /* Highlight.js theme - GitHub Dark (shared with the text viewer) */
+    ${getHljsThemeStyles()}
+
     .markdown-content blockquote {
       border-left: 4px solid #8f8fff;
       padding-left: 1rem;
@@ -1853,7 +1831,7 @@ async function renderMarkdownAsHTML(
 <body>
   <header class="header">
     <div class="header-title">
-      <span class="brand">Ded</span>Paste - Markdown Viewer
+      <span class="brand">Ded</span>Paste &middot; ${escapeHtml(title)}
     </div>
     <div class="paste-info">
       ${filename ? `<span>📄 ${escapeHtml(filename)}</span>` : ''}
@@ -1891,122 +1869,80 @@ async function renderMarkdownAsHTML(
   <script>
     // Store the original markdown content
     const originalMarkdown = ${safeJsonEmbed(markdownContent)};
-    
+
+    // Legacy clipboard fallback using a hidden textarea + execCommand
+    function legacyCopy(text) {
+      const textarea = document.createElement('textarea');
+      textarea.value = text;
+      textarea.style.position = 'fixed';
+      textarea.style.top = '-9999px';
+      document.body.appendChild(textarea);
+      let ok = false;
+      try {
+        textarea.select();
+        ok = document.execCommand('copy');
+      } catch (err) {
+        ok = false;
+      }
+      document.body.removeChild(textarea);
+      return ok;
+    }
+
+    // Copy helper: navigator.clipboard first, execCommand fallback
+    function copyTextToClipboard(text, onSuccess, onFailure) {
+      if (navigator.clipboard && window.isSecureContext) {
+        navigator.clipboard.writeText(text).then(onSuccess).catch(() => {
+          if (legacyCopy(text)) { onSuccess(); } else { onFailure(); }
+        });
+      } else if (legacyCopy(text)) {
+        onSuccess();
+      } else {
+        onFailure();
+      }
+    }
+
+    // Briefly flips a button into its "copied" state
+    function flashCopied(button, label) {
+      const originalText = label.textContent;
+      button.classList.add('copied');
+      label.textContent = 'Copied!';
+      setTimeout(() => {
+        button.classList.remove('copied');
+        label.textContent = originalText;
+      }, 2000);
+    }
+
     // Copy all markdown source to clipboard
     function copyAllMarkdown() {
       const button = document.querySelector('.copy-all-button');
       const buttonText = button.querySelector('.copy-all-text');
-      const originalText = buttonText.textContent;
-      
-      // Create a temporary textarea to copy from
-      const textarea = document.createElement('textarea');
-      textarea.value = originalMarkdown;
-      textarea.style.position = 'fixed';
-      textarea.style.top = '-9999px';
-      document.body.appendChild(textarea);
-      
-      try {
-        // Select and copy the text
-        textarea.select();
-        document.execCommand('copy');
-        
-        // Update button state
-        button.classList.add('copied');
-        buttonText.textContent = 'Copied!';
-        
-        // Reset after 2 seconds
-        setTimeout(() => {
-          button.classList.remove('copied');
-          buttonText.textContent = originalText;
-        }, 2000);
-      } catch (err) {
-        console.error('Failed to copy markdown:', err);
-        // Try modern clipboard API as fallback
-        if (navigator.clipboard && window.isSecureContext) {
-          navigator.clipboard.writeText(originalMarkdown).then(() => {
-            button.classList.add('copied');
-            buttonText.textContent = 'Copied!';
-            setTimeout(() => {
-              button.classList.remove('copied');
-              buttonText.textContent = originalText;
-            }, 2000);
-          }).catch(err => {
-            console.error('Clipboard API also failed:', err);
-            alert('Failed to copy markdown. Please try selecting and copying manually.');
-          });
-        }
-      } finally {
-        document.body.removeChild(textarea);
-      }
+
+      copyTextToClipboard(originalMarkdown, () => {
+        flashCopied(button, buttonText);
+      }, () => {
+        console.error('Failed to copy markdown');
+        alert('Failed to copy markdown. Please try selecting and copying manually.');
+      });
     }
-    
+
+    // Copy an individual code block to clipboard
     function copyCode(blockId) {
       const codeBlock = document.getElementById(blockId);
       const button = document.querySelector(\`button[data-code-id="\${blockId}"]\`);
-      
+
       if (!codeBlock || !button) return;
-      
+
       // Get the text content without HTML tags
       const codeText = codeBlock.textContent || codeBlock.innerText;
-      
-      // Create a temporary textarea to copy from
-      const textarea = document.createElement('textarea');
-      textarea.value = codeText;
-      textarea.style.position = 'fixed';
-      textarea.style.top = '-9999px';
-      document.body.appendChild(textarea);
-      
-      try {
-        // Select and copy the text
-        textarea.select();
-        document.execCommand('copy');
-        
-        // Update button state
-        button.classList.add('copied');
-        const copyText = button.querySelector('.copy-text');
-        const originalText = copyText.textContent;
-        copyText.textContent = 'Copied!';
-        
-        // Reset after 2 seconds
-        setTimeout(() => {
-          button.classList.remove('copied');
-          copyText.textContent = originalText;
-        }, 2000);
-      } catch (err) {
-        console.error('Failed to copy code:', err);
-      } finally {
-        document.body.removeChild(textarea);
-      }
+      const copyText = button.querySelector('.copy-text');
+
+      copyTextToClipboard(codeText, () => {
+        flashCopied(button, copyText);
+      }, () => {
+        console.error('Failed to copy code');
+      });
     }
-    
-    // Alternative modern copy method for browsers that support it
-    if (navigator.clipboard && window.isSecureContext) {
-      window.copyCode = function(blockId) {
-        const codeBlock = document.getElementById(blockId);
-        const button = document.querySelector(\`button[data-code-id="\${blockId}"]\`);
-        
-        if (!codeBlock || !button) return;
-        
-        const codeText = codeBlock.textContent || codeBlock.innerText;
-        
-        navigator.clipboard.writeText(codeText).then(() => {
-          // Update button state
-          button.classList.add('copied');
-          const copyText = button.querySelector('.copy-text');
-          const originalText = copyText.textContent;
-          copyText.textContent = 'Copied!';
-          
-          // Reset after 2 seconds
-          setTimeout(() => {
-            button.classList.remove('copied');
-            copyText.textContent = originalText;
-          }, 2000);
-        }).catch(err => {
-          console.error('Failed to copy code:', err);
-        });
-      };
-    }
-    
+
     // Toggle between code and diagram view for Mermaid blocks
     function toggleMermaidView(mermaidId) {
       const codeView = document.getElementById(mermaidId + '-code');
@@ -2295,7 +2231,7 @@ async function handleWebUpload(request: Request, env: Env): Promise<Response> {
     };
 
     await env.PASTE_BUCKET.put(key, content, {
-      customMetadata: metadata as any,
+      customMetadata: toCustomMetadata(metadata),
     });
 
     const url = `${new URL(request.url).origin}/${id}/${encodeURIComponent(file.name)}`;
@@ -2367,7 +2303,7 @@ async function handleTextUpload(request: Request, env: Env): Promise<Response> {
     };
 
     await env.PASTE_BUCKET.put(key, content, {
-      customMetadata: metadata as any,
+      customMetadata: toCustomMetadata(metadata),
     });
 
     const url = `${new URL(request.url).origin}/${id}/paste.txt`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,7 +112,8 @@ const MAX_STANDARD_UPLOAD_SIZE = 25 * 1024 * 1024;
 const VIEWER_HIGHLIGHT_MAX_SIZE = 500 * 1024;
 
 // Pastes larger than this skip the HTML viewer entirely and stream raw bytes
-const VIEWER_MAX_SIZE = 5 * 1024 * 1024;
+// (kept small because the viewer must buffer the full body in Worker memory)
+const VIEWER_MAX_SIZE = 1024 * 1024;
 
 // Map of filename extensions to registered highlight.js language names
 const EXTENSION_LANGUAGE_MAP: Record<string, string> = {
@@ -575,7 +576,6 @@ async function handleRequest(request: Request, env: Env, ctx: ExecutionContext):
       return new Response(generateHomepage(), {
         headers: {
           'Content-Type': 'text/html',
-          'Access-Control-Allow-Origin': '*',
         },
       });
     }
@@ -1006,7 +1006,7 @@ async function handleGet(
       filename.endsWith('.md') ||
       filename.endsWith('.markdown');
 
-    if (isMarkdown && !isEncrypted && !wantsRaw) {
+    if (isMarkdown && !isEncrypted && wantsBrowserView) {
       // Convert markdown to HTML for browser viewing
       const textContent = new TextDecoder().decode(content);
       const renderedHTML = await renderMarkdownAsHTML(textContent, id, filename, true);
@@ -1138,7 +1138,7 @@ async function handleGet(
     filename.endsWith('.md') ||
     filename.endsWith('.markdown');
 
-  if (isMarkdown && !isEncrypted && !wantsRaw) {
+  if (isMarkdown && !isEncrypted && wantsBrowserView) {
     // Markdown rendering requires buffering the content into memory
     const content = await paste.arrayBuffer();
     const textContent = new TextDecoder().decode(content);
@@ -2120,7 +2120,8 @@ function sanitizeHtml(html: string): string {
   html = html.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '');
   html = html.replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, '');
 
-  // Remove dangerous self-closing/void tags
+  // Remove dangerous self-closing/void tags. svg/math open foreign-content
+  // parsing contexts where script execution is possible, so they are banned too.
   const dangerousTags = [
     'iframe',
     'object',
@@ -2134,6 +2135,8 @@ function sanitizeHtml(html: string): string {
     'link',
     'meta',
     'base',
+    'svg',
+    'math',
   ];
   for (const tag of dangerousTags) {
     const openClose = new RegExp(`<${tag}\\b[^<]*(?:(?!<\\/${tag}>)<[^<]*)*<\\/${tag}>`, 'gi');
@@ -2142,19 +2145,25 @@ function sanitizeHtml(html: string): string {
     html = html.replace(selfClose, '');
   }
 
-  // Remove event handler attributes (on*)
-  html = html.replace(/\s+on\w+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, '');
+  // Remove event handler attributes (on*). The leading character may be
+  // whitespace, a quote closing the previous attribute value, or a slash,
+  // so capture and preserve it rather than requiring whitespace.
+  html = html.replace(/([\s"'/])on\w+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, '$1');
 
-  // Remove javascript: and vbscript: URLs in href/src/action attributes
-  html = html.replace(
-    /(href|src|action)\s*=\s*(?:"[^"]*javascript:[^"]*"|'[^']*javascript:[^']*')/gi,
-    '$1=""'
-  );
-  html = html.replace(
-    /(href|src|action)\s*=\s*(?:"[^"]*vbscript:[^"]*"|'[^']*vbscript:[^']*')/gi,
-    '$1=""'
-  );
-  html = html.replace(/(href|src|action)\s*=\s*(?:"[^"]*data:[^"]*"|'[^']*data:[^']*')/gi, '$1=""');
+  // Remove style attributes (CSS url(javascript:...) and similar vectors)
+  html = html.replace(/([\s"'/])style\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, '$1');
+
+  // Remove javascript:, vbscript:, and data: URLs in href/src/action
+  // attributes — quoted or unquoted
+  for (const scheme of ['javascript', 'vbscript', 'data']) {
+    html = html.replace(
+      new RegExp(
+        `(href|src|action)\\s*=\\s*(?:"[^"]*${scheme}:[^"]*"|'[^']*${scheme}:[^']*'|\\s*${scheme}:[^\\s>]*)`,
+        'gi'
+      ),
+      '$1=""'
+    );
+  }
 
   return html;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2130,14 +2130,11 @@ function sanitizeHtml(html: string): string {
 
 /** Single sanitization pass used by sanitizeHtml's fixpoint loop. */
 function stripDangerousMarkup(html: string): string {
-  // Remove dangerous tags entirely (including content for script/style).
+  // Remove dangerous tags entirely, paired (including content) or stray.
   // End tags may contain whitespace or attributes (</script foo>), so match
-  // <\/tag\b[^>]*> rather than a literal </tag>.
-  html = html.replace(/<script\b[^<]*(?:(?!<\/script\b[^>]*>)<[^<]*)*<\/script\b[^>]*>/gi, '');
-  html = html.replace(/<style\b[^<]*(?:(?!<\/style\b[^>]*>)<[^<]*)*<\/style\b[^>]*>/gi, '');
-
-  // Remove dangerous self-closing/void tags. svg/math open foreign-content
-  // parsing contexts where script execution is possible, so they are banned too.
+  // <\/tag\b[^>]*> rather than a literal </tag>. svg/math open
+  // foreign-content parsing contexts where script execution is possible,
+  // so they are banned too.
   const dangerousTags = [
     'script',
     'style',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,49 +1,49 @@
-import { marked } from "marked";
-import hljs from "highlight.js/lib/core";
+import { marked } from 'marked';
+import hljs from 'highlight.js/lib/core';
 // Import only the languages we want to support to keep bundle size down
-import javascript from "highlight.js/lib/languages/javascript";
-import typescript from "highlight.js/lib/languages/typescript";
-import python from "highlight.js/lib/languages/python";
-import json from "highlight.js/lib/languages/json";
-import xml from "highlight.js/lib/languages/xml"; // HTML, XML
-import css from "highlight.js/lib/languages/css";
-import markdown from "highlight.js/lib/languages/markdown";
-import bash from "highlight.js/lib/languages/bash";
-import yaml from "highlight.js/lib/languages/yaml";
-import sql from "highlight.js/lib/languages/sql";
-import java from "highlight.js/lib/languages/java";
-import cpp from "highlight.js/lib/languages/cpp";
-import go from "highlight.js/lib/languages/go";
-import rust from "highlight.js/lib/languages/rust";
-import ruby from "highlight.js/lib/languages/ruby";
-import php from "highlight.js/lib/languages/php";
+import javascript from 'highlight.js/lib/languages/javascript';
+import typescript from 'highlight.js/lib/languages/typescript';
+import python from 'highlight.js/lib/languages/python';
+import json from 'highlight.js/lib/languages/json';
+import xml from 'highlight.js/lib/languages/xml'; // HTML, XML
+import css from 'highlight.js/lib/languages/css';
+import markdown from 'highlight.js/lib/languages/markdown';
+import bash from 'highlight.js/lib/languages/bash';
+import yaml from 'highlight.js/lib/languages/yaml';
+import sql from 'highlight.js/lib/languages/sql';
+import java from 'highlight.js/lib/languages/java';
+import cpp from 'highlight.js/lib/languages/cpp';
+import go from 'highlight.js/lib/languages/go';
+import rust from 'highlight.js/lib/languages/rust';
+import ruby from 'highlight.js/lib/languages/ruby';
+import php from 'highlight.js/lib/languages/php';
 
 // Import MUI styles
-import { getHomepageHTML, getMuiCSS, getMarkdownStyles } from "./muiStyles";
+import { getHomepageHTML, getMuiCSS, getMarkdownStyles } from './muiStyles';
 
 // Import analytics
-import { createAnalytics, WorkerAnalytics } from "./analytics";
+import { createAnalytics, WorkerAnalytics } from './analytics';
 
 // Register languages with highlight.js
-hljs.registerLanguage("javascript", javascript);
-hljs.registerLanguage("typescript", typescript);
-hljs.registerLanguage("python", python);
-hljs.registerLanguage("json", json);
-hljs.registerLanguage("xml", xml);
-hljs.registerLanguage("html", xml); // HTML is handled by XML
-hljs.registerLanguage("css", css);
-hljs.registerLanguage("markdown", markdown);
-hljs.registerLanguage("bash", bash);
-hljs.registerLanguage("sh", bash); // Shell alias
-hljs.registerLanguage("yaml", yaml);
-hljs.registerLanguage("sql", sql);
-hljs.registerLanguage("java", java);
-hljs.registerLanguage("cpp", cpp);
-hljs.registerLanguage("c++", cpp); // C++ alias
-hljs.registerLanguage("go", go);
-hljs.registerLanguage("rust", rust);
-hljs.registerLanguage("ruby", ruby);
-hljs.registerLanguage("php", php);
+hljs.registerLanguage('javascript', javascript);
+hljs.registerLanguage('typescript', typescript);
+hljs.registerLanguage('python', python);
+hljs.registerLanguage('json', json);
+hljs.registerLanguage('xml', xml);
+hljs.registerLanguage('html', xml); // HTML is handled by XML
+hljs.registerLanguage('css', css);
+hljs.registerLanguage('markdown', markdown);
+hljs.registerLanguage('bash', bash);
+hljs.registerLanguage('sh', bash); // Shell alias
+hljs.registerLanguage('yaml', yaml);
+hljs.registerLanguage('sql', sql);
+hljs.registerLanguage('java', java);
+hljs.registerLanguage('cpp', cpp);
+hljs.registerLanguage('c++', cpp); // C++ alias
+hljs.registerLanguage('go', go);
+hljs.registerLanguage('rust', rust);
+hljs.registerLanguage('ruby', ruby);
+hljs.registerLanguage('php', php);
 
 // Import multipart upload types
 import type {
@@ -55,11 +55,11 @@ import type {
   MultipartCompleteRequest,
   MultipartCompleteResponse,
   UploadStatusResponse,
-} from "./types";
-import { LARGE_FILE_CONSTANTS } from "./types";
+} from './types';
+import { LARGE_FILE_CONSTANTS } from './types';
 
 // Import service layer
-import { createServices, parseDuration } from "./services";
+import { createServices, parseDuration } from './services';
 
 // Import validation
 import {
@@ -67,10 +67,10 @@ import {
   validateWebUpload,
   checkValidation,
   parseJsonBody,
-} from "./validation";
+} from './validation';
 
 // Import API v1 router
-import { routeApiV1 } from "./api/v1";
+import { routeApiV1 } from './api/v1';
 
 // Define the environment interface for Cloudflare Workers
 type Env = {
@@ -94,33 +94,33 @@ type PasteMetadata = {
 
 // For one-time pastes, we'll use a completely different key format
 // with a prefix to make identifying them clear
-const ONE_TIME_PREFIX = "onetime-";
+const ONE_TIME_PREFIX = 'onetime-';
 
 // Maximum upload size for standard (non-multipart) uploads: 25MB
 const MAX_STANDARD_UPLOAD_SIZE = 25 * 1024 * 1024;
 
 // Allowed CORS origin (restrict from wildcard)
-const ALLOWED_ORIGIN = "https://paste.d3d.dev";
+const ALLOWED_ORIGIN = 'https://paste.d3d.dev';
 
 /** Security headers applied to all responses */
 const SECURITY_HEADERS: Record<string, string> = {
-  "X-Content-Type-Options": "nosniff",
-  "X-Frame-Options": "DENY",
-  "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-  "Referrer-Policy": "no-referrer",
-  "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
-  "X-XSS-Protection": "1; mode=block",
+  'X-Content-Type-Options': 'nosniff',
+  'X-Frame-Options': 'DENY',
+  'Strict-Transport-Security': 'max-age=31536000; includeSubDomains',
+  'Referrer-Policy': 'no-referrer',
+  'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
+  'X-XSS-Protection': '1; mode=block',
 };
 
 /** Get CORS origin header based on request origin */
 function getCorsOrigin(request?: Request): string {
   if (!request) return ALLOWED_ORIGIN;
-  const origin = request.headers.get("Origin") || "";
+  const origin = request.headers.get('Origin') || '';
   // Allow the primary domain and localhost for development
   if (
     origin === ALLOWED_ORIGIN ||
-    origin.startsWith("http://localhost:") ||
-    origin.startsWith("http://127.0.0.1:")
+    origin.startsWith('http://localhost:') ||
+    origin.startsWith('http://127.0.0.1:')
   ) {
     return origin;
   }
@@ -134,16 +134,16 @@ function withSecurityHeaders(response: Response, request?: Request): Response {
     newHeaders.set(key, value);
   }
   // Set CSP for HTML responses
-  const contentType = newHeaders.get("Content-Type") || "";
-  if (contentType.includes("text/html")) {
+  const contentType = newHeaders.get('Content-Type') || '';
+  if (contentType.includes('text/html')) {
     newHeaders.set(
-      "Content-Security-Policy",
-      "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self';",
+      'Content-Security-Policy',
+      "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self';"
     );
   }
   // Restrict CORS
-  if (newHeaders.has("Access-Control-Allow-Origin")) {
-    newHeaders.set("Access-Control-Allow-Origin", getCorsOrigin(request));
+  if (newHeaders.has('Access-Control-Allow-Origin')) {
+    newHeaders.set('Access-Control-Allow-Origin', getCorsOrigin(request));
   }
   return new Response(response.body, {
     status: response.status,
@@ -154,11 +154,10 @@ function withSecurityHeaders(response: Response, request?: Request): Response {
 
 // Generate a cryptographically secure random ID for the paste
 function generateId(length = 16): string {
-  const chars =
-    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
   const randomValues = new Uint32Array(length);
   crypto.getRandomValues(randomValues);
-  let result = "";
+  let result = '';
   for (let i = 0; i < length; i++) {
     result += chars.charAt(randomValues[i] % chars.length);
   }
@@ -179,7 +178,7 @@ interface ViewedPasteTracker {
 const viewedPastes: ViewedPasteTracker = {};
 
 // KV namespace key for tracking viewed pastes (to persist across worker restarts/instances)
-const VIEWED_PASTES_KEY = "viewed_pastes_registry";
+const VIEWED_PASTES_KEY = 'viewed_pastes_registry';
 
 // Helper function to safely parse JSON with a default value
 function safeJsonParse<T>(jsonString: string | null, defaultValue: T): T {
@@ -187,27 +186,19 @@ function safeJsonParse<T>(jsonString: string | null, defaultValue: T): T {
   try {
     return JSON.parse(jsonString) as T;
   } catch (e) {
-    console.error("Error parsing JSON:", e);
+    console.error('Error parsing JSON:', e);
     return defaultValue;
   }
 }
 
 export default {
-  async fetch(
-    request: Request,
-    env: Env,
-    ctx: ExecutionContext,
-  ): Promise<Response> {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const response = await handleRequest(request, env, ctx);
     return withSecurityHeaders(response, request);
   },
 };
 
-async function handleRequest(
-  request: Request,
-  env: Env,
-  ctx: ExecutionContext,
-): Promise<Response> {
+async function handleRequest(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
   // Initialize analytics
   const analytics = createAnalytics(env);
 
@@ -218,32 +209,28 @@ async function handleRequest(
   // Initialize viewedPastes from KV store if available (completely optional enhancement)
   try {
     if (env.PASTE_METADATA) {
-      const storedViewedPastes =
-        await env.PASTE_METADATA.get(VIEWED_PASTES_KEY);
+      const storedViewedPastes = await env.PASTE_METADATA.get(VIEWED_PASTES_KEY);
       if (storedViewedPastes) {
-        const parsedPastes = safeJsonParse<ViewedPasteTracker>(
-          storedViewedPastes,
-          {},
-        );
+        const parsedPastes = safeJsonParse<ViewedPasteTracker>(storedViewedPastes, {});
         // Merge with any in-memory pastes (newer ones take precedence)
         Object.assign(viewedPastes, parsedPastes);
       }
     }
   } catch (error) {
     // Log but continue without error - KV is an enhancement, not a requirement
-    console.log("[KV] Optional paste metadata storage not available:", error);
+    console.log('[KV] Optional paste metadata storage not available:', error);
   }
   const url = new URL(request.url);
   const path = url.pathname;
 
   // Handle OPTIONS requests for CORS
-  if (request.method === "OPTIONS") {
+  if (request.method === 'OPTIONS') {
     return new Response(null, {
       headers: {
-        "Access-Control-Allow-Origin": getCorsOrigin(request),
-        "Access-Control-Allow-Methods": "GET, POST, PUT, OPTIONS",
-        "Access-Control-Allow-Headers":
-          "Content-Type, X-Filename, X-Content-Type, X-One-Time, X-Expire, X-Burn-Reads, Authorization",
+        'Access-Control-Allow-Origin': getCorsOrigin(request),
+        'Access-Control-Allow-Methods': 'GET, POST, PUT, OPTIONS',
+        'Access-Control-Allow-Headers':
+          'Content-Type, X-Filename, X-Content-Type, X-One-Time, X-Expire, X-Burn-Reads, Authorization',
       },
     });
   }
@@ -257,25 +244,25 @@ async function handleRequest(
   }
 
   // Upload a new paste
-  if (request.method === "POST") {
+  if (request.method === 'POST') {
     // Handle API uploads for web interface
-    if (path === "/api/upload") {
+    if (path === '/api/upload') {
       return await handleWebUpload(request, env);
     }
 
-    if (path === "/api/text") {
+    if (path === '/api/text') {
       return await handleTextUpload(request, env);
     }
 
     // Handle regular uploads
-    if (path === "/upload" || path === "/temp") {
-      const isOneTime = path === "/temp";
+    if (path === '/upload' || path === '/temp') {
+      const isOneTime = path === '/temp';
       return await handleUpload(request, env, isOneTime, false, analytics);
     }
 
     // Handle encrypted uploads
-    if (path === "/e/upload" || path === "/e/temp") {
-      const isOneTime = path === "/e/temp";
+    if (path === '/e/upload' || path === '/e/temp') {
+      const isOneTime = path === '/e/temp';
       return await handleUpload(request, env, isOneTime, true, analytics);
     }
 
@@ -284,24 +271,17 @@ async function handleRequest(
     // ============================================
 
     // Initialize multipart upload
-    if (path === "/upload/init" || path === "/e/upload/init") {
-      const isEncrypted = path.startsWith("/e/");
+    if (path === '/upload/init' || path === '/e/upload/init') {
+      const isEncrypted = path.startsWith('/e/');
       return await handleMultipartInit(request, env, isEncrypted);
     }
 
     // Complete multipart upload
-    const completeMatch = path.match(
-      /^(\/e)?\/upload\/([a-zA-Z0-9_-]+)\/complete$/,
-    );
+    const completeMatch = path.match(/^(\/e)?\/upload\/([a-zA-Z0-9_-]+)\/complete$/);
     if (completeMatch) {
       const isEncrypted = !!completeMatch[1];
       const sessionId = completeMatch[2];
-      return await handleMultipartComplete(
-        request,
-        env,
-        sessionId,
-        isEncrypted,
-      );
+      return await handleMultipartComplete(request, env, sessionId, isEncrypted);
     }
 
     // Abort multipart upload
@@ -311,35 +291,26 @@ async function handleRequest(
       return await handleMultipartAbort(request, env, sessionId);
     }
 
-    return new Response("Not found", { status: 404 });
+    return new Response('Not found', { status: 404 });
   }
 
   // Handle PUT requests for multipart upload parts
-  if (request.method === "PUT") {
-    const partMatch = path.match(
-      /^(\/e)?\/upload\/([a-zA-Z0-9_-]+)\/part\/(\d+)$/,
-    );
+  if (request.method === 'PUT') {
+    const partMatch = path.match(/^(\/e)?\/upload\/([a-zA-Z0-9_-]+)\/part\/(\d+)$/);
     if (partMatch) {
       const isEncrypted = !!partMatch[1];
       const sessionId = partMatch[2];
       const partNumber = parseInt(partMatch[3], 10);
-      return await handleMultipartPartUpload(
-        request,
-        env,
-        sessionId,
-        partNumber,
-      );
+      return await handleMultipartPartUpload(request, env, sessionId, partNumber);
     }
 
-    return new Response("Not found", { status: 404 });
+    return new Response('Not found', { status: 404 });
   }
 
   // Get a paste
-  if (request.method === "GET") {
+  if (request.method === 'GET') {
     // Handle multipart upload status (for resume)
-    const statusMatch = path.match(
-      /^(\/e)?\/upload\/([a-zA-Z0-9_-]+)\/status$/,
-    );
+    const statusMatch = path.match(/^(\/e)?\/upload\/([a-zA-Z0-9_-]+)\/status$/);
     if (statusMatch) {
       const sessionId = statusMatch[2];
       return await handleMultipartStatus(env, sessionId);
@@ -369,36 +340,36 @@ async function handleRequest(
     }
 
     // Try to serve styles.css directly if [site] configuration doesn't work
-    if (path === "/styles.css") {
+    if (path === '/styles.css') {
       // Serve MUI CSS instead of Tailwind
       const cssContent = getMuiCSS();
 
-      console.log("Serving MUI CSS file");
+      console.log('Serving MUI CSS file');
       return new Response(cssContent, {
         headers: {
-          "Content-Type": "text/css",
-          "Cache-Control": "public, max-age=86400",
+          'Content-Type': 'text/css',
+          'Cache-Control': 'public, max-age=86400',
         },
       });
     }
 
     // Serve the HTML homepage
-    if (path === "/") {
+    if (path === '/') {
       // Track homepage view
       await analytics.trackHomepageView(request);
 
       return new Response(generateHomepage(url.origin), {
         headers: {
-          "Content-Type": "text/html",
-          "Access-Control-Allow-Origin": "*",
+          'Content-Type': 'text/html',
+          'Access-Control-Allow-Origin': '*',
         },
       });
     }
 
-    return new Response("Not found", { status: 404 });
+    return new Response('Not found', { status: 404 });
   }
 
-  return new Response("Method not allowed", { status: 405 });
+  return new Response('Method not allowed', { status: 405 });
 }
 
 function generateHomepage(origin: string): string {
@@ -701,27 +672,27 @@ async function handleUpload(
   env: Env,
   isOneTime: boolean,
   isEncrypted: boolean,
-  analytics?: WorkerAnalytics,
+  analytics?: WorkerAnalytics
 ): Promise<Response> {
-  const contentType = request.headers.get("Content-Type") || "text/plain";
-  const filename = request.headers.get("X-Filename") || "";
+  const contentType = request.headers.get('Content-Type') || 'text/plain';
+  const filename = request.headers.get('X-Filename') || '';
   const content = await request.arrayBuffer();
 
   // Read expiration and burn-after-reading headers
-  const expireDuration = request.headers.get("X-Expire") || undefined;
-  const burnReadsHeader = request.headers.get("X-Burn-Reads");
+  const expireDuration = request.headers.get('X-Expire') || undefined;
+  const burnReadsHeader = request.headers.get('X-Burn-Reads');
   const burnAfterReads = burnReadsHeader ? parseInt(burnReadsHeader, 10) : undefined;
 
   // Check if the content is empty
   if (content.byteLength === 0) {
-    return new Response("Content cannot be empty", { status: 400 });
+    return new Response('Content cannot be empty', { status: 400 });
   }
 
   // Enforce upload size limit for standard uploads
   if (content.byteLength > MAX_STANDARD_UPLOAD_SIZE) {
     return new Response(
       `Content too large. Maximum size is ${MAX_STANDARD_UPLOAD_SIZE / 1024 / 1024}MB for standard uploads. Use multipart upload for larger files.`,
-      { status: 413 },
+      { status: 413 }
     );
   }
 
@@ -730,7 +701,7 @@ async function handleUpload(
 
   // Ensure encrypted content is always stored with the correct content type
   // This fixes issues with one-time encrypted pastes
-  const adjustedContentType = isEncrypted ? "application/json" : contentType;
+  const adjustedContentType = isEncrypted ? 'application/json' : contentType;
 
   // Compute expiration timestamp if duration specified
   let expiresAt: number | undefined;
@@ -763,7 +734,7 @@ async function handleUpload(
     });
 
     console.log(
-      `Created one-time paste with storage key ${storageKey}, isEncrypted=${isEncrypted}, expires=${expiresAt || "never"}`,
+      `Created one-time paste with storage key ${storageKey}, isEncrypted=${isEncrypted}, expires=${expiresAt || 'never'}`
     );
   } else {
     // Regular paste - standard storage path
@@ -783,7 +754,9 @@ async function handleUpload(
       customMetadata: metadata as any,
     });
 
-    console.log(`Created regular paste ${id}, isEncrypted=${isEncrypted}, expires=${expiresAt || "never"}`);
+    console.log(
+      `Created regular paste ${id}, isEncrypted=${isEncrypted}, expires=${expiresAt || 'never'}`
+    );
   }
 
   const baseUrl = new URL(request.url).origin;
@@ -796,10 +769,8 @@ async function handleUpload(
       : `${baseUrl}/${id}/${encodedFilename}`;
   } else {
     // For text pastes without filename, add .txt extension
-    const extension = contentType === "text/plain" ? "/paste.txt" : "";
-    pasteUrl = isEncrypted
-      ? `${baseUrl}/e/${id}${extension}`
-      : `${baseUrl}/${id}${extension}`;
+    const extension = contentType === 'text/plain' ? '/paste.txt' : '';
+    pasteUrl = isEncrypted ? `${baseUrl}/e/${id}${extension}` : `${baseUrl}/${id}${extension}`;
   }
 
   // Track paste creation
@@ -814,14 +785,14 @@ async function handleUpload(
 
   // Build response headers
   const responseHeaders: Record<string, string> = {
-    "Access-Control-Allow-Origin": "*",
-    "Content-Type": "text/plain",
+    'Access-Control-Allow-Origin': '*',
+    'Content-Type': 'text/plain',
   };
   if (expiresAt) {
-    responseHeaders["X-Expires-At"] = new Date(expiresAt).toISOString();
+    responseHeaders['X-Expires-At'] = new Date(expiresAt).toISOString();
   }
   if (burnAfterReads) {
-    responseHeaders["X-Burn-Reads"] = burnAfterReads.toString();
+    responseHeaders['X-Burn-Reads'] = burnAfterReads.toString();
   }
 
   // Return the paste URL - we always use the unprefixed ID in the URL
@@ -834,15 +805,15 @@ async function handleGet(
   ctx: ExecutionContext,
   isEncrypted: boolean,
   request: Request,
-  urlFilename?: string | null,
+  urlFilename?: string | null
 ): Promise<Response> {
   // Check for raw parameter to bypass markdown rendering
   const url = new URL(request.url);
-  const wantsRaw = url.searchParams.get("raw") === "true";
+  const wantsRaw = url.searchParams.get('raw') === 'true';
   // First, check if this is a one-time paste by trying to get it with the one-time prefix
   const oneTimeKey = `${ONE_TIME_PREFIX}${id}`;
   console.log(
-    `[GET] Checking for one-time paste with key: ${oneTimeKey}, isEncrypted=${isEncrypted}`,
+    `[GET] Checking for one-time paste with key: ${oneTimeKey}, isEncrypted=${isEncrypted}`
   );
 
   // Add onlyIf condition to bust caches
@@ -853,7 +824,7 @@ async function handleGet(
     // Check if this paste has already been viewed in this instance
     if (oneTimeKey in viewedPastes) {
       console.log(
-        `[TEMP PASTE] Paste already viewed and pending deletion: ${id}, key=${oneTimeKey}`,
+        `[TEMP PASTE] Paste already viewed and pending deletion: ${id}, key=${oneTimeKey}`
       );
 
       // Double-check by trying to delete it again, just to be sure
@@ -864,20 +835,19 @@ async function handleGet(
       }
 
       return new Response(
-        "This one-time paste has already been viewed and is no longer available.",
+        'This one-time paste has already been viewed and is no longer available.',
         {
           status: 404,
           headers: {
-            "Content-Type": "text/plain",
-            "Cache-Control":
-              "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0",
-            "Surrogate-Control": "no-store",
-            Pragma: "no-cache",
-            Expires: "0",
-            "X-One-Time": "true",
-            "X-Already-Viewed": "true",
+            'Content-Type': 'text/plain',
+            'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0',
+            'Surrogate-Control': 'no-store',
+            Pragma: 'no-cache',
+            Expires: '0',
+            'X-One-Time': 'true',
+            'X-Already-Viewed': 'true',
           },
-        },
+        }
       );
     }
 
@@ -891,44 +861,35 @@ async function handleGet(
     // Store in KV if available (optional enhancement)
     if (env.PASTE_METADATA) {
       try {
-        await env.PASTE_METADATA.put(
-          VIEWED_PASTES_KEY,
-          JSON.stringify(viewedPastes),
-        );
+        await env.PASTE_METADATA.put(VIEWED_PASTES_KEY, JSON.stringify(viewedPastes));
       } catch (error) {
         // Non-blocking error - the in-memory tracking still works
         console.log(`[KV] Optional metadata storage unavailable: ${error}`);
       }
     }
-    console.log(
-      `[TEMP PASTE] Found one-time paste with ID: ${id}, isEncrypted=${isEncrypted}`,
-    );
+    console.log(`[TEMP PASTE] Found one-time paste with ID: ${id}, isEncrypted=${isEncrypted}`);
 
     // Get the content and metadata before we delete the paste
     const content = await oneTimePaste.arrayBuffer();
-    let contentType = "text/plain";
-    let filename = "";
+    let contentType = 'text/plain';
+    let filename = '';
 
     try {
       const metadata = oneTimePaste.customMetadata as unknown as PasteMetadata;
-      contentType = metadata.contentType || "text/plain";
-      filename = metadata.filename || "";
-      console.log(
-        `[TEMP PASTE] Content type from metadata: ${contentType}, filename: ${filename}`,
-      );
+      contentType = metadata.contentType || 'text/plain';
+      filename = metadata.filename || '';
+      console.log(`[TEMP PASTE] Content type from metadata: ${contentType}, filename: ${filename}`);
     } catch (err) {
-      console.error(
-        `[TEMP PASTE] Error retrieving metadata for one-time paste ${id}: ${err}`,
-      );
+      console.error(`[TEMP PASTE] Error retrieving metadata for one-time paste ${id}: ${err}`);
     }
 
     // Override content type if this is an encrypted paste but the content type doesn't match
     // This ensures proper decryption on the client side
-    if (isEncrypted && contentType !== "application/json") {
+    if (isEncrypted && contentType !== 'application/json') {
       console.log(
-        `[TEMP PASTE] Overriding content type for encrypted paste from ${contentType} to application/json`,
+        `[TEMP PASTE] Overriding content type for encrypted paste from ${contentType} to application/json`
       );
-      contentType = "application/json";
+      contentType = 'application/json';
     }
 
     // Delete the paste immediately before returning the content
@@ -936,7 +897,7 @@ async function handleGet(
       // First deletion attempt - force immediate deletion
       await env.PASTE_BUCKET.delete(oneTimeKey);
       console.log(
-        `[TEMP PASTE] First deletion attempt for one-time paste with ID: ${id}, key=${oneTimeKey}, isEncrypted=${isEncrypted}`,
+        `[TEMP PASTE] First deletion attempt for one-time paste with ID: ${id}, key=${oneTimeKey}, isEncrypted=${isEncrypted}`
       );
 
       // Important: Add a small delay to allow propagation in Cloudflare's systems
@@ -945,14 +906,14 @@ async function handleGet(
       // Second deletion attempt to ensure consistency
       await env.PASTE_BUCKET.delete(oneTimeKey);
       console.log(
-        `[TEMP PASTE] Second deletion attempt for one-time paste with ID: ${id}, key=${oneTimeKey}, isEncrypted=${isEncrypted}`,
+        `[TEMP PASTE] Second deletion attempt for one-time paste with ID: ${id}, key=${oneTimeKey}, isEncrypted=${isEncrypted}`
       );
 
       // Verify the deletion worked
       const verifyDeletion = await env.PASTE_BUCKET.get(oneTimeKey);
       if (verifyDeletion) {
         console.error(
-          `[TEMP PASTE] Warning: Failed to delete one-time paste: ${id}, key=${oneTimeKey}`,
+          `[TEMP PASTE] Warning: Failed to delete one-time paste: ${id}, key=${oneTimeKey}`
         );
         // Even though deletion appears to have failed, mark it as viewed in our tracking
         // system to prevent subsequent access
@@ -962,10 +923,7 @@ async function handleGet(
         // Store updated tracking in KV if available
         if (env.PASTE_METADATA) {
           try {
-            await env.PASTE_METADATA.put(
-              VIEWED_PASTES_KEY,
-              JSON.stringify(viewedPastes),
-            );
+            await env.PASTE_METADATA.put(VIEWED_PASTES_KEY, JSON.stringify(viewedPastes));
           } catch (kvError) {
             // Non-blocking - in-memory tracking still works
             console.log(`[KV] Optional metadata update failed: ${kvError}`);
@@ -976,7 +934,7 @@ async function handleGet(
         await env.PASTE_BUCKET.delete(oneTimeKey);
       } else {
         console.log(
-          `[TEMP PASTE] Successfully deleted one-time paste with ID: ${id}, key=${oneTimeKey}`,
+          `[TEMP PASTE] Successfully deleted one-time paste with ID: ${id}, key=${oneTimeKey}`
         );
         viewedPastes[oneTimeKey].deleted = true;
         viewedPastes[oneTimeKey].attempts++;
@@ -984,21 +942,16 @@ async function handleGet(
         // Store updated tracking in KV
         try {
           if (env.PASTE_METADATA) {
-            await env.PASTE_METADATA.put(
-              VIEWED_PASTES_KEY,
-              JSON.stringify(viewedPastes),
-            );
+            await env.PASTE_METADATA.put(VIEWED_PASTES_KEY, JSON.stringify(viewedPastes));
           }
         } catch (kvError) {
           console.error(
-            `[TEMP PASTE] Error updating paste registry after successful deletion: ${kvError}`,
+            `[TEMP PASTE] Error updating paste registry after successful deletion: ${kvError}`
           );
         }
       }
     } catch (error) {
-      console.error(
-        `[TEMP PASTE] Error deleting one-time paste with ID: ${id}: ${error}`,
-      );
+      console.error(`[TEMP PASTE] Error deleting one-time paste with ID: ${id}: ${error}`);
 
       // Schedule multiple backup deletion attempts to make sure it gets deleted
       ctx.waitUntil(
@@ -1011,7 +964,7 @@ async function handleGet(
               const delay = 200 * Math.pow(2, i); // 200ms, 400ms, 800ms, 1600ms, 3200ms
               await new Promise((resolve) => setTimeout(resolve, delay));
               console.log(
-                `[TEMP PASTE] Backup deletion attempt ${i + 1}/${deletionAttempts} for one-time paste ${id}, key=${oneTimeKey}`,
+                `[TEMP PASTE] Backup deletion attempt ${i + 1}/${deletionAttempts} for one-time paste ${id}, key=${oneTimeKey}`
               );
               await env.PASTE_BUCKET.delete(oneTimeKey);
 
@@ -1019,7 +972,7 @@ async function handleGet(
               const checkResult = await env.PASTE_BUCKET.get(oneTimeKey);
               if (!checkResult) {
                 console.log(
-                  `[TEMP PASTE] Backup deletion attempt ${i + 1} successfully deleted one-time paste ${id}`,
+                  `[TEMP PASTE] Backup deletion attempt ${i + 1} successfully deleted one-time paste ${id}`
                 );
 
                 // Update tracking with success
@@ -1029,15 +982,10 @@ async function handleGet(
                 // Store updated tracking in KV if available
                 if (env.PASTE_METADATA) {
                   try {
-                    await env.PASTE_METADATA.put(
-                      VIEWED_PASTES_KEY,
-                      JSON.stringify(viewedPastes),
-                    );
+                    await env.PASTE_METADATA.put(VIEWED_PASTES_KEY, JSON.stringify(viewedPastes));
                   } catch (kvUpdateError) {
                     // Non-blocking - in-memory tracking still works
-                    console.log(
-                      `[KV] Optional metadata backup update failed: ${kvUpdateError}`,
-                    );
+                    console.log(`[KV] Optional metadata backup update failed: ${kvUpdateError}`);
                   }
                 }
 
@@ -1045,72 +993,63 @@ async function handleGet(
               }
             } catch (backupError) {
               console.error(
-                `[TEMP PASTE] Backup deletion attempt ${i + 1} failed for one-time paste ${id}: ${backupError}`,
+                `[TEMP PASTE] Backup deletion attempt ${i + 1} failed for one-time paste ${id}: ${backupError}`
               );
             }
           }
-        })(),
+        })()
       );
     }
 
     // Check if this is markdown content that should be rendered as HTML
     const isMarkdown =
-      contentType === "text/markdown" ||
-      contentType === "text/x-markdown" ||
-      filename.endsWith(".md") ||
-      filename.endsWith(".markdown");
+      contentType === 'text/markdown' ||
+      contentType === 'text/x-markdown' ||
+      filename.endsWith('.md') ||
+      filename.endsWith('.markdown');
 
     if (isMarkdown && !isEncrypted && !wantsRaw) {
       // Convert markdown to HTML for browser viewing
       const textContent = new TextDecoder().decode(content);
-      const renderedHTML = await renderMarkdownAsHTML(
-        textContent,
-        id,
-        filename,
-        true,
-      );
+      const renderedHTML = await renderMarkdownAsHTML(textContent, id, filename, true);
 
       return new Response(renderedHTML, {
         headers: {
-          "Content-Type": "text/html; charset=utf-8",
-          "Access-Control-Allow-Origin": "*",
-          "Cache-Control":
-            "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0",
-          "CDN-Cache-Control": "no-store",
-          "Surrogate-Control": "no-store",
-          Pragma: "no-cache",
-          Expires: "0",
-          "X-Original-Content-Type": contentType,
-          "X-Rendered-Markdown": "true",
-          "X-One-Time": "true",
-          "X-Paste-Viewed-At": new Date().toISOString(),
+          'Content-Type': 'text/html; charset=utf-8',
+          'Access-Control-Allow-Origin': '*',
+          'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0',
+          'CDN-Cache-Control': 'no-store',
+          'Surrogate-Control': 'no-store',
+          Pragma: 'no-cache',
+          Expires: '0',
+          'X-Original-Content-Type': contentType,
+          'X-Rendered-Markdown': 'true',
+          'X-One-Time': 'true',
+          'X-Paste-Viewed-At': new Date().toISOString(),
         },
       });
     }
 
     // Determine if content should be displayed inline or downloaded
     const isViewableInBrowser = isViewableContentType(contentType);
-    const disposition = isViewableInBrowser ? "inline" : "attachment";
+    const disposition = isViewableInBrowser ? 'inline' : 'attachment';
     const effectiveFilename =
-      urlFilename ||
-      filename ||
-      `${id}${getExtensionForContentType(contentType)}`;
+      urlFilename || filename || `${id}${getExtensionForContentType(contentType)}`;
 
     // Return the content with stronger cache control headers
     return new Response(content, {
       headers: {
-        "Content-Type": contentType,
-        "Content-Disposition": `${disposition}; filename="${sanitizeFilename(effectiveFilename)}"`,
-        "Access-Control-Allow-Origin": "*",
-        "Cache-Control":
-          "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0",
-        "CDN-Cache-Control": "no-store", // Additional CDN-specific directive
-        "Surrogate-Control": "no-store", // For Cloudflare and other CDNs
-        Pragma: "no-cache",
-        Expires: "0",
-        "X-Encrypted": isEncrypted ? "true" : "false",
-        "X-One-Time": "true", // Mark as one-time paste explicitly
-        "X-Paste-Viewed-At": new Date().toISOString(), // Add timestamp of viewing
+        'Content-Type': contentType,
+        'Content-Disposition': `${disposition}; filename="${sanitizeFilename(effectiveFilename)}"`,
+        'Access-Control-Allow-Origin': '*',
+        'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0',
+        'CDN-Cache-Control': 'no-store', // Additional CDN-specific directive
+        'Surrogate-Control': 'no-store', // For Cloudflare and other CDNs
+        Pragma: 'no-cache',
+        Expires: '0',
+        'X-Encrypted': isEncrypted ? 'true' : 'false',
+        'X-One-Time': 'true', // Mark as one-time paste explicitly
+        'X-Paste-Viewed-At': new Date().toISOString(), // Add timestamp of viewing
       },
     });
   }
@@ -1120,19 +1059,19 @@ async function handleGet(
   const paste = await env.PASTE_BUCKET.get(id);
 
   if (!paste) {
-    return new Response("Paste not found", { status: 404 });
+    return new Response('Paste not found', { status: 404 });
   }
 
   // Regular paste - get metadata (available without reading the body)
-  let contentType = "text/plain";
-  let filename = "";
+  let contentType = 'text/plain';
+  let filename = '';
 
   try {
     const metadata = paste.customMetadata as unknown as PasteMetadata;
-    contentType = metadata.contentType || "text/plain";
-    filename = metadata.filename || "";
+    contentType = metadata.contentType || 'text/plain';
+    filename = metadata.filename || '';
     console.log(
-      `[REGULAR PASTE] Content type from metadata: ${contentType}, filename: ${filename}`,
+      `[REGULAR PASTE] Content type from metadata: ${contentType}, filename: ${filename}`
     );
   } catch (err) {
     console.error(`Error retrieving metadata for paste ${id}: ${err}`);
@@ -1140,25 +1079,23 @@ async function handleGet(
 
   // Use URL filename if provided, otherwise use stored filename
   const effectiveFilename =
-    urlFilename ||
-    filename ||
-    `${id}${getExtensionForContentType(contentType)}`;
+    urlFilename || filename || `${id}${getExtensionForContentType(contentType)}`;
 
   // Override content type if this is an encrypted paste but the content type doesn't match
   // This ensures proper decryption on the client side
-  if (isEncrypted && contentType !== "application/json") {
+  if (isEncrypted && contentType !== 'application/json') {
     console.log(
-      `[REGULAR PASTE] Overriding content type for encrypted paste from ${contentType} to application/json`,
+      `[REGULAR PASTE] Overriding content type for encrypted paste from ${contentType} to application/json`
     );
-    contentType = "application/json";
+    contentType = 'application/json';
   }
 
   // Check if this is markdown content that should be rendered as HTML
   const isMarkdown =
-    contentType === "text/markdown" ||
-    contentType === "text/x-markdown" ||
-    filename.endsWith(".md") ||
-    filename.endsWith(".markdown");
+    contentType === 'text/markdown' ||
+    contentType === 'text/x-markdown' ||
+    filename.endsWith('.md') ||
+    filename.endsWith('.markdown');
 
   if (isMarkdown && !isEncrypted && !wantsRaw) {
     // Markdown rendering requires buffering the content into memory
@@ -1168,35 +1105,34 @@ async function handleGet(
 
     return new Response(renderedHTML, {
       headers: {
-        "Content-Type": "text/html; charset=utf-8",
-        "Access-Control-Allow-Origin": "*",
-        "Cache-Control":
-          "no-store, no-cache, must-revalidate, proxy-revalidate",
-        Pragma: "no-cache",
-        Expires: "0",
-        "X-Original-Content-Type": contentType,
-        "X-Rendered-Markdown": "true",
+        'Content-Type': 'text/html; charset=utf-8',
+        'Access-Control-Allow-Origin': '*',
+        'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
+        Pragma: 'no-cache',
+        Expires: '0',
+        'X-Original-Content-Type': contentType,
+        'X-Rendered-Markdown': 'true',
       },
     });
   }
 
   // Determine if content should be displayed inline or downloaded
   const isViewableInBrowser = isViewableContentType(contentType);
-  const disposition = isViewableInBrowser ? "inline" : "attachment";
+  const disposition = isViewableInBrowser ? 'inline' : 'attachment';
 
   // Stream the R2 object body directly to avoid buffering large files in memory.
   // This is critical for multipart-uploaded files which can be up to 5GB.
   return new Response(paste.body, {
     headers: {
-      "Content-Type": contentType,
-      "Content-Disposition": `${disposition}; filename="${sanitizeFilename(effectiveFilename)}"`,
-      "Content-Length": paste.size.toString(),
-      "Access-Control-Allow-Origin": "*",
-      "Cache-Control": "no-store, no-cache, must-revalidate, proxy-revalidate",
-      Pragma: "no-cache",
-      Expires: "0",
+      'Content-Type': contentType,
+      'Content-Disposition': `${disposition}; filename="${sanitizeFilename(effectiveFilename)}"`,
+      'Content-Length': paste.size.toString(),
+      'Access-Control-Allow-Origin': '*',
+      'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
+      Pragma: 'no-cache',
+      Expires: '0',
       // Add a header to indicate if the paste is encrypted
-      "X-Encrypted": isEncrypted ? "true" : "false",
+      'X-Encrypted': isEncrypted ? 'true' : 'false',
     },
   });
 }
@@ -1206,14 +1142,14 @@ async function handleGet(
  */
 function isViewableContentType(contentType: string): boolean {
   const viewableTypes = [
-    "text/",
-    "image/",
-    "audio/",
-    "video/",
-    "application/pdf",
-    "application/json",
-    "application/xml",
-    "application/javascript",
+    'text/',
+    'image/',
+    'audio/',
+    'video/',
+    'application/pdf',
+    'application/json',
+    'application/xml',
+    'application/javascript',
   ];
 
   return viewableTypes.some((type) => contentType.startsWith(type));
@@ -1224,37 +1160,37 @@ function isViewableContentType(contentType: string): boolean {
  */
 function getExtensionForContentType(contentType: string): string {
   const extensionMap: { [key: string]: string } = {
-    "text/plain": ".txt",
-    "text/html": ".html",
-    "text/css": ".css",
-    "text/javascript": ".js",
-    "text/markdown": ".md",
-    "text/x-markdown": ".md",
-    "application/json": ".json",
-    "application/xml": ".xml",
-    "application/pdf": ".pdf",
-    "application/zip": ".zip",
-    "application/x-zip-compressed": ".zip",
-    "application/gzip": ".gz",
-    "application/x-tar": ".tar",
-    "application/x-7z-compressed": ".7z",
-    "application/x-rar-compressed": ".rar",
-    "application/octet-stream": ".bin",
-    "image/jpeg": ".jpg",
-    "image/png": ".png",
-    "image/gif": ".gif",
-    "image/svg+xml": ".svg",
-    "image/webp": ".webp",
-    "video/mp4": ".mp4",
-    "video/webm": ".webm",
-    "video/ogg": ".ogv",
-    "audio/mpeg": ".mp3",
-    "audio/ogg": ".ogg",
-    "audio/wav": ".wav",
-    "audio/webm": ".weba",
+    'text/plain': '.txt',
+    'text/html': '.html',
+    'text/css': '.css',
+    'text/javascript': '.js',
+    'text/markdown': '.md',
+    'text/x-markdown': '.md',
+    'application/json': '.json',
+    'application/xml': '.xml',
+    'application/pdf': '.pdf',
+    'application/zip': '.zip',
+    'application/x-zip-compressed': '.zip',
+    'application/gzip': '.gz',
+    'application/x-tar': '.tar',
+    'application/x-7z-compressed': '.7z',
+    'application/x-rar-compressed': '.rar',
+    'application/octet-stream': '.bin',
+    'image/jpeg': '.jpg',
+    'image/png': '.png',
+    'image/gif': '.gif',
+    'image/svg+xml': '.svg',
+    'image/webp': '.webp',
+    'video/mp4': '.mp4',
+    'video/webm': '.webm',
+    'video/ogg': '.ogv',
+    'audio/mpeg': '.mp3',
+    'audio/ogg': '.ogg',
+    'audio/wav': '.wav',
+    'audio/webm': '.weba',
   };
 
-  return extensionMap[contentType] || "";
+  return extensionMap[contentType] || '';
 }
 
 /**
@@ -1268,8 +1204,8 @@ function getExtensionForContentType(contentType: string): string {
 async function renderMarkdownAsHTML(
   markdownContent: string,
   pasteId: string,
-  filename: string = "",
-  isOneTime: boolean = false,
+  filename: string = '',
+  isOneTime: boolean = false
 ): Promise<string> {
   // Create a custom renderer for marked
   const renderer = new marked.Renderer();
@@ -1292,7 +1228,7 @@ async function renderMarkdownAsHTML(
     const blockId = `code-block-${++codeBlockId}`;
 
     // Check if this is a mermaid diagram
-    if (lang === "mermaid") {
+    if (lang === 'mermaid') {
       hasMermaidDiagrams = true;
       const mermaidId = `mermaid-${++mermaidBlockId}`;
 
@@ -1330,7 +1266,7 @@ async function renderMarkdownAsHTML(
 
     // Regular code block handling
     let highlighted: string;
-    let detectedLanguage = lang || "plaintext";
+    let detectedLanguage = lang || 'plaintext';
 
     try {
       if (lang && hljs.getLanguage(lang)) {
@@ -1340,12 +1276,12 @@ async function renderMarkdownAsHTML(
         // Auto-detect language
         const result = hljs.highlightAuto(text);
         highlighted = result.value;
-        detectedLanguage = result.language || "plaintext";
+        detectedLanguage = result.language || 'plaintext';
       }
     } catch (err) {
       // Fallback to plain text if highlighting fails
       highlighted = escapeHtml(text);
-      detectedLanguage = "plaintext";
+      detectedLanguage = 'plaintext';
     }
 
     // Return the highlighted code with a wrapper for the copy button
@@ -1376,10 +1312,10 @@ async function renderMarkdownAsHTML(
   const htmlContent = sanitizeHtml(rawHtmlContent);
 
   // Generate a title from the filename or first heading
-  let title = filename || "Markdown Document";
-  if (title.endsWith(".md")) {
+  let title = filename || 'Markdown Document';
+  if (title.endsWith('.md')) {
     title = title.slice(0, -3);
-  } else if (title.endsWith(".markdown")) {
+  } else if (title.endsWith('.markdown')) {
     title = title.slice(0, -9);
   }
 
@@ -1920,9 +1856,9 @@ async function renderMarkdownAsHTML(
       <span class="brand">Ded</span>Paste - Markdown Viewer
     </div>
     <div class="paste-info">
-      ${filename ? `<span>📄 ${escapeHtml(filename)}</span>` : ""}
+      ${filename ? `<span>📄 ${escapeHtml(filename)}</span>` : ''}
       <span class="paste-id">ID: ${escapeHtml(pasteId)}</span>
-      ${isOneTime ? '<span class="one-time-badge">⚠️ One-Time Paste</span>' : ""}
+      ${isOneTime ? '<span class="one-time-badge">⚠️ One-Time Paste</span>' : ''}
     </div>
   </header>
   
@@ -2231,11 +2167,11 @@ async function renderMarkdownAsHTML(
  */
 function escapeHtml(unsafe: string): string {
   return unsafe
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
 }
 
 /**
@@ -2245,53 +2181,44 @@ function escapeHtml(unsafe: string): string {
  */
 function sanitizeHtml(html: string): string {
   // Remove dangerous tags entirely (including content for script/style)
-  html = html.replace(
-    /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,
-    "",
-  );
-  html = html.replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, "");
+  html = html.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '');
+  html = html.replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, '');
 
   // Remove dangerous self-closing/void tags
   const dangerousTags = [
-    "iframe",
-    "object",
-    "embed",
-    "applet",
-    "form",
-    "input",
-    "textarea",
-    "select",
-    "button",
-    "link",
-    "meta",
-    "base",
+    'iframe',
+    'object',
+    'embed',
+    'applet',
+    'form',
+    'input',
+    'textarea',
+    'select',
+    'button',
+    'link',
+    'meta',
+    'base',
   ];
   for (const tag of dangerousTags) {
-    const openClose = new RegExp(
-      `<${tag}\\b[^<]*(?:(?!<\\/${tag}>)<[^<]*)*<\\/${tag}>`,
-      "gi",
-    );
-    html = html.replace(openClose, "");
-    const selfClose = new RegExp(`<${tag}\\b[^>]*\\/?>`, "gi");
-    html = html.replace(selfClose, "");
+    const openClose = new RegExp(`<${tag}\\b[^<]*(?:(?!<\\/${tag}>)<[^<]*)*<\\/${tag}>`, 'gi');
+    html = html.replace(openClose, '');
+    const selfClose = new RegExp(`<${tag}\\b[^>]*\\/?>`, 'gi');
+    html = html.replace(selfClose, '');
   }
 
   // Remove event handler attributes (on*)
-  html = html.replace(/\s+on\w+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, "");
+  html = html.replace(/\s+on\w+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, '');
 
   // Remove javascript: and vbscript: URLs in href/src/action attributes
   html = html.replace(
     /(href|src|action)\s*=\s*(?:"[^"]*javascript:[^"]*"|'[^']*javascript:[^']*')/gi,
-    '$1=""',
+    '$1=""'
   );
   html = html.replace(
     /(href|src|action)\s*=\s*(?:"[^"]*vbscript:[^"]*"|'[^']*vbscript:[^']*')/gi,
-    '$1=""',
+    '$1=""'
   );
-  html = html.replace(
-    /(href|src|action)\s*=\s*(?:"[^"]*data:[^"]*"|'[^']*data:[^']*')/gi,
-    '$1=""',
-  );
+  html = html.replace(/(href|src|action)\s*=\s*(?:"[^"]*data:[^"]*"|'[^']*data:[^']*')/gi, '$1=""');
 
   return html;
 }
@@ -2301,9 +2228,7 @@ function sanitizeHtml(html: string): string {
  * Escapes </script> and <!-- sequences that could break out of the script context.
  */
 function safeJsonEmbed(value: string): string {
-  return JSON.stringify(value)
-    .replace(/</g, "\\u003c")
-    .replace(/>/g, "\\u003e");
+  return JSON.stringify(value).replace(/</g, '\\u003c').replace(/>/g, '\\u003e');
 }
 
 /**
@@ -2313,9 +2238,9 @@ function safeJsonEmbed(value: string): string {
 function sanitizeFilename(filename: string): string {
   // Remove path traversal, quotes, control characters, and newlines
   return filename
-    .replace(/["\\\r\n]/g, "_")
-    .replace(/\.\.\//g, "")
-    .replace(/[^\x20-\x7E]/g, "_");
+    .replace(/["\\\r\n]/g, '_')
+    .replace(/\.\.\//g, '')
+    .replace(/[^\x20-\x7E]/g, '_');
 }
 
 /**
@@ -2328,15 +2253,15 @@ function sanitizeFilename(filename: string): string {
 async function handleWebUpload(request: Request, env: Env): Promise<Response> {
   try {
     const formData = await request.formData();
-    const file = formData.get("file") as File;
-    const oneTime = formData.get("oneTime") === "true";
+    const file = formData.get('file') as File;
+    const oneTime = formData.get('oneTime') === 'true';
 
     if (!file) {
-      return new Response(JSON.stringify({ error: "No file provided" }), {
+      return new Response(JSON.stringify({ error: 'No file provided' }), {
         status: 400,
         headers: {
-          "Content-Type": "application/json",
-          "Access-Control-Allow-Origin": "*",
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
         },
       });
     }
@@ -2352,10 +2277,10 @@ async function handleWebUpload(request: Request, env: Env): Promise<Response> {
         {
           status: 413,
           headers: {
-            "Content-Type": "application/json",
-            "Access-Control-Allow-Origin": getCorsOrigin(request),
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Origin': getCorsOrigin(request),
           },
-        },
+        }
       );
     }
 
@@ -2363,7 +2288,7 @@ async function handleWebUpload(request: Request, env: Env): Promise<Response> {
     const key = oneTime ? `${ONE_TIME_PREFIX}${id}` : id;
 
     const metadata: PasteMetadata = {
-      contentType: file.type || "application/octet-stream",
+      contentType: file.type || 'application/octet-stream',
       isOneTime: oneTime,
       createdAt: Date.now(),
       filename: file.name,
@@ -2378,16 +2303,16 @@ async function handleWebUpload(request: Request, env: Env): Promise<Response> {
     return new Response(JSON.stringify({ url, id }), {
       status: 200,
       headers: {
-        "Content-Type": "application/json",
-        "Access-Control-Allow-Origin": "*",
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
       },
     });
   } catch (error) {
-    return new Response(JSON.stringify({ error: "Upload failed" }), {
+    return new Response(JSON.stringify({ error: 'Upload failed' }), {
       status: 500,
       headers: {
-        "Content-Type": "application/json",
-        "Access-Control-Allow-Origin": "*",
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
       },
     });
   }
@@ -2405,11 +2330,11 @@ async function handleTextUpload(request: Request, env: Env): Promise<Response> {
     const { content, oneTime } = body;
 
     if (!content) {
-      return new Response(JSON.stringify({ error: "No content provided" }), {
+      return new Response(JSON.stringify({ error: 'No content provided' }), {
         status: 400,
         headers: {
-          "Content-Type": "application/json",
-          "Access-Control-Allow-Origin": getCorsOrigin(request),
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': getCorsOrigin(request),
         },
       });
     }
@@ -2424,10 +2349,10 @@ async function handleTextUpload(request: Request, env: Env): Promise<Response> {
         {
           status: 413,
           headers: {
-            "Content-Type": "application/json",
-            "Access-Control-Allow-Origin": getCorsOrigin(request),
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Origin': getCorsOrigin(request),
           },
-        },
+        }
       );
     }
 
@@ -2435,10 +2360,10 @@ async function handleTextUpload(request: Request, env: Env): Promise<Response> {
     const key = oneTime ? `${ONE_TIME_PREFIX}${id}` : id;
 
     const metadata: PasteMetadata = {
-      contentType: "text/plain",
+      contentType: 'text/plain',
       isOneTime: oneTime,
       createdAt: Date.now(),
-      filename: "paste.txt",
+      filename: 'paste.txt',
     };
 
     await env.PASTE_BUCKET.put(key, content, {
@@ -2450,16 +2375,16 @@ async function handleTextUpload(request: Request, env: Env): Promise<Response> {
     return new Response(JSON.stringify({ url, id }), {
       status: 200,
       headers: {
-        "Content-Type": "application/json",
-        "Access-Control-Allow-Origin": "*",
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
       },
     });
   } catch (error) {
-    return new Response(JSON.stringify({ error: "Upload failed" }), {
+    return new Response(JSON.stringify({ error: 'Upload failed' }), {
       status: 500,
       headers: {
-        "Content-Type": "application/json",
-        "Access-Control-Allow-Origin": "*",
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
       },
     });
   }
@@ -2472,7 +2397,7 @@ async function handleWebDecrypt(
   id: string,
   env: Env,
   ctx: ExecutionContext,
-  request: Request,
+  request: Request
 ): Promise<Response> {
   // For now, just redirect to the regular GET handler
   // In the future, this would handle decryption with provided keys
@@ -2495,10 +2420,7 @@ function generateSessionId(): string {
 /**
  * Get upload session from KV storage.
  */
-async function getUploadSession(
-  env: Env,
-  sessionId: string,
-): Promise<UploadSession | null> {
+async function getUploadSession(env: Env, sessionId: string): Promise<UploadSession | null> {
   if (!env.UPLOAD_SESSIONS) {
     return null;
   }
@@ -2515,16 +2437,13 @@ async function getUploadSession(
 async function saveUploadSession(
   env: Env,
   sessionId: string,
-  session: UploadSession,
+  session: UploadSession
 ): Promise<void> {
   if (!env.UPLOAD_SESSIONS) {
-    throw new Error("UPLOAD_SESSIONS KV namespace not configured");
+    throw new Error('UPLOAD_SESSIONS KV namespace not configured');
   }
   // Set TTL to session expiration time
-  const ttlSeconds = Math.max(
-    60,
-    Math.floor((session.expiresAt - Date.now()) / 1000),
-  );
+  const ttlSeconds = Math.max(60, Math.floor((session.expiresAt - Date.now()) / 1000));
   await env.UPLOAD_SESSIONS.put(sessionId, JSON.stringify(session), {
     expirationTtl: ttlSeconds,
   });
@@ -2546,22 +2465,21 @@ async function deleteUploadSession(env: Env, sessionId: string): Promise<void> {
 async function handleMultipartInit(
   request: Request,
   env: Env,
-  isEncrypted: boolean,
+  isEncrypted: boolean
 ): Promise<Response> {
   // Check if UPLOAD_SESSIONS is configured
   if (!env.UPLOAD_SESSIONS) {
     return new Response(
       JSON.stringify({
-        error:
-          "Large file uploads not configured. UPLOAD_SESSIONS KV namespace required.",
+        error: 'Large file uploads not configured. UPLOAD_SESSIONS KV namespace required.',
       }),
       {
         status: 503,
         headers: {
-          "Content-Type": "application/json",
-          "Access-Control-Allow-Origin": "*",
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
         },
-      },
+      }
     );
   }
 
@@ -2580,16 +2498,15 @@ async function handleMultipartInit(
     if (!filename || !contentType || !totalSize || !totalParts) {
       return new Response(
         JSON.stringify({
-          error:
-            "Missing required fields: filename, contentType, totalSize, totalParts",
+          error: 'Missing required fields: filename, contentType, totalSize, totalParts',
         }),
         {
           status: 400,
           headers: {
-            "Content-Type": "application/json",
-            "Access-Control-Allow-Origin": "*",
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Origin': '*',
           },
-        },
+        }
       );
     }
 
@@ -2602,10 +2519,10 @@ async function handleMultipartInit(
         {
           status: 400,
           headers: {
-            "Content-Type": "application/json",
-            "Access-Control-Allow-Origin": "*",
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Origin': '*',
           },
-        },
+        }
       );
     }
 
@@ -2616,11 +2533,11 @@ async function handleMultipartInit(
     // Create multipart upload in R2
     const multipartUpload = await env.PASTE_BUCKET.createMultipartUpload(key, {
       customMetadata: {
-        contentType: isEncrypted ? "application/json" : contentType,
+        contentType: isEncrypted ? 'application/json' : contentType,
         isOneTime: String(isOneTime),
         createdAt: String(Date.now()),
         filename: filename,
-        isMultipart: "true",
+        isMultipart: 'true',
       },
     });
 
@@ -2632,7 +2549,7 @@ async function handleMultipartInit(
       uploadId: multipartUpload.uploadId,
       key,
       filename,
-      contentType: isEncrypted ? "application/json" : contentType,
+      contentType: isEncrypted ? 'application/json' : contentType,
       totalSize,
       totalParts,
       uploadedParts: [],
@@ -2648,7 +2565,7 @@ async function handleMultipartInit(
 
     console.log(
       `[MULTIPART] Initialized upload session ${sessionId} for paste ${pasteId}, ` +
-        `size=${totalSize}, parts=${totalParts}, encrypted=${isEncrypted}, oneTime=${isOneTime}`,
+        `size=${totalSize}, parts=${totalParts}, encrypted=${isEncrypted}, oneTime=${isOneTime}`
     );
 
     const response: MultipartInitResponse = {
@@ -2661,22 +2578,19 @@ async function handleMultipartInit(
     return new Response(JSON.stringify(response), {
       status: 200,
       headers: {
-        "Content-Type": "application/json",
-        "Access-Control-Allow-Origin": "*",
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
       },
     });
   } catch (error) {
-    console.error("[MULTIPART] Init error:", error);
-    return new Response(
-      JSON.stringify({ error: "Failed to initialize multipart upload" }),
-      {
-        status: 500,
-        headers: {
-          "Content-Type": "application/json",
-          "Access-Control-Allow-Origin": "*",
-        },
+    console.error('[MULTIPART] Init error:', error);
+    return new Response(JSON.stringify({ error: 'Failed to initialize multipart upload' }), {
+      status: 500,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
       },
-    );
+    });
   }
 }
 
@@ -2688,37 +2602,31 @@ async function handleMultipartPartUpload(
   request: Request,
   env: Env,
   sessionId: string,
-  partNumber: number,
+  partNumber: number
 ): Promise<Response> {
   try {
     // Get session
     const session = await getUploadSession(env, sessionId);
     if (!session) {
-      return new Response(
-        JSON.stringify({ error: "Upload session not found or expired" }),
-        {
-          status: 404,
-          headers: {
-            "Content-Type": "application/json",
-            "Access-Control-Allow-Origin": "*",
-          },
+      return new Response(JSON.stringify({ error: 'Upload session not found or expired' }), {
+        status: 404,
+        headers: {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
         },
-      );
+      });
     }
 
     // Check if session has expired
     if (Date.now() > session.expiresAt) {
       await deleteUploadSession(env, sessionId);
-      return new Response(
-        JSON.stringify({ error: "Upload session has expired" }),
-        {
-          status: 410,
-          headers: {
-            "Content-Type": "application/json",
-            "Access-Control-Allow-Origin": "*",
-          },
+      return new Response(JSON.stringify({ error: 'Upload session has expired' }), {
+        status: 410,
+        headers: {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
         },
-      );
+      });
     }
 
     // Validate part number
@@ -2730,17 +2638,15 @@ async function handleMultipartPartUpload(
         {
           status: 400,
           headers: {
-            "Content-Type": "application/json",
-            "Access-Control-Allow-Origin": "*",
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Origin': '*',
           },
-        },
+        }
       );
     }
 
     // Check if part already uploaded
-    const existingPart = session.uploadedParts.find(
-      (p) => p.partNumber === partNumber,
-    );
+    const existingPart = session.uploadedParts.find((p) => p.partNumber === partNumber);
     if (existingPart) {
       // Return existing etag (idempotent)
       const response: PartUploadResponse = {
@@ -2750,29 +2656,20 @@ async function handleMultipartPartUpload(
       return new Response(JSON.stringify(response), {
         status: 200,
         headers: {
-          "Content-Type": "application/json",
-          "Access-Control-Allow-Origin": "*",
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
         },
       });
     }
 
     // Resume multipart upload in R2
-    const multipartUpload = env.PASTE_BUCKET.resumeMultipartUpload(
-      session.key,
-      session.uploadId,
-    );
+    const multipartUpload = env.PASTE_BUCKET.resumeMultipartUpload(session.key, session.uploadId);
 
     // Get content length
-    const contentLength = parseInt(
-      request.headers.get("Content-Length") || "0",
-      10,
-    );
+    const contentLength = parseInt(request.headers.get('Content-Length') || '0', 10);
 
     // Validate minimum part size (except for last part)
-    if (
-      partNumber < session.totalParts &&
-      contentLength < LARGE_FILE_CONSTANTS.MIN_CHUNK_SIZE
-    ) {
+    if (partNumber < session.totalParts && contentLength < LARGE_FILE_CONSTANTS.MIN_CHUNK_SIZE) {
       return new Response(
         JSON.stringify({
           error: `Part size too small. Minimum is ${LARGE_FILE_CONSTANTS.MIN_CHUNK_SIZE / (1024 * 1024)}MB (except for last part)`,
@@ -2780,17 +2677,17 @@ async function handleMultipartPartUpload(
         {
           status: 400,
           headers: {
-            "Content-Type": "application/json",
-            "Access-Control-Allow-Origin": "*",
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Origin': '*',
           },
-        },
+        }
       );
     }
 
     // Upload the part - stream the request body directly to R2
     const uploadedPart = await multipartUpload.uploadPart(
       partNumber,
-      request.body as ReadableStream,
+      request.body as ReadableStream
     );
 
     // Update session with uploaded part
@@ -2808,7 +2705,7 @@ async function handleMultipartPartUpload(
 
     console.log(
       `[MULTIPART] Uploaded part ${partNumber}/${session.totalParts} for session ${sessionId}, ` +
-        `size=${contentLength}, etag=${uploadedPart.etag}`,
+        `size=${contentLength}, etag=${uploadedPart.etag}`
     );
 
     const response: PartUploadResponse = {
@@ -2819,20 +2716,17 @@ async function handleMultipartPartUpload(
     return new Response(JSON.stringify(response), {
       status: 200,
       headers: {
-        "Content-Type": "application/json",
-        "Access-Control-Allow-Origin": "*",
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
       },
     });
   } catch (error) {
-    console.error(
-      `[MULTIPART] Part upload error for session ${sessionId}:`,
-      error,
-    );
-    return new Response(JSON.stringify({ error: "Failed to upload part" }), {
+    console.error(`[MULTIPART] Part upload error for session ${sessionId}:`, error);
+    return new Response(JSON.stringify({ error: 'Failed to upload part' }), {
       status: 500,
       headers: {
-        "Content-Type": "application/json",
-        "Access-Control-Allow-Origin": "*",
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
       },
     });
   }
@@ -2846,22 +2740,19 @@ async function handleMultipartComplete(
   request: Request,
   env: Env,
   sessionId: string,
-  isEncrypted: boolean,
+  isEncrypted: boolean
 ): Promise<Response> {
   try {
     // Get session
     const session = await getUploadSession(env, sessionId);
     if (!session) {
-      return new Response(
-        JSON.stringify({ error: "Upload session not found or expired" }),
-        {
-          status: 404,
-          headers: {
-            "Content-Type": "application/json",
-            "Access-Control-Allow-Origin": "*",
-          },
+      return new Response(JSON.stringify({ error: 'Upload session not found or expired' }), {
+        status: 404,
+        headers: {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
         },
-      );
+      });
     }
 
     // Parse request body
@@ -2877,18 +2768,15 @@ async function handleMultipartComplete(
         {
           status: 400,
           headers: {
-            "Content-Type": "application/json",
-            "Access-Control-Allow-Origin": "*",
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Origin': '*',
           },
-        },
+        }
       );
     }
 
     // Resume multipart upload in R2
-    const multipartUpload = env.PASTE_BUCKET.resumeMultipartUpload(
-      session.key,
-      session.uploadId,
-    );
+    const multipartUpload = env.PASTE_BUCKET.resumeMultipartUpload(session.key, session.uploadId);
 
     // Complete the upload
     // Parts must be sorted by part number
@@ -2921,7 +2809,7 @@ async function handleMultipartComplete(
 
     console.log(
       `[MULTIPART] Completed upload for session ${sessionId}, paste=${pasteId}, ` +
-        `totalSize=${totalSize}, encrypted=${isEncrypted}`,
+        `totalSize=${totalSize}, encrypted=${isEncrypted}`
     );
 
     const response: MultipartCompleteResponse = {
@@ -2933,25 +2821,19 @@ async function handleMultipartComplete(
     return new Response(JSON.stringify(response), {
       status: 200,
       headers: {
-        "Content-Type": "application/json",
-        "Access-Control-Allow-Origin": "*",
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
       },
     });
   } catch (error) {
-    console.error(
-      `[MULTIPART] Complete error for session ${sessionId}:`,
-      error,
-    );
-    return new Response(
-      JSON.stringify({ error: "Failed to complete multipart upload" }),
-      {
-        status: 500,
-        headers: {
-          "Content-Type": "application/json",
-          "Access-Control-Allow-Origin": "*",
-        },
+    console.error(`[MULTIPART] Complete error for session ${sessionId}:`, error);
+    return new Response(JSON.stringify({ error: 'Failed to complete multipart upload' }), {
+      status: 500,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
       },
-    );
+    });
   }
 }
 
@@ -2962,7 +2844,7 @@ async function handleMultipartComplete(
 async function handleMultipartAbort(
   request: Request,
   env: Env,
-  sessionId: string,
+  sessionId: string
 ): Promise<Response> {
   try {
     // Get session
@@ -2972,31 +2854,25 @@ async function handleMultipartAbort(
       return new Response(
         JSON.stringify({
           success: true,
-          message: "Session not found or already cleaned up",
+          message: 'Session not found or already cleaned up',
         }),
         {
           status: 200,
           headers: {
-            "Content-Type": "application/json",
-            "Access-Control-Allow-Origin": "*",
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Origin': '*',
           },
-        },
+        }
       );
     }
 
     try {
       // Resume and abort the R2 multipart upload
-      const multipartUpload = env.PASTE_BUCKET.resumeMultipartUpload(
-        session.key,
-        session.uploadId,
-      );
+      const multipartUpload = env.PASTE_BUCKET.resumeMultipartUpload(session.key, session.uploadId);
       await multipartUpload.abort();
     } catch (e) {
       // Ignore abort errors - upload may already be completed or aborted
-      console.log(
-        `[MULTIPART] Abort R2 upload warning for session ${sessionId}:`,
-        e,
-      );
+      console.log(`[MULTIPART] Abort R2 upload warning for session ${sessionId}:`, e);
     }
 
     // Delete session from KV
@@ -3007,28 +2883,25 @@ async function handleMultipartAbort(
     return new Response(
       JSON.stringify({
         success: true,
-        message: "Upload session aborted and cleaned up",
+        message: 'Upload session aborted and cleaned up',
       }),
       {
         status: 200,
         headers: {
-          "Content-Type": "application/json",
-          "Access-Control-Allow-Origin": "*",
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
         },
-      },
+      }
     );
   } catch (error) {
     console.error(`[MULTIPART] Abort error for session ${sessionId}:`, error);
-    return new Response(
-      JSON.stringify({ error: "Failed to abort multipart upload" }),
-      {
-        status: 500,
-        headers: {
-          "Content-Type": "application/json",
-          "Access-Control-Allow-Origin": "*",
-        },
+    return new Response(JSON.stringify({ error: 'Failed to abort multipart upload' }), {
+      status: 500,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
       },
-    );
+    });
   }
 }
 
@@ -3036,26 +2909,23 @@ async function handleMultipartAbort(
  * Get upload session status (for resume support).
  * GET /upload/:sessionId/status or GET /e/upload/:sessionId/status
  */
-async function handleMultipartStatus(
-  env: Env,
-  sessionId: string,
-): Promise<Response> {
+async function handleMultipartStatus(env: Env, sessionId: string): Promise<Response> {
   try {
     // Get session
     const session = await getUploadSession(env, sessionId);
     if (!session) {
       return new Response(
         JSON.stringify({
-          error: "Upload session not found or expired",
+          error: 'Upload session not found or expired',
           isValid: false,
         }),
         {
           status: 404,
           headers: {
-            "Content-Type": "application/json",
-            "Access-Control-Allow-Origin": "*",
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Origin': '*',
           },
-        },
+        }
       );
     }
 
@@ -3065,16 +2935,16 @@ async function handleMultipartStatus(
       await deleteUploadSession(env, sessionId);
       return new Response(
         JSON.stringify({
-          error: "Upload session has expired",
+          error: 'Upload session has expired',
           isValid: false,
         }),
         {
           status: 410,
           headers: {
-            "Content-Type": "application/json",
-            "Access-Control-Allow-Origin": "*",
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Origin': '*',
           },
-        },
+        }
       );
     }
 
@@ -3084,10 +2954,7 @@ async function handleMultipartStatus(
       : session.key;
 
     // Calculate uploaded bytes
-    const uploadedBytes = session.uploadedParts.reduce(
-      (sum, p) => sum + p.size,
-      0,
-    );
+    const uploadedBytes = session.uploadedParts.reduce((sum, p) => sum + p.size, 0);
 
     const response: UploadStatusResponse = {
       sessionId,
@@ -3103,21 +2970,18 @@ async function handleMultipartStatus(
     return new Response(JSON.stringify(response), {
       status: 200,
       headers: {
-        "Content-Type": "application/json",
-        "Access-Control-Allow-Origin": "*",
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
       },
     });
   } catch (error) {
     console.error(`[MULTIPART] Status error for session ${sessionId}:`, error);
-    return new Response(
-      JSON.stringify({ error: "Failed to get upload status", isValid: false }),
-      {
-        status: 500,
-        headers: {
-          "Content-Type": "application/json",
-          "Access-Control-Allow-Origin": "*",
-        },
+    return new Response(JSON.stringify({ error: 'Failed to get upload status', isValid: false }), {
+      status: 500,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
       },
-    );
+    });
   }
 }

--- a/src/muiStyles.ts
+++ b/src/muiStyles.ts
@@ -2,14 +2,38 @@
 // Since we can't use React components in a Cloudflare Worker,
 // we'll create CSS classes that follow MUI's design system
 
-export const getMuiCSS = () => `
+/**
+ * Package version displayed in the homepage footer.
+ *
+ * NOTE: kept as a constant instead of `import packageJson from "../package.json"`
+ * because pulling package.json into the tsc program shifts the computed rootDir
+ * to the repo root, emitting `dist/src/index.js` instead of `dist/index.js` and
+ * breaking the `main = "dist/index.js"` entry in wrangler.toml. Keep in sync
+ * with package.json (currently bumped by `npm version`).
+ */
+const PACKAGE_VERSION = '1.24.8';
+
+/** Google Fonts stylesheet shared by every server-rendered page. */
+const GOOGLE_FONTS_URL =
+  'https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&family=Roboto+Mono:wght@400;500&display=swap';
+
+/**
+ * Base MUI-flavored CSS.
+ *
+ * @param includeFontImport - When true (default) the Google Fonts "@import"
+ *   is embedded so existing consumers that inline this CSS keep loading
+ *   Roboto. Pages that load the fonts via <link> tags in their <head>
+ *   (e.g. the homepage) should pass false to avoid a render-blocking
+ *   double-fetch.
+ */
+export const getMuiCSS = (includeFontImport = true) => `
   /* MUI Reset and Base Styles */
   *, *::before, *::after {
     box-sizing: border-box;
   }
 
   /* MUI Typography */
-  @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&family=Roboto+Mono:wght@400;500&display=swap');
+  ${includeFontImport ? `@import url('${GOOGLE_FONTS_URL}');` : ''}
 
   :root {
     /* MUI Dark Theme Colors */
@@ -70,9 +94,9 @@ export const getMuiCSS = () => `
     color: var(--mui-palette-text-primary);
   }
 
-  /* Typography Classes */
+  /* Typography Classes (h1-h3 use clamp() so headings scale down on phones) */
   .MuiTypography-h1 {
-    font-size: 6rem;
+    font-size: clamp(2.75rem, 7vw + 1rem, 6rem);
     font-weight: 300;
     line-height: 1.167;
     letter-spacing: -0.01562em;
@@ -80,7 +104,7 @@ export const getMuiCSS = () => `
   }
 
   .MuiTypography-h2 {
-    font-size: 3.75rem;
+    font-size: clamp(2rem, 4.5vw + 0.75rem, 3.75rem);
     font-weight: 300;
     line-height: 1.2;
     letter-spacing: -0.00833em;
@@ -88,7 +112,7 @@ export const getMuiCSS = () => `
   }
 
   .MuiTypography-h3 {
-    font-size: 3rem;
+    font-size: clamp(1.75rem, 3.5vw + 0.6rem, 3rem);
     font-weight: 400;
     line-height: 1.167;
     letter-spacing: 0;
@@ -831,6 +855,287 @@ export const getMarkdownStyles = () => `
   }
 `;
 
+/**
+ * Homepage-only CSS: feature card hover states, the hero terminal window,
+ * and the paste creation panel (tabs, drop zone, loader, result alerts).
+ */
+const getHomepageCSS = () => `
+  /* Feature cards: hover lift implemented in CSS instead of inline JS handlers */
+  .feature-card {
+    height: 100%;
+    cursor: default;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .feature-card {
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .feature-card:hover,
+    .feature-card:focus-within {
+      transform: translateY(-4px);
+      box-shadow: var(--mui-shadows-4);
+    }
+  }
+
+  /* Hero terminal window */
+  .terminal-window {
+    max-width: 720px;
+    margin: var(--mui-spacing-5) auto 0;
+    border: 1px solid var(--mui-palette-divider);
+    border-radius: 8px;
+    background-color: #161616;
+    box-shadow: var(--mui-shadows-3);
+    overflow: hidden;
+    text-align: left;
+  }
+
+  .terminal-titlebar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px;
+    background-color: var(--mui-palette-background-paper-elevated);
+    border-bottom: 1px solid var(--mui-palette-divider);
+  }
+
+  .terminal-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+  }
+
+  .terminal-dot--red { background-color: #ff5f57; }
+  .terminal-dot--yellow { background-color: #febc2e; }
+  .terminal-dot--green { background-color: #28c840; }
+
+  .terminal-title {
+    margin-left: 8px;
+    font-family: 'Roboto Mono', 'Courier New', monospace;
+    font-size: 0.75rem;
+    color: var(--mui-palette-text-secondary);
+  }
+
+  .terminal-body {
+    margin: 0;
+    padding: var(--mui-spacing-2);
+    font-family: 'Roboto Mono', 'Courier New', monospace;
+    font-size: 0.85rem;
+    line-height: 1.9;
+    background-color: transparent;
+    border: none;
+    border-radius: 0;
+    overflow-x: auto;
+  }
+
+  .terminal-prompt {
+    color: var(--mui-palette-success-main);
+    user-select: none;
+  }
+
+  .terminal-cmd { color: var(--mui-palette-text-primary); }
+  .terminal-output { color: var(--mui-palette-primary-main); }
+
+  /* Paste creator panel */
+  .paste-creator {
+    max-width: 860px;
+    margin: var(--mui-spacing-6) auto 0;
+    text-align: left;
+  }
+
+  .paste-tabs {
+    display: flex;
+    border-bottom: 1px solid var(--mui-palette-divider);
+  }
+
+  .paste-tab {
+    flex: 1;
+    padding: 14px 16px;
+    background-color: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    color: var(--mui-palette-text-secondary);
+    font-family: inherit;
+    font-size: 0.9375rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.02857em;
+    cursor: pointer;
+    transition: color 0.2s, border-color 0.2s, background-color 0.2s;
+  }
+
+  .paste-tab:hover {
+    background-color: var(--mui-palette-action-hover);
+  }
+
+  .paste-tab.Mui-selected {
+    color: var(--mui-palette-primary-main);
+    border-bottom-color: var(--mui-palette-primary-main);
+  }
+
+  .paste-tab-panel {
+    padding: var(--mui-spacing-3);
+  }
+
+  .paste-textarea {
+    width: 100%;
+    min-height: 180px;
+    resize: vertical;
+    padding: var(--mui-spacing-2);
+    font-family: 'Roboto Mono', 'Courier New', monospace;
+    font-size: 0.875rem;
+    color: var(--mui-palette-text-primary);
+    background-color: var(--mui-palette-background-default);
+    border: 1px solid var(--mui-palette-divider);
+    border-radius: var(--mui-shape-borderRadius);
+  }
+
+  .paste-textarea:focus {
+    outline: none;
+    border-color: var(--mui-palette-primary-main);
+  }
+
+  .drop-zone {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--mui-spacing-1);
+    padding: var(--mui-spacing-5) var(--mui-spacing-2);
+    border: 2px dashed var(--mui-palette-divider);
+    border-radius: var(--mui-shape-borderRadius);
+    color: var(--mui-palette-text-secondary);
+    text-align: center;
+    cursor: pointer;
+    transition: border-color 0.2s, background-color 0.2s, color 0.2s;
+  }
+
+  .drop-zone:hover,
+  .drop-zone:focus-visible {
+    border-color: var(--mui-palette-primary-main);
+  }
+
+  .drop-zone--dragover {
+    border-color: var(--mui-palette-primary-main);
+    background-color: rgba(144, 202, 249, 0.08);
+    color: var(--mui-palette-primary-main);
+  }
+
+  .paste-option-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--mui-spacing-2);
+    margin-top: var(--mui-spacing-2);
+  }
+
+  .paste-checkbox-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--mui-palette-text-secondary);
+    font-size: 0.875rem;
+    cursor: pointer;
+  }
+
+  .paste-checkbox-label input {
+    accent-color: var(--mui-palette-primary-main);
+  }
+
+  .file-info {
+    margin-top: var(--mui-spacing-2);
+    padding: var(--mui-spacing-1) var(--mui-spacing-2);
+    border: 1px solid var(--mui-palette-divider);
+    border-radius: var(--mui-shape-borderRadius);
+    background-color: var(--mui-palette-background-paper-elevated);
+    font-family: 'Roboto Mono', 'Courier New', monospace;
+    font-size: 0.8125rem;
+    color: var(--mui-palette-text-secondary);
+  }
+
+  /* Circular progress loader */
+  .paste-loader {
+    display: flex;
+    justify-content: center;
+    padding: var(--mui-spacing-2);
+  }
+
+  .paste-loader svg {
+    width: 36px;
+    height: 36px;
+    color: var(--mui-palette-primary-main);
+    animation: rotate 1.4s linear infinite;
+  }
+
+  .paste-loader circle {
+    stroke: currentColor;
+    animation: circular-dash 1.4s ease-in-out infinite;
+  }
+
+  @keyframes rotate {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+  }
+
+  @keyframes circular-dash {
+    0% {
+      stroke-dasharray: 1px, 200px;
+      stroke-dashoffset: 0;
+    }
+    50% {
+      stroke-dasharray: 100px, 200px;
+      stroke-dashoffset: -15px;
+    }
+    100% {
+      stroke-dasharray: 100px, 200px;
+      stroke-dashoffset: -125px;
+    }
+  }
+
+  /* Result alert */
+  .result-alert {
+    padding: var(--mui-spacing-2);
+    border-radius: var(--mui-shape-borderRadius);
+    font-size: 0.875rem;
+  }
+
+  .result-alert--success {
+    background-color: rgba(102, 187, 106, 0.12);
+    border: 1px solid rgba(102, 187, 106, 0.4);
+    color: var(--mui-palette-success-main);
+  }
+
+  .result-alert--error {
+    background-color: rgba(244, 67, 54, 0.12);
+    border: 1px solid rgba(244, 67, 54, 0.4);
+    color: var(--mui-palette-error-main);
+  }
+
+  .result-alert p {
+    margin: 4px 0 0;
+    color: var(--mui-palette-text-primary);
+  }
+
+  .result-url-row {
+    display: flex;
+    gap: var(--mui-spacing-1);
+    margin-top: var(--mui-spacing-2);
+  }
+
+  .result-url-row input {
+    flex: 1;
+    min-width: 0;
+    padding: 8px 12px;
+    font-family: 'Roboto Mono', 'Courier New', monospace;
+    font-size: 0.8125rem;
+    color: var(--mui-palette-text-primary);
+    background-color: var(--mui-palette-background-default);
+    border: 1px solid var(--mui-palette-divider);
+    border-radius: var(--mui-shape-borderRadius);
+  }
+`;
+
 export const getHomepageHTML = () => `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -838,14 +1143,24 @@ export const getHomepageHTML = () => `<!DOCTYPE html>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>DedPaste - Secure Pastebin with End-to-End Encryption</title>
   <meta name="description" content="A secure pastebin with end-to-end encryption, PGP support, and one-time pastes. Share text and files securely.">
+  <meta property="og:title" content="DedPaste - Secure Pastebin with End-to-End Encryption">
+  <meta property="og:description" content="A secure pastebin with end-to-end encryption, PGP support, and one-time pastes. Share text and files securely.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://paste.d3d.dev">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="DedPaste - Secure Pastebin with End-to-End Encryption">
+  <meta name="twitter:description" content="A secure pastebin with end-to-end encryption, PGP support, and one-time pastes. Share text and files securely.">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔐</text></svg>">
-  <style>${getMuiCSS()}</style>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="${GOOGLE_FONTS_URL}">
+  <style>${getMuiCSS(false)}${getHomepageCSS()}</style>
 </head>
 <body>
   <div class="MuiAppBar MuiAppBar-static">
     <div class="MuiToolbar">
-      <div class="MuiContainer flex items-center justify-between" style="width: 100%;">
-        <h1 class="MuiTypography-h4" style="margin: 0;">
+      <div class="MuiContainer flex items-center justify-between" style="width: 100%; flex-wrap: wrap; gap: 8px;">
+        <h1 class="MuiTypography-h4" style="margin: 0; font-size: clamp(1.5rem, 4vw + 0.5rem, 2.125rem);">
           <span style="color: var(--mui-palette-primary-main);">Ded</span>Paste
         </h1>
         <div class="MuiStack MuiStack-row MuiStack-spacing-2">
@@ -887,13 +1202,96 @@ export const getHomepageHTML = () => `<!DOCTYPE html>
             Documentation
           </a>
         </div>
+
+        <div class="terminal-window" aria-hidden="true">
+          <div class="terminal-titlebar">
+            <span class="terminal-dot terminal-dot--red"></span>
+            <span class="terminal-dot terminal-dot--yellow"></span>
+            <span class="terminal-dot terminal-dot--green"></span>
+            <span class="terminal-title">dedpaste — zsh</span>
+          </div>
+          <pre class="terminal-body"><span class="terminal-prompt">$</span> <span class="terminal-cmd">echo "deploy token: tk_91x4" | dedpaste send --encrypt --one-time</span>
+<span class="terminal-output">https://paste.d3d.dev/e/AbCdEfGh</span>
+<span class="terminal-prompt">$</span> <span class="terminal-cmd">dedpaste send release-notes.md</span>
+<span class="terminal-output">https://paste.d3d.dev/QrStUvWx/release-notes.md</span></pre>
+        </div>
       </div>
 
+      <!-- Create a paste -->
+      <div class="MuiPaper MuiPaper-elevation3 paste-creator">
+        <div class="paste-tabs" role="tablist" aria-label="Create a paste">
+          <button type="button" id="tab-text" class="paste-tab Mui-selected" role="tab" aria-selected="true" aria-controls="text-tab-content" onclick="switchTab('text')">
+            Share Text
+          </button>
+          <button type="button" id="tab-upload" class="paste-tab" role="tab" aria-selected="false" aria-controls="upload-tab-content" onclick="switchTab('upload')">
+            Upload File
+          </button>
+        </div>
+
+        <div id="text-tab-content" class="paste-tab-panel" role="tabpanel" aria-labelledby="tab-text">
+          <textarea id="textContent" class="paste-textarea" placeholder="Paste or type the text you want to share..." aria-label="Text to share"></textarea>
+          <div class="paste-option-row">
+            <label class="paste-checkbox-label">
+              <input type="checkbox" id="textOneTime">
+              One-time (self-destructs after first view)
+            </label>
+            <div class="MuiStack MuiStack-row MuiStack-spacing-1">
+              <button type="button" class="MuiButton MuiButton-text MuiButton-textPrimary" onclick="clearText()">Clear</button>
+              <button type="button" class="MuiButton MuiButton-contained MuiButton-containedPrimary" onclick="shareText()">Share Text</button>
+            </div>
+          </div>
+        </div>
+
+        <div id="upload-tab-content" class="paste-tab-panel" role="tabpanel" aria-labelledby="tab-upload" style="display: none;">
+          <div id="dropZone" class="drop-zone" tabindex="0" role="button" aria-label="Choose a file or drag and drop it here">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" width="36" height="36" aria-hidden="true">
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+              <polyline points="17 8 12 3 7 8"></polyline>
+              <line x1="12" y1="3" x2="12" y2="15"></line>
+            </svg>
+            <span>Drag &amp; drop a file here, or click to browse</span>
+            <span class="MuiTypography-body2">Maximum size: 25 MB</span>
+          </div>
+          <input type="file" id="fileInput" style="display: none;" aria-hidden="true" tabindex="-1">
+          <div id="fileInfo" class="file-info" style="display: none;">
+            <div id="fileName"></div>
+            <div id="fileSize"></div>
+          </div>
+          <div class="paste-option-row">
+            <label class="paste-checkbox-label">
+              <input type="checkbox" id="oneTime">
+              One-time (self-destructs after first view)
+            </label>
+            <div class="MuiStack MuiStack-row MuiStack-spacing-1">
+              <button type="button" class="MuiButton MuiButton-text MuiButton-textPrimary" onclick="clearUpload()">Clear</button>
+              <button type="button" class="MuiButton MuiButton-contained MuiButton-containedPrimary" onclick="uploadFile()">Upload File</button>
+            </div>
+          </div>
+        </div>
+
+        <div id="loader" class="paste-loader" style="display: none;" role="status" aria-label="Uploading">
+          <svg viewBox="22 22 44 44" aria-hidden="true">
+            <circle cx="44" cy="44" r="20.2" fill="none" stroke-width="3.6"></circle>
+          </svg>
+        </div>
+
+        <div id="resultContainer" class="paste-tab-panel" style="display: none; padding-top: 0;">
+          <div id="resultAlert" class="result-alert" role="alert">
+            <strong id="resultTitle"></strong>
+            <p id="resultMessage"></p>
+            <div id="resultUrl" class="result-url-row" style="display: none;">
+              <input id="shareUrl" type="text" readonly aria-label="Paste URL">
+              <button type="button" class="MuiButton MuiButton-outlined MuiButton-outlinedPrimary" onclick="copyToClipboard(this)">Copy</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="mb-8">
       <div class="MuiGrid-container MuiGrid-spacing-3">
         <div class="MuiGrid-item MuiGrid-xs-12 MuiGrid-sm-6 MuiGrid-md-4">
-          <div class="MuiPaper MuiPaper-elevation3 MuiCard" style="height: 100%; transition: transform 0.2s, box-shadow 0.2s; cursor: default;" 
-               onmouseover="this.style.transform='translateY(-4px)'; this.style.boxShadow='var(--mui-shadows-4)';" 
-               onmouseout="this.style.transform='translateY(0)'; this.style.boxShadow='var(--mui-shadows-3)';">
+          <div class="MuiPaper MuiPaper-elevation3 MuiCard feature-card">
             <div class="MuiCardContent">
               <div class="mb-2">
                 <span class="MuiChip MuiChip-primary">🔒 End-to-End</span>
@@ -907,9 +1305,7 @@ export const getHomepageHTML = () => `<!DOCTYPE html>
         </div>
         
         <div class="MuiGrid-item MuiGrid-xs-12 MuiGrid-sm-6 MuiGrid-md-4">
-          <div class="MuiPaper MuiPaper-elevation3 MuiCard" style="height: 100%; transition: transform 0.2s, box-shadow 0.2s; cursor: default;"
-               onmouseover="this.style.transform='translateY(-4px)'; this.style.boxShadow='var(--mui-shadows-4)';"
-               onmouseout="this.style.transform='translateY(0)'; this.style.boxShadow='var(--mui-shadows-3)';">
+          <div class="MuiPaper MuiPaper-elevation3 MuiCard feature-card">
             <div class="MuiCardContent">
               <div class="mb-2">
                 <span class="MuiChip MuiChip-primary">🔑 PGP Ready</span>
@@ -923,9 +1319,7 @@ export const getHomepageHTML = () => `<!DOCTYPE html>
         </div>
         
         <div class="MuiGrid-item MuiGrid-xs-12 MuiGrid-sm-6 MuiGrid-md-4">
-          <div class="MuiPaper MuiPaper-elevation3 MuiCard" style="height: 100%; transition: transform 0.2s, box-shadow 0.2s; cursor: default;" 
-               onmouseover="this.style.transform='translateY(-4px)'; this.style.boxShadow='var(--mui-shadows-4)';" 
-               onmouseout="this.style.transform='translateY(0)'; this.style.boxShadow='var(--mui-shadows-3)';">
+          <div class="MuiPaper MuiPaper-elevation3 MuiCard feature-card">
             <div class="MuiCardContent">
               <div class="mb-2">
                 <span class="MuiChip MuiChip-secondary">⏱️ One-Time</span>
@@ -939,9 +1333,7 @@ export const getHomepageHTML = () => `<!DOCTYPE html>
         </div>
         
         <div class="MuiGrid-item MuiGrid-xs-12 MuiGrid-sm-6 MuiGrid-md-4">
-          <div class="MuiPaper MuiPaper-elevation3 MuiCard" style="height: 100%; transition: transform 0.2s, box-shadow 0.2s; cursor: default;" 
-               onmouseover="this.style.transform='translateY(-4px)'; this.style.boxShadow='var(--mui-shadows-4)';" 
-               onmouseout="this.style.transform='translateY(0)'; this.style.boxShadow='var(--mui-shadows-3)';">
+          <div class="MuiPaper MuiPaper-elevation3 MuiCard feature-card">
             <div class="MuiCardContent">
               <div class="mb-2">
                 <span class="MuiChip">📁 Binary Files</span>
@@ -955,9 +1347,7 @@ export const getHomepageHTML = () => `<!DOCTYPE html>
         </div>
         
         <div class="MuiGrid-item MuiGrid-xs-12 MuiGrid-sm-6 MuiGrid-md-4">
-          <div class="MuiPaper MuiPaper-elevation3 MuiCard" style="height: 100%; transition: transform 0.2s, box-shadow 0.2s; cursor: default;"
-               onmouseover="this.style.transform='translateY(-4px)'; this.style.boxShadow='var(--mui-shadows-4)';"
-               onmouseout="this.style.transform='translateY(0)'; this.style.boxShadow='var(--mui-shadows-3)';">
+          <div class="MuiPaper MuiPaper-elevation3 MuiCard feature-card">
             <div class="MuiCardContent">
               <div class="mb-2">
                 <span class="MuiChip">👥 Recipient Groups</span>
@@ -971,9 +1361,7 @@ export const getHomepageHTML = () => `<!DOCTYPE html>
         </div>
         
         <div class="MuiGrid-item MuiGrid-xs-12 MuiGrid-sm-6 MuiGrid-md-4">
-          <div class="MuiPaper MuiPaper-elevation3 MuiCard" style="height: 100%; transition: transform 0.2s, box-shadow 0.2s; cursor: default;" 
-               onmouseover="this.style.transform='translateY(-4px)'; this.style.boxShadow='var(--mui-shadows-4)';" 
-               onmouseout="this.style.transform='translateY(0)'; this.style.boxShadow='var(--mui-shadows-3)';">
+          <div class="MuiPaper MuiPaper-elevation3 MuiCard feature-card">
             <div class="MuiCardContent">
               <div class="mb-2">
                 <span class="MuiChip">⚡ CLI Power</span>
@@ -1211,74 +1599,25 @@ curl -X POST https://paste.d3d.dev/api/paste \\
     <div class="MuiDivider mb-6"></div>
   </main>
 
-  <style>
-    @keyframes rotate {
-      from { transform: rotate(0deg); }
-      to { transform: rotate(360deg); }
-    }
-    @keyframes circular-dash {
-      0% {
-        stroke-dasharray: 1px, 200px;
-        stroke-dashoffset: 0;
-      }
-      50% {
-        stroke-dasharray: 100px, 200px;
-        stroke-dashoffset: -15px;
-      }
-      100% {
-        stroke-dasharray: 100px, 200px;
-        stroke-dashoffset: -125px;
-      }
-    }
-  </style>
-
   <script>
+    // Client-side mirror of the server's MAX_STANDARD_UPLOAD_SIZE (25 MB)
+    const MAX_UPLOAD_BYTES = 25 * 1024 * 1024;
+
     let selectedFile = null;
 
     // Tab switching
     function switchTab(tab) {
-      if (tab === 'upload') {
-        document.getElementById('tab-upload').classList.add('Mui-selected');
-        document.getElementById('tab-upload').style.color = 'var(--mui-palette-primary-main)';
-        document.getElementById('tab-upload').style.borderBottom = '2px solid var(--mui-palette-primary-main)';
-        document.getElementById('tab-text').classList.remove('Mui-selected');
-        document.getElementById('tab-text').style.color = 'var(--mui-palette-text-secondary)';
-        document.getElementById('tab-text').style.borderBottom = '2px solid transparent';
-        document.getElementById('upload-tab-content').style.display = 'block';
-        document.getElementById('text-tab-content').style.display = 'none';
-      } else {
-        document.getElementById('tab-text').classList.add('Mui-selected');
-        document.getElementById('tab-text').style.color = 'var(--mui-palette-primary-main)';
-        document.getElementById('tab-text').style.borderBottom = '2px solid var(--mui-palette-primary-main)';
-        document.getElementById('tab-upload').classList.remove('Mui-selected');
-        document.getElementById('tab-upload').style.color = 'var(--mui-palette-text-secondary)';
-        document.getElementById('tab-upload').style.borderBottom = '2px solid transparent';
-        document.getElementById('text-tab-content').style.display = 'block';
-        document.getElementById('upload-tab-content').style.display = 'none';
-      }
+      const isUpload = tab === 'upload';
+      const uploadTab = document.getElementById('tab-upload');
+      const textTab = document.getElementById('tab-text');
+
+      uploadTab.classList.toggle('Mui-selected', isUpload);
+      uploadTab.setAttribute('aria-selected', String(isUpload));
+      textTab.classList.toggle('Mui-selected', !isUpload);
+      textTab.setAttribute('aria-selected', String(!isUpload));
+      document.getElementById('upload-tab-content').style.display = isUpload ? 'block' : 'none';
+      document.getElementById('text-tab-content').style.display = isUpload ? 'none' : 'block';
       document.getElementById('resultContainer').style.display = 'none';
-    }
-
-    // File handling
-    document.getElementById('dropZone').addEventListener('click', () => {
-      document.getElementById('fileInput').click();
-    });
-
-    function handleDrop(event) {
-      event.preventDefault();
-      const files = event.dataTransfer.files;
-      if (files.length > 0) {
-        handleFileSelect(files);
-      }
-    }
-
-    function handleFileSelect(files) {
-      if (files.length > 0) {
-        selectedFile = files[0];
-        document.getElementById('fileName').textContent = 'Name: ' + selectedFile.name;
-        document.getElementById('fileSize').textContent = 'Size: ' + formatFileSize(selectedFile.size);
-        document.getElementById('fileInfo').style.display = 'block';
-      }
     }
 
     function formatFileSize(bytes) {
@@ -1289,10 +1628,65 @@ curl -X POST https://paste.d3d.dev/api/paste \\
       return Math.round(bytes / Math.pow(k, i) * 100) / 100 + ' ' + sizes[i];
     }
 
+    function handleFileSelect(files) {
+      if (!files || files.length === 0) {
+        return;
+      }
+      const file = files[0];
+
+      // Client-side size validation (server enforces the same 25 MB limit)
+      if (file.size > MAX_UPLOAD_BYTES) {
+        selectedFile = null;
+        document.getElementById('fileInfo').style.display = 'none';
+        showError('File is too large (' + formatFileSize(file.size) + '). Maximum size is 25 MB.');
+        return;
+      }
+
+      selectedFile = file;
+      document.getElementById('resultContainer').style.display = 'none';
+      document.getElementById('fileName').textContent = 'Name: ' + file.name;
+      document.getElementById('fileSize').textContent = 'Size: ' + formatFileSize(file.size);
+      document.getElementById('fileInfo').style.display = 'block';
+    }
+
+    // Drop zone wiring (click, keyboard, and drag-and-drop with visual state)
+    const dropZone = document.getElementById('dropZone');
+    const fileInput = document.getElementById('fileInput');
+
+    dropZone.addEventListener('click', () => {
+      fileInput.click();
+    });
+    dropZone.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        fileInput.click();
+      }
+    });
+    dropZone.addEventListener('dragover', (event) => {
+      event.preventDefault();
+      dropZone.classList.add('drop-zone--dragover');
+    });
+    dropZone.addEventListener('dragleave', () => {
+      dropZone.classList.remove('drop-zone--dragover');
+    });
+    dropZone.addEventListener('drop', (event) => {
+      event.preventDefault();
+      dropZone.classList.remove('drop-zone--dragover');
+      handleFileSelect(event.dataTransfer.files);
+    });
+    fileInput.addEventListener('change', () => {
+      handleFileSelect(fileInput.files);
+    });
+
     // Upload functions
     async function uploadFile() {
       if (!selectedFile) {
         showError('Please select a file to upload');
+        return;
+      }
+
+      if (selectedFile.size > MAX_UPLOAD_BYTES) {
+        showError('File is too large (' + formatFileSize(selectedFile.size) + '). Maximum size is 25 MB.');
         return;
       }
 
@@ -1302,7 +1696,7 @@ curl -X POST https://paste.d3d.dev/api/paste \\
       try {
         const formData = new FormData();
         formData.append('file', selectedFile);
-        formData.append('oneTime', oneTime);
+        formData.append('oneTime', String(oneTime));
 
         const response = await fetch('/api/upload', {
           method: 'POST',
@@ -1362,7 +1756,7 @@ curl -X POST https://paste.d3d.dev/api/paste \\
     // Clear functions
     function clearUpload() {
       selectedFile = null;
-      document.getElementById('fileInput').value = '';
+      fileInput.value = '';
       document.getElementById('fileInfo').style.display = 'none';
       document.getElementById('oneTime').checked = false;
       document.getElementById('resultContainer').style.display = 'none';
@@ -1376,25 +1770,19 @@ curl -X POST https://paste.d3d.dev/api/paste \\
 
     // Helper functions
     function showLoader(show) {
-      document.getElementById('loader').style.display = show ? 'block' : 'none';
+      document.getElementById('loader').style.display = show ? 'flex' : 'none';
     }
 
     function showSuccess(message, url) {
-      const container = document.getElementById('resultContainer');
-      const alert = document.getElementById('resultAlert');
-      const title = document.getElementById('resultTitle');
-      const messageEl = document.getElementById('resultMessage');
       const urlContainer = document.getElementById('resultUrl');
 
-      alert.className = 'MuiAlert MuiAlert-success';
-      alert.style.background = 'rgba(102, 187, 106, 0.12)';
-      alert.style.color = 'var(--mui-palette-success-main)';
-      container.style.display = 'block';
-      title.textContent = 'Success!';
-      messageEl.textContent = message;
+      document.getElementById('resultAlert').className = 'result-alert result-alert--success';
+      document.getElementById('resultContainer').style.display = 'block';
+      document.getElementById('resultTitle').textContent = 'Success!';
+      document.getElementById('resultMessage').textContent = message;
 
       if (url) {
-        urlContainer.style.display = 'block';
+        urlContainer.style.display = 'flex';
         document.getElementById('shareUrl').value = url;
       } else {
         urlContainer.style.display = 'none';
@@ -1402,30 +1790,40 @@ curl -X POST https://paste.d3d.dev/api/paste \\
     }
 
     function showError(message) {
-      const container = document.getElementById('resultContainer');
-      const alert = document.getElementById('resultAlert');
-      const title = document.getElementById('resultTitle');
-      const messageEl = document.getElementById('resultMessage');
-
-      alert.className = 'MuiAlert MuiAlert-error';
-      alert.style.background = 'rgba(244, 67, 54, 0.12)';
-      alert.style.color = 'var(--mui-palette-error-main)';
-      container.style.display = 'block';
-      title.textContent = 'Error';
-      messageEl.textContent = message;
+      document.getElementById('resultAlert').className = 'result-alert result-alert--error';
+      document.getElementById('resultContainer').style.display = 'block';
+      document.getElementById('resultTitle').textContent = 'Error';
+      document.getElementById('resultMessage').textContent = message;
       document.getElementById('resultUrl').style.display = 'none';
     }
 
-    function copyToClipboard() {
+    // Copy via the async Clipboard API, falling back to execCommand
+    async function copyToClipboard(button) {
       const input = document.getElementById('shareUrl');
-      input.select();
-      document.execCommand('copy');
+      let copied = false;
 
-      const btn = event.target;
-      const originalText = btn.textContent;
-      btn.textContent = 'Copied!';
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        try {
+          await navigator.clipboard.writeText(input.value);
+          copied = true;
+        } catch (error) {
+          copied = false;
+        }
+      }
+
+      if (!copied) {
+        input.select();
+        try {
+          copied = document.execCommand('copy');
+        } catch (error) {
+          copied = false;
+        }
+      }
+
+      const originalText = button.textContent;
+      button.textContent = copied ? 'Copied!' : 'Copy failed';
       setTimeout(() => {
-        btn.textContent = originalText;
+        button.textContent = originalText;
       }, 2000);
     }
   </script>
@@ -1447,7 +1845,7 @@ curl -X POST https://paste.d3d.dev/api/paste \\
           <a href="https://github.com/anoncam/dedpaste/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT License</a>
         </div>
         <p class="MuiTypography-body2" style="color: var(--mui-palette-text-secondary); margin-bottom: var(--mui-spacing-1);">
-          Version 1.23.2 • © 2025 DedPaste
+          Version ${PACKAGE_VERSION} • © 2026 DedPaste
         </p>
         <p class="MuiTypography-caption" style="color: var(--mui-palette-text-disabled);">
           Built with 🔐 for privacy enthusiasts • Powered by Cloudflare Workers & Material-UI

--- a/src/viewerTemplates.ts
+++ b/src/viewerTemplates.ts
@@ -1,0 +1,1079 @@
+// Browser-facing HTML viewer templates for DedPaste.
+// These pages are only served when a request's Accept header includes
+// text/html (i.e. real browsers); CLI/curl clients always receive raw bytes.
+
+import { getMuiCSS } from './muiStyles';
+
+/**
+ * Escapes HTML special characters to prevent XSS.
+ */
+function escapeHtml(unsafe: string): string {
+  return unsafe
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+/**
+ * Safely embeds a string into a <script> block as JSON.
+ * Escapes angle brackets so the value cannot break out of the script context.
+ */
+function safeJsonEmbed(value: string): string {
+  return JSON.stringify(value).replace(/</g, '\\u003c').replace(/>/g, '\\u003e');
+}
+
+/**
+ * Formats a byte count as a human-readable size label.
+ * @param bytes Number of bytes
+ * @returns Human readable string such as "1.2 KB"
+ */
+export function formatSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) {
+    return 'unknown size';
+  }
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  const units = ['KB', 'MB', 'GB'];
+  let value = bytes;
+  let unit = 'B';
+  for (const next of units) {
+    if (value < 1024) break;
+    value = value / 1024;
+    unit = next;
+  }
+  return `${value.toFixed(value >= 100 ? 0 : 1)} ${unit}`;
+}
+
+/**
+ * Highlight.js GitHub-Dark theme used by both the markdown viewer and the
+ * universal text viewer so the two pages render code identically.
+ */
+export function getHljsThemeStyles(): string {
+  return `
+    .hljs {
+      color: #e1e4e8;
+      background: #18171c;
+    }
+
+    .hljs-doctag,
+    .hljs-keyword,
+    .hljs-meta .hljs-keyword,
+    .hljs-template-tag,
+    .hljs-template-variable,
+    .hljs-type,
+    .hljs-variable.language_ {
+      color: #ff7b72;
+    }
+
+    .hljs-title,
+    .hljs-title.class_,
+    .hljs-title.class_.inherited__,
+    .hljs-title.function_ {
+      color: #d2a8ff;
+    }
+
+    .hljs-attr,
+    .hljs-attribute,
+    .hljs-literal,
+    .hljs-meta,
+    .hljs-number,
+    .hljs-operator,
+    .hljs-selector-attr,
+    .hljs-selector-class,
+    .hljs-selector-id,
+    .hljs-variable {
+      color: #79c0ff;
+    }
+
+    .hljs-meta .hljs-string,
+    .hljs-regexp,
+    .hljs-string {
+      color: #a5d6ff;
+    }
+
+    .hljs-built_in,
+    .hljs-symbol {
+      color: #ffa657;
+    }
+
+    .hljs-code,
+    .hljs-comment,
+    .hljs-formula {
+      color: #8b949e;
+    }
+
+    .hljs-name,
+    .hljs-quote,
+    .hljs-selector-pseudo,
+    .hljs-selector-tag {
+      color: #7ee83f;
+    }
+
+    .hljs-subst {
+      color: #e1e4e8;
+    }
+
+    .hljs-section {
+      color: #1f6feb;
+      font-weight: bold;
+    }
+
+    .hljs-bullet {
+      color: #f2cc60;
+    }
+
+    .hljs-emphasis {
+      color: #e1e4e8;
+      font-style: italic;
+    }
+
+    .hljs-strong {
+      color: #e1e4e8;
+      font-weight: bold;
+    }
+
+    .hljs-addition {
+      color: #aff5b4;
+      background-color: #033a16;
+    }
+
+    .hljs-deletion {
+      color: #ffdcd7;
+      background-color: #67060c;
+    }
+  `;
+}
+
+/**
+ * Shared page chrome styles (header, footer, buttons) used by every
+ * browser-facing viewer page. Mirrors the markdown viewer's visual language
+ * built on the MUI dark palette variables.
+ */
+function getViewerChromeStyles(): string {
+  return `
+    body {
+      margin: 0;
+      padding: 0;
+      background-color: var(--mui-palette-background-default);
+      color: var(--mui-palette-text-primary);
+      font-family: 'Inter', 'Roboto', system-ui, -apple-system, sans-serif;
+    }
+
+    .header {
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      background: var(--mui-palette-background-paper);
+      border-bottom: 1px solid var(--mui-palette-divider);
+      padding: var(--mui-spacing-2) var(--mui-spacing-3);
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1rem;
+      flex-wrap: wrap;
+      box-shadow: var(--mui-shadows-2);
+    }
+
+    .header-title {
+      font-size: 1.25rem;
+      font-weight: 500;
+      color: var(--mui-palette-text-primary);
+      overflow-wrap: anywhere;
+    }
+
+    .header-title .brand {
+      color: var(--mui-palette-primary-main);
+    }
+
+    .paste-info {
+      display: flex;
+      gap: var(--mui-spacing-1);
+      align-items: center;
+      flex-wrap: wrap;
+      font-size: 0.875rem;
+      color: var(--mui-palette-text-secondary);
+    }
+
+    .paste-id,
+    .meta-chip {
+      font-family: 'Roboto Mono', 'Fira Code', monospace;
+      background: var(--mui-palette-background-default);
+      padding: 4px 8px;
+      border-radius: var(--mui-shape-borderRadius);
+      border: 1px solid var(--mui-palette-divider);
+      white-space: nowrap;
+    }
+
+    .one-time-badge {
+      background: var(--mui-palette-error-main);
+      color: white;
+      padding: 4px 8px;
+      border-radius: 16px;
+      font-weight: 500;
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      white-space: nowrap;
+    }
+
+    .container {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: var(--mui-spacing-4) var(--mui-spacing-3);
+    }
+
+    .toolbar {
+      display: flex;
+      justify-content: flex-end;
+      align-items: center;
+      gap: 0.5rem;
+      margin-bottom: 1rem;
+      flex-wrap: wrap;
+    }
+
+    .viewer-button {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      background: #2c2b31;
+      border: 1px solid #4a4952;
+      border-radius: 0.5rem;
+      color: #e1e4e8;
+      font-size: 0.875rem;
+      font-weight: 500;
+      cursor: pointer;
+      text-decoration: none;
+      transition: all 0.2s;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+
+    .viewer-button:hover {
+      background: #4a4952;
+      border-color: var(--mui-palette-primary-main);
+      transform: translateY(-1px);
+      box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+    }
+
+    .viewer-button:active {
+      transform: translateY(0);
+    }
+
+    .viewer-button.copied {
+      background: #10b981;
+      border-color: #10b981;
+      color: #ffffff;
+    }
+
+    .viewer-button-icon {
+      width: 16px;
+      height: 16px;
+      flex-shrink: 0;
+    }
+
+    .footer {
+      text-align: center;
+      padding: 2rem;
+      color: #6b7280;
+      font-size: 0.875rem;
+    }
+
+    .footer a {
+      color: var(--mui-palette-primary-main);
+      text-decoration: none;
+    }
+
+    .footer a:hover {
+      text-decoration: underline;
+    }
+
+    @media (max-width: 768px) {
+      .header {
+        flex-direction: column;
+        text-align: center;
+      }
+
+      .container {
+        padding: 1rem;
+      }
+    }
+  `;
+}
+
+/** Copy icon SVG shared by viewer buttons */
+const COPY_ICON_SVG = `<svg class="viewer-button-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>`;
+
+/**
+ * Shared clipboard helper script: tries navigator.clipboard first and falls
+ * back to a hidden textarea + document.execCommand for older browsers.
+ */
+function getClipboardScript(): string {
+  return `
+    function legacyCopy(text) {
+      var textarea = document.createElement('textarea');
+      textarea.value = text;
+      textarea.style.position = 'fixed';
+      textarea.style.top = '-9999px';
+      document.body.appendChild(textarea);
+      var ok = false;
+      try {
+        textarea.select();
+        ok = document.execCommand('copy');
+      } catch (err) {
+        ok = false;
+      }
+      document.body.removeChild(textarea);
+      return ok;
+    }
+
+    function copyTextToClipboard(text, onSuccess, onFailure) {
+      if (navigator.clipboard && window.isSecureContext) {
+        navigator.clipboard.writeText(text).then(onSuccess).catch(function () {
+          if (legacyCopy(text)) { onSuccess(); } else { onFailure(); }
+        });
+      } else if (legacyCopy(text)) {
+        onSuccess();
+      } else {
+        onFailure();
+      }
+    }
+
+    function flashCopied(button, labelSelector, copiedLabel) {
+      var label = labelSelector ? button.querySelector(labelSelector) : button;
+      var originalText = label.textContent;
+      button.classList.add('copied');
+      label.textContent = copiedLabel || 'Copied!';
+      setTimeout(function () {
+        button.classList.remove('copied');
+        label.textContent = originalText;
+      }, 2000);
+    }
+  `;
+}
+
+/** Common header markup for viewer pages */
+function renderHeader(
+  titleHtml: string,
+  pasteId: string,
+  infoChips: string[],
+  isOneTime: boolean
+): string {
+  const chips = infoChips.join('\n      ');
+  return `<header class="header">
+    <div class="header-title">
+      <span class="brand">Ded</span>Paste${titleHtml ? ` &middot; ${titleHtml}` : ''}
+    </div>
+    <div class="paste-info">
+      ${chips}
+      <span class="paste-id">ID: ${escapeHtml(pasteId)}</span>
+      ${isOneTime ? '<span class="one-time-badge">⚠️ One-Time Paste</span>' : ''}
+    </div>
+  </header>`;
+}
+
+/** Common footer markup for viewer pages */
+function renderFooter(rawUrl: string | null): string {
+  return `<footer class="footer">
+    <p>Served by <a href="https://github.com/anoncam/dedpaste" target="_blank" rel="noopener noreferrer">DedPaste</a></p>
+    <p style="margin-top: 0.5rem;">
+      ${rawUrl ? `<a href="${escapeHtml(rawUrl)}">View Raw</a> &bull; ` : ''}<a href="/">Create New Paste</a>
+    </p>
+  </footer>`;
+}
+
+/** Options for the universal text/code viewer page */
+export interface TextViewerOptions {
+  /** Paste ID for display */
+  pasteId: string;
+  /** Filename if known (used as page title) */
+  filename: string;
+  /** Content type of the paste */
+  contentType: string;
+  /** Size of the paste in bytes */
+  sizeBytes: number;
+  /** Pre-escaped (highlighted or escapeHtml'd) HTML of the paste content */
+  highlightedHtml: string;
+  /** Number of lines in the original content */
+  lineCount: number;
+  /** Detected/declared language label */
+  language: string;
+  /** Whether syntax highlighting was skipped (large paste) */
+  highlightingSkipped: boolean;
+  /** Whether this is a one-time paste */
+  isOneTime: boolean;
+}
+
+/**
+ * Renders the universal syntax-highlighted viewer page for text-like pastes.
+ * The content passed in `highlightedHtml` MUST already be HTML-escaped
+ * (highlight.js output or escapeHtml fallback).
+ */
+export function renderTextViewerPage(options: TextViewerOptions): string {
+  const {
+    pasteId,
+    filename,
+    contentType,
+    sizeBytes,
+    highlightedHtml,
+    lineCount,
+    language,
+    highlightingSkipped,
+    isOneTime,
+  } = options;
+
+  const title = filename || pasteId;
+  const lineNumbers = Array.from({ length: Math.max(lineCount, 1) }, (_, i) => String(i + 1)).join(
+    '\n'
+  );
+
+  const chips = [
+    `<span class="meta-chip">${escapeHtml(contentType)}</span>`,
+    `<span class="meta-chip">${escapeHtml(formatSize(sizeBytes))}</span>`,
+    `<span class="meta-chip">${escapeHtml(language)}</span>`,
+  ];
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex">
+  <title>${escapeHtml(title)} - DedPaste</title>
+  <style>
+    ${getMuiCSS()}
+    ${getViewerChromeStyles()}
+    ${getHljsThemeStyles()}
+
+    .truncation-note {
+      background: var(--mui-palette-background-paper);
+      border: 1px solid var(--mui-palette-warning-main);
+      border-radius: var(--mui-shape-borderRadius);
+      color: var(--mui-palette-warning-main);
+      padding: 0.75rem 1rem;
+      margin-bottom: 1rem;
+      font-size: 0.875rem;
+    }
+
+    .code-panel {
+      background: #18171c;
+      border: 1px solid #4a4952;
+      border-radius: 0.5rem;
+      overflow: hidden;
+      box-shadow: var(--mui-shadows-1);
+    }
+
+    .code-area {
+      display: flex;
+      overflow-x: auto;
+    }
+
+    .code-area pre {
+      margin: 0;
+      padding: 1rem 0;
+      font-family: 'Fira Code', 'Roboto Mono', 'Courier New', monospace;
+      font-size: 0.875rem;
+      line-height: 1.5;
+    }
+
+    .line-numbers {
+      flex-shrink: 0;
+      text-align: right;
+      color: #6b7280;
+      background: #1f1e24;
+      border-right: 1px solid #4a4952;
+      padding-left: 1rem !important;
+      padding-right: 0.75rem !important;
+      user-select: none;
+      position: sticky;
+      left: 0;
+    }
+
+    .code-content {
+      flex: 1;
+      padding-left: 1rem !important;
+      padding-right: 1rem !important;
+      white-space: pre;
+    }
+
+    .code-content code {
+      background: transparent;
+      border: none;
+      padding: 0;
+      font-family: inherit;
+      font-size: inherit;
+      line-height: inherit;
+      color: #f3f4f6;
+    }
+  </style>
+</head>
+<body>
+  ${renderHeader(escapeHtml(title), pasteId, chips, isOneTime)}
+
+  <main class="container">
+    <div class="toolbar">
+      <button class="viewer-button" id="copy-all-button" onclick="copyAllContent()" title="Copy the entire paste">
+        ${COPY_ICON_SVG}
+        <span class="viewer-button-label">Copy All</span>
+      </button>
+      <a class="viewer-button" href="?raw=true" title="View the raw paste content">View Raw</a>
+      <a class="viewer-button" href="?raw=true&amp;download=true" title="Download the paste as a file">Download</a>
+    </div>
+    ${
+      highlightingSkipped
+        ? `<div class="truncation-note">⚠️ Syntax highlighting was skipped because this paste is larger than 500 KB. Showing plain text.</div>`
+        : ''
+    }
+    <div class="code-panel">
+      <div class="code-area">
+        <pre class="line-numbers" aria-hidden="true">${lineNumbers}</pre>
+        <pre class="code-content"><code id="paste-content" class="hljs language-${escapeHtml(language)}">${highlightedHtml}</code></pre>
+      </div>
+    </div>
+  </main>
+
+  ${renderFooter('?raw=true')}
+
+  <script>
+    ${getClipboardScript()}
+
+    function copyAllContent() {
+      var button = document.getElementById('copy-all-button');
+      var code = document.getElementById('paste-content');
+      if (!button || !code) return;
+      var text = code.textContent || code.innerText || '';
+      copyTextToClipboard(text, function () {
+        flashCopied(button, '.viewer-button-label');
+      }, function () {
+        alert('Failed to copy. Please select the text and copy manually.');
+      });
+    }
+  </script>
+</body>
+</html>`;
+}
+
+/** Options for the encrypted paste landing page */
+export interface EncryptedLandingOptions {
+  /** Paste ID for display */
+  pasteId: string;
+  /** Full canonical paste URL (no query string) used in the CLI command */
+  pasteUrl: string;
+  /** Whether this is also a one-time paste */
+  isOneTime: boolean;
+}
+
+/**
+ * Renders the landing page shown to browsers for encrypted pastes (/e/<id>).
+ * Explains that decryption is client-side and shows the CLI command to use.
+ */
+export function renderEncryptedLandingPage(options: EncryptedLandingOptions): string {
+  const { pasteId, pasteUrl, isOneTime } = options;
+  const cliCommand = `dedpaste get ${pasteUrl}`;
+  const installCommand = 'npm install -g dedpaste';
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex">
+  <title>Encrypted Paste - DedPaste</title>
+  <style>
+    ${getMuiCSS()}
+    ${getViewerChromeStyles()}
+
+    .landing-card {
+      max-width: 640px;
+      margin: var(--mui-spacing-6) auto;
+      background: var(--mui-palette-background-paper);
+      border: 1px solid var(--mui-palette-divider);
+      border-radius: 0.5rem;
+      padding: var(--mui-spacing-4);
+      box-shadow: var(--mui-shadows-2);
+      text-align: center;
+    }
+
+    .landing-icon {
+      font-size: 3rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .landing-card h1 {
+      font-size: 1.5rem;
+      font-weight: 600;
+      margin: 0 0 1rem;
+      color: var(--mui-palette-text-primary);
+    }
+
+    .landing-card p {
+      color: var(--mui-palette-text-secondary);
+      line-height: 1.7;
+      margin: 0 0 1rem;
+    }
+
+    .one-time-note {
+      background: rgba(244, 67, 54, 0.1);
+      border: 1px solid var(--mui-palette-error-main);
+      border-radius: var(--mui-shape-borderRadius);
+      color: var(--mui-palette-error-main);
+      padding: 0.75rem 1rem;
+      margin-bottom: 1rem;
+      font-size: 0.875rem;
+      text-align: left;
+    }
+
+    .command-block {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      background: #18171c;
+      border: 1px solid #4a4952;
+      border-radius: 0.5rem;
+      padding: 0.75rem 1rem;
+      margin: 0 0 1rem;
+      text-align: left;
+    }
+
+    .command-block code {
+      flex: 1;
+      font-family: 'Fira Code', 'Roboto Mono', monospace;
+      font-size: 0.875rem;
+      color: #a5d6ff;
+      overflow-x: auto;
+      white-space: nowrap;
+      background: transparent;
+      border: none;
+    }
+
+    .command-label {
+      text-align: left;
+      font-size: 0.8125rem;
+      color: var(--mui-palette-text-secondary);
+      margin: 0 0 0.25rem;
+    }
+
+    .raw-link {
+      display: inline-block;
+      margin-top: 0.5rem;
+      font-size: 0.875rem;
+      color: var(--mui-palette-text-secondary);
+    }
+
+    .raw-link a {
+      color: var(--mui-palette-primary-main);
+      text-decoration: none;
+    }
+
+    .raw-link a:hover {
+      text-decoration: underline;
+    }
+  </style>
+</head>
+<body>
+  ${renderHeader('Encrypted Paste', pasteId, [], isOneTime)}
+
+  <main class="container">
+    <div class="landing-card">
+      <div class="landing-icon">🔐</div>
+      <h1>This paste is end-to-end encrypted</h1>
+      <p>
+        The server only stores ciphertext &mdash; it never sees the plaintext or
+        any decryption keys. Decryption happens entirely on your machine using
+        the DedPaste CLI.
+      </p>
+      ${
+        isOneTime
+          ? `<div class="one-time-note">⚠️ This is also a <strong>one-time paste</strong>: it will be permanently destroyed after the first time it is retrieved. Viewing this page does not consume it.</div>`
+          : ''
+      }
+      <p class="command-label">Retrieve and decrypt with the CLI:</p>
+      <div class="command-block">
+        <code id="cli-command">${escapeHtml(cliCommand)}</code>
+        <button class="viewer-button" id="copy-command-button" onclick="copyCommand('cli-command', this)" title="Copy command">
+          ${COPY_ICON_SVG}
+          <span class="viewer-button-label">Copy</span>
+        </button>
+      </div>
+      <p class="command-label">Don't have the CLI yet?</p>
+      <div class="command-block">
+        <code id="install-command">${escapeHtml(installCommand)}</code>
+        <button class="viewer-button" id="copy-install-button" onclick="copyCommand('install-command', this)" title="Copy command">
+          ${COPY_ICON_SVG}
+          <span class="viewer-button-label">Copy</span>
+        </button>
+      </div>
+      <p class="raw-link"><a href="?raw=true">View raw encrypted payload</a></p>
+    </div>
+  </main>
+
+  ${renderFooter(null)}
+
+  <script>
+    ${getClipboardScript()}
+
+    function copyCommand(codeId, button) {
+      var code = document.getElementById(codeId);
+      if (!code || !button) return;
+      copyTextToClipboard(code.textContent || '', function () {
+        flashCopied(button, '.viewer-button-label');
+      }, function () {
+        alert('Failed to copy. Please select the command and copy manually.');
+      });
+    }
+  </script>
+</body>
+</html>`;
+}
+
+/** Options for the one-time paste interstitial page */
+export interface OneTimeInterstitialOptions {
+  /** Paste ID for display */
+  pasteId: string;
+  /** Filename if known */
+  filename: string;
+  /** Content type of the paste */
+  contentType: string;
+  /** Size of the paste in bytes */
+  sizeBytes: number;
+}
+
+/**
+ * Renders the confirmation interstitial for one-time pastes. The paste is NOT
+ * consumed by serving this page; the reveal button fetches the same URL with
+ * `?confirm=true&raw=true`, which triggers the normal consume-and-delete flow.
+ * Because link-unfurling bots don't execute JavaScript, they can no longer
+ * burn one-time pastes before the recipient opens them.
+ */
+export function renderOneTimeInterstitialPage(options: OneTimeInterstitialOptions): string {
+  const { pasteId, filename, contentType, sizeBytes } = options;
+  const downloadName = filename || `${pasteId}.bin`;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex">
+  <title>One-Time Paste - DedPaste</title>
+  <style>
+    ${getMuiCSS()}
+    ${getViewerChromeStyles()}
+
+    .interstitial-card {
+      max-width: 640px;
+      margin: var(--mui-spacing-6) auto;
+      background: var(--mui-palette-background-paper);
+      border: 1px solid var(--mui-palette-error-main);
+      border-radius: 0.5rem;
+      padding: var(--mui-spacing-4);
+      box-shadow: var(--mui-shadows-2);
+      text-align: center;
+    }
+
+    .interstitial-icon {
+      font-size: 3rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .interstitial-card h1 {
+      font-size: 1.5rem;
+      font-weight: 600;
+      margin: 0 0 1rem;
+      color: var(--mui-palette-text-primary);
+    }
+
+    .interstitial-card p {
+      color: var(--mui-palette-text-secondary);
+      line-height: 1.7;
+      margin: 0 0 1rem;
+    }
+
+    .reveal-button {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.75rem 1.5rem;
+      background: var(--mui-palette-error-main);
+      border: 1px solid var(--mui-palette-error-main);
+      border-radius: 0.5rem;
+      color: #ffffff;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: all 0.2s;
+    }
+
+    .reveal-button:hover:not(:disabled) {
+      filter: brightness(1.1);
+      transform: translateY(-1px);
+    }
+
+    .reveal-button:disabled {
+      opacity: 0.6;
+      cursor: wait;
+    }
+
+    .reveal-error {
+      display: none;
+      background: rgba(244, 67, 54, 0.1);
+      border: 1px solid var(--mui-palette-error-main);
+      border-radius: var(--mui-shape-borderRadius);
+      color: var(--mui-palette-error-main);
+      padding: 0.75rem 1rem;
+      margin-top: 1rem;
+      font-size: 0.875rem;
+    }
+
+    #revealed-section {
+      display: none;
+    }
+
+    .revealed-panel {
+      background: #18171c;
+      border: 1px solid #4a4952;
+      border-radius: 0.5rem;
+      overflow: hidden;
+      box-shadow: var(--mui-shadows-1);
+      text-align: left;
+    }
+
+    .revealed-panel pre {
+      margin: 0;
+      padding: 1rem;
+      overflow-x: auto;
+      font-family: 'Fira Code', 'Roboto Mono', 'Courier New', monospace;
+      font-size: 0.875rem;
+      line-height: 1.5;
+      color: #f3f4f6;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+
+    .destroyed-note {
+      background: var(--mui-palette-background-paper);
+      border: 1px solid var(--mui-palette-warning-main);
+      border-radius: var(--mui-shape-borderRadius);
+      color: var(--mui-palette-warning-main);
+      padding: 0.75rem 1rem;
+      margin-bottom: 1rem;
+      font-size: 0.875rem;
+      text-align: left;
+    }
+  </style>
+</head>
+<body>
+  ${renderHeader(
+    escapeHtml(filename || 'One-Time Paste'),
+    pasteId,
+    [
+      `<span class="meta-chip">${escapeHtml(contentType)}</span>`,
+      `<span class="meta-chip">${escapeHtml(formatSize(sizeBytes))}</span>`,
+    ],
+    true
+  )}
+
+  <main class="container">
+    <div class="interstitial-card" id="reveal-warning">
+      <div class="interstitial-icon">⚠️</div>
+      <h1>One-time paste: viewing will permanently destroy it</h1>
+      <p>
+        This paste self-destructs the first time its content is retrieved.
+        Opening this page has <strong>not</strong> consumed it yet. Click the
+        button below to reveal the content &mdash; after that, it is gone
+        forever.
+      </p>
+      <button class="reveal-button" id="reveal-button" onclick="revealPaste()">
+        🔥 Reveal (and destroy) this paste
+      </button>
+      <div class="reveal-error" id="reveal-error"></div>
+    </div>
+
+    <div id="revealed-section">
+      <div class="destroyed-note">
+        🔥 This one-time paste has now been destroyed on the server. Copy the
+        content below before leaving this page &mdash; it cannot be retrieved
+        again.
+      </div>
+      <div class="toolbar">
+        <button class="viewer-button" id="copy-all-button" onclick="copyRevealedContent()" title="Copy the entire paste">
+          ${COPY_ICON_SVG}
+          <span class="viewer-button-label">Copy All</span>
+        </button>
+      </div>
+      <div class="revealed-panel">
+        <pre id="paste-content"></pre>
+      </div>
+    </div>
+  </main>
+
+  ${renderFooter(null)}
+
+  <script>
+    ${getClipboardScript()}
+
+    var downloadFilename = ${safeJsonEmbed(downloadName)};
+
+    function showRevealError(message) {
+      var errorBox = document.getElementById('reveal-error');
+      errorBox.textContent = message;
+      errorBox.style.display = 'block';
+      var button = document.getElementById('reveal-button');
+      button.disabled = false;
+      button.textContent = '🔥 Reveal (and destroy) this paste';
+    }
+
+    async function revealPaste() {
+      var button = document.getElementById('reveal-button');
+      button.disabled = true;
+      button.textContent = 'Retrieving…';
+      try {
+        // The confirm+raw request performs the server's consume-and-delete
+        // flow and returns the raw content (Accept is not text/html).
+        var response = await fetch(window.location.pathname + '?confirm=true&raw=true', {
+          headers: { 'Accept': 'application/octet-stream' },
+          cache: 'no-store'
+        });
+        if (!response.ok) {
+          showRevealError('This paste is no longer available. It may have already been viewed or expired.');
+          return;
+        }
+        var contentType = (response.headers.get('Content-Type') || '').toLowerCase();
+        var isText = contentType.indexOf('text/') === 0 ||
+          contentType.indexOf('application/json') !== -1 ||
+          contentType.indexOf('application/xml') !== -1 ||
+          contentType.indexOf('application/javascript') !== -1;
+        if (isText) {
+          var text = await response.text();
+          // textContent assignment is XSS-safe: the browser treats it as text.
+          document.getElementById('paste-content').textContent = text;
+          document.getElementById('reveal-warning').style.display = 'none';
+          document.getElementById('revealed-section').style.display = 'block';
+        } else {
+          var blob = await response.blob();
+          var url = URL.createObjectURL(blob);
+          var link = document.createElement('a');
+          link.href = url;
+          link.download = downloadFilename;
+          document.body.appendChild(link);
+          link.click();
+          link.remove();
+          setTimeout(function () { URL.revokeObjectURL(url); }, 60000);
+          document.getElementById('paste-content').textContent =
+            'Binary content downloaded as "' + downloadFilename + '". The paste has been destroyed on the server.';
+          document.getElementById('reveal-warning').style.display = 'none';
+          document.getElementById('revealed-section').style.display = 'block';
+        }
+      } catch (err) {
+        showRevealError('Failed to retrieve the paste: ' + (err && err.message ? err.message : 'unknown error'));
+      }
+    }
+
+    function copyRevealedContent() {
+      var button = document.getElementById('copy-all-button');
+      var pre = document.getElementById('paste-content');
+      if (!button || !pre) return;
+      copyTextToClipboard(pre.textContent || '', function () {
+        flashCopied(button, '.viewer-button-label');
+      }, function () {
+        alert('Failed to copy. Please select the text and copy manually.');
+      });
+    }
+  </script>
+</body>
+</html>`;
+}
+
+/** Options for styled error pages */
+export interface ErrorPageOptions {
+  /** Page heading, e.g. "Paste not found" */
+  title: string;
+  /** Explanatory message shown under the heading */
+  message: string;
+}
+
+/**
+ * Renders a styled error page (e.g. 404) for browser clients.
+ * Non-browser clients keep receiving plain-text errors.
+ */
+export function renderErrorPage(options: ErrorPageOptions): string {
+  const { title, message } = options;
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex">
+  <title>${escapeHtml(title)} - DedPaste</title>
+  <style>
+    ${getMuiCSS()}
+    ${getViewerChromeStyles()}
+
+    .error-card {
+      max-width: 560px;
+      margin: var(--mui-spacing-8) auto;
+      background: var(--mui-palette-background-paper);
+      border: 1px solid var(--mui-palette-divider);
+      border-radius: 0.5rem;
+      padding: var(--mui-spacing-4);
+      box-shadow: var(--mui-shadows-2);
+      text-align: center;
+    }
+
+    .error-icon {
+      font-size: 3rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .error-card h1 {
+      font-size: 1.5rem;
+      font-weight: 600;
+      margin: 0 0 1rem;
+      color: var(--mui-palette-text-primary);
+    }
+
+    .error-card p {
+      color: var(--mui-palette-text-secondary);
+      line-height: 1.7;
+      margin: 0 0 1.5rem;
+    }
+
+    .home-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1.25rem;
+      background: var(--mui-palette-primary-main);
+      border-radius: 0.5rem;
+      color: var(--mui-palette-primary-contrastText);
+      font-weight: 600;
+      text-decoration: none;
+      transition: filter 0.2s;
+    }
+
+    .home-link:hover {
+      filter: brightness(1.1);
+    }
+  </style>
+</head>
+<body>
+  <header class="header">
+    <div class="header-title">
+      <span class="brand">Ded</span>Paste
+    </div>
+  </header>
+
+  <main class="container">
+    <div class="error-card">
+      <div class="error-icon">🪦</div>
+      <h1>${escapeHtml(title)}</h1>
+      <p>${escapeHtml(message)}</p>
+      <a class="home-link" href="/">Back to homepage</a>
+    </div>
+  </main>
+
+  ${renderFooter(null)}
+</body>
+</html>`;
+}


### PR DESCRIPTION
## Summary

Comprehensive UX overhaul of the worker hosting paste.d3d.dev. All new browser experiences are gated on `Accept: text/html`, so CLI/curl/API behavior is byte-for-byte unchanged.

### Homepage (`src/muiStyles.ts`)
- **Restores the paste-creation UI** (the previous redesign deleted the markup but left ~200 lines of orphaned JS that crashed on load, leaving browser users with no way to create pastes). New centerpiece card: Share Text / Upload File tabs, drag-and-drop with visual feedback, one-time checkboxes, client-side 25 MB validation, result panel with clipboard-first URL copy — wired to the existing `/api/text` and `/api/upload` endpoints.
- CSS-only feature-card hovers (replacing inline `onmouseover` handlers) honoring `prefers-reduced-motion`
- Font loading via `preconnect` + `link` instead of render-blocking `@import`
- Open Graph / Twitter meta tags; `clamp()` responsive typography; terminal-window hero demo of the CLI
- Footer corrected to Version 1.24.8 • © 2026

### Browser viewing pipeline (`src/index.ts`, new `src/viewerTemplates.ts`)
- **Syntax-highlighted viewer** for all text-like pastes (text/*, JSON, XML, JS): line numbers, filename/type/size header, Copy All / View Raw / Download actions; `?raw=true&download=true` forces attachment
- **Encrypted-paste landing page**: `/e/<id>` in a browser now shows a copy-able `dedpaste get <url>` command and install hint instead of raw ciphertext JSON
- **One-time paste interstitial**: browser GETs no longer consume — a confirmation page requires an explicit reveal click (the reveal fetch consumes via the existing flow). This also stops Slack/iMessage link-preview bots from burning one-time pastes before the recipient opens them
- Styled 404/error pages for browsers (plain text preserved for CLI)
- Markdown viewer: title-based header, clipboard-API-first copying; markdown rendering now also Accept-gated so `curl` of a `.md` paste returns raw source
- Removed the 600-line dead commented-out Tailwind homepage block
- R2 metadata no longer stores literal `"undefined"` strings

### Security hardening (post-review fixes)
- `sanitizeHtml` now strips `svg`/`math` foreign-content tags, `style` attributes, and unquoted `javascript:`/`vbscript:`/`data:` URLs
- Viewer memory buffering capped at 1 MB (was 5 MB)
- Homepage no longer sets a wildcard `Access-Control-Allow-Origin`

## Test plan
- `npm run build` clean; prettier clean
- Test suite: 21 passing / 2 failing — the 2 failures are pre-existing on `main` (CLI crypto tests, unrelated)
- Live integration matrix against `wrangler dev` (15/15): browser viewer, raw curl bytes, one-time interstitial → reveal → destroyed, second-GET-not-consumed, encrypted landing vs raw JSON, markdown both lenses, styled vs plain 404, download disposition, homepage form, sanitizer XSS probes (svg/script, unquoted `javascript:` href, style attr)
- Node-fetch with default headers (`Accept: */*`, what the CLI sends) receives exact raw bytes

## Known items deliberately deferred
- Cross-isolate one-time double-serve race (pre-existing; needs R2 conditional writes or a Durable Object lock)
- Nonce-based CSP to drop `'unsafe-inline'` scripts (template-wide refactor)
- Pre-existing CLI bug discovered during testing: `dedpaste get <url>` rejects current paste URLs because its regex requires 8-char IDs (`cli/index.ts:1633,1639`) while the server issues 16-char IDs